### PR TITLE
Extract Tollbooth commerce layer from thebrain-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Don't Pester Your Client** — Bitcoin Lightning micropayments for MCP servers.
+**Don't Pester Your Customer** — Bitcoin Lightning micropayments for MCP servers.
 
 > Under Construction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tollbooth-dpyc"
 version = "0.1.0"
-description = "Don't Pester Your Client — Bitcoin Lightning micropayments for MCP servers"
+description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -23,6 +23,15 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
+dependencies = [
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/lonniev/tollbooth-dpyc"
@@ -31,3 +40,6 @@ Issues = "https://github.com/lonniev/tollbooth-dpyc/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tollbooth"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -1,3 +1,28 @@
-"""Tollbooth DPYC — Bitcoin Lightning micropayments for MCP servers."""
+"""Tollbooth DPYC — Don't Pester Your Customer.
+
+Bitcoin Lightning micropayments for MCP servers.
+"""
 
 __version__ = "0.1.0"
+
+from tollbooth.config import TollboothConfig
+from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord
+from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
+from tollbooth.vault_backend import VaultBackend
+from tollbooth.ledger_cache import LedgerCache
+from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
+
+__all__ = [
+    "TollboothConfig",
+    "UserLedger",
+    "ToolUsage",
+    "InvoiceRecord",
+    "BTCPayClient",
+    "BTCPayError",
+    "BTCPayAuthError",
+    "VaultBackend",
+    "LedgerCache",
+    "ToolTier",
+    "MAX_INVOICE_SATS",
+    "LOW_BALANCE_FLOOR_API_SATS",
+]

--- a/src/tollbooth/btcpay_client.py
+++ b/src/tollbooth/btcpay_client.py
@@ -1,0 +1,196 @@
+"""Async HTTP client for BTCPay Server's Greenfield API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class BTCPayError(Exception):
+    """Base exception for BTCPay operations."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class BTCPayAuthError(BTCPayError):
+    """401/403 — authentication or authorization failure."""
+
+
+class BTCPayNotFoundError(BTCPayError):
+    """404 — resource not found."""
+
+
+class BTCPayValidationError(BTCPayError):
+    """422 — request validation failure."""
+
+
+class BTCPayServerError(BTCPayError):
+    """5xx — server-side error (retryable)."""
+
+
+class BTCPayConnectionError(BTCPayError):
+    """Network/DNS failure (retryable)."""
+
+
+class BTCPayTimeoutError(BTCPayError):
+    """Request timeout (retryable)."""
+
+
+# ---------------------------------------------------------------------------
+# Sats → BTC conversion
+# ---------------------------------------------------------------------------
+
+# Default ceiling: 1 BTC.  Any single payout above this is almost certainly
+# a unit-mismatch bug (sats confused with BTC → 10^8× overpayment).
+_SATS_CONVERSION_MAX_DEFAULT = 100_000_000
+
+
+def sats_to_btc_string(sats: int, *, max_sats: int = _SATS_CONVERSION_MAX_DEFAULT) -> str:
+    """Convert satoshis to an 8-decimal-place BTC string for the BTCPay API.
+
+    Raises ValueError on negative values or values exceeding *max_sats*.
+    """
+    if sats < 0:
+        raise ValueError(f"sats must be non-negative, got {sats}")
+    if sats > max_sats:
+        raise ValueError(
+            f"sats ({sats:,}) exceeds ceiling ({max_sats:,})"
+        )
+    return f"{sats / 100_000_000:.8f}"
+
+
+# ---------------------------------------------------------------------------
+# Status code → exception mapping
+# ---------------------------------------------------------------------------
+
+_STATUS_MAP: dict[int, type[BTCPayError]] = {
+    401: BTCPayAuthError,
+    403: BTCPayAuthError,
+    404: BTCPayNotFoundError,
+    422: BTCPayValidationError,
+}
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class BTCPayClient:
+    """Async client for BTCPay Server Greenfield API v1.
+
+    Constructor accepts explicit params — no env-var loading.
+    Uses ``token`` auth header (not Bearer) per BTCPay convention.
+    """
+
+    def __init__(self, host: str, api_key: str, store_id: str) -> None:
+        base_url = host.rstrip("/") + "/api/v1"
+        self._store_id = store_id
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={"Authorization": f"token {api_key}"},
+            timeout=httpx.Timeout(connect=5.0, read=15.0, write=10.0, pool=5.0),
+        )
+
+    # -- internal request dispatcher -----------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send a request and map errors to the BTCPay exception hierarchy."""
+        try:
+            response = await self._client.request(method, endpoint, json=json_data)
+        except httpx.ConnectError as exc:
+            raise BTCPayConnectionError(str(exc)) from exc
+        except httpx.TimeoutException as exc:
+            raise BTCPayTimeoutError(str(exc)) from exc
+
+        if response.status_code >= 400:
+            body = response.text
+            exc_cls = _STATUS_MAP.get(response.status_code)
+            if exc_cls is not None:
+                raise exc_cls(body, status_code=response.status_code)
+            if response.status_code >= 500:
+                raise BTCPayServerError(body, status_code=response.status_code)
+            raise BTCPayError(body, status_code=response.status_code)
+
+        return response.json()
+
+    # -- public API methods ---------------------------------------------------
+
+    async def health_check(self) -> dict[str, Any]:
+        """GET /health — server health status."""
+        return await self._request("GET", "/health")
+
+    async def get_store(self) -> dict[str, Any]:
+        """GET /stores/{storeId} — store details."""
+        return await self._request("GET", f"/stores/{self._store_id}")
+
+    async def create_invoice(
+        self,
+        amount_sats: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST /stores/{storeId}/invoices — create a Lightning invoice."""
+        payload: dict[str, Any] = {
+            "amount": str(amount_sats),
+            "currency": "SATS",
+        }
+        if metadata is not None:
+            payload["metadata"] = metadata
+        return await self._request(
+            "POST", f"/stores/{self._store_id}/invoices", json_data=payload
+        )
+
+    async def get_invoice(self, invoice_id: str) -> dict[str, Any]:
+        """GET /stores/{storeId}/invoices/{invoiceId} — invoice details."""
+        return await self._request(
+            "GET", f"/stores/{self._store_id}/invoices/{invoice_id}"
+        )
+
+    async def get_api_key_info(self) -> dict[str, Any]:
+        """GET /api-keys/current — current API key metadata and permissions."""
+        return await self._request("GET", "/api-keys/current")
+
+    async def create_payout(
+        self,
+        destination: str,
+        amount_sats: int,
+        payout_method: str = "BTC-LN",
+    ) -> dict[str, Any]:
+        """POST /stores/{storeId}/payouts — create a store payout.
+
+        Amount is converted from sats to BTC decimal (BTCPay expects BTC).
+        """
+        amount_btc = sats_to_btc_string(amount_sats)
+        payload: dict[str, Any] = {
+            "destination": destination,
+            "amount": amount_btc,
+            "payoutMethodId": payout_method,
+        }
+        return await self._request(
+            "POST", f"/stores/{self._store_id}/payouts", json_data=payload
+        )
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> BTCPayClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -1,0 +1,20 @@
+"""Tollbooth configuration — plain frozen dataclass, no pydantic.
+
+The host application constructs this from its own settings (env vars,
+pydantic-settings, etc.) and passes it to Tollbooth tools.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TollboothConfig:
+    btcpay_host: str | None = None
+    btcpay_store_id: str | None = None
+    btcpay_api_key: str | None = None
+    btcpay_tier_config: str | None = None
+    btcpay_user_tiers: str | None = None
+    seed_balance_sats: int = 0
+    tollbooth_royalty_address: str | None = None
+    tollbooth_royalty_percent: float = 0.02
+    tollbooth_royalty_min_sats: int = 10

--- a/src/tollbooth/constants.py
+++ b/src/tollbooth/constants.py
@@ -1,0 +1,16 @@
+"""Constants for Tollbooth micropayment gating."""
+
+from enum import IntEnum
+
+
+MAX_INVOICE_SATS = 1_000_000  # 0.01 BTC cap per invoice
+LOW_BALANCE_FLOOR_API_SATS = 100  # minimum warning threshold
+
+
+class ToolTier(IntEnum):
+    """Cost tiers for tool-call metering (satoshis per call)."""
+
+    FREE = 0
+    READ = 1
+    WRITE = 5
+    HEAVY = 10

--- a/src/tollbooth/ledger.py
+++ b/src/tollbooth/ledger.py
@@ -1,0 +1,310 @@
+"""Per-user credit ledger for tool-call metering.
+
+Pure data model — no I/O. All api_sats values are integer API credits
+(not real Bitcoin satoshis). Real BTC amounts use ``amount_sats`` and
+only appear in invoice/BTCPay contexts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 3
+
+
+# ---------------------------------------------------------------------------
+# ToolUsage
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolUsage:
+    """Aggregate usage counter for a single tool."""
+
+    calls: int = 0
+    api_sats: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {"calls": self.calls, "api_sats": self.api_sats}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolUsage:
+        return cls(
+            calls=int(data.get("calls", 0)),
+            # Migration: accept old "sats" key or new "api_sats"
+            api_sats=int(data.get("api_sats", data.get("sats", 0))),
+        )
+
+
+# ---------------------------------------------------------------------------
+# InvoiceRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InvoiceRecord:
+    """Append-only record of a single BTCPay invoice."""
+
+    invoice_id: str
+    amount_sats: int  # Real BTC satoshis (never rename to api_sats)
+    api_sats_credited: int = 0  # Multiplied credits granted
+    multiplier: int = 1
+    status: str = "Pending"  # Pending | Settled | Expired | Invalid
+    created_at: str = ""  # ISO datetime
+    settled_at: str | None = None
+    btcpay_status: str | None = None  # Raw BTCPay status string
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "invoice_id": self.invoice_id,
+            "amount_sats": self.amount_sats,
+            "api_sats_credited": self.api_sats_credited,
+            "multiplier": self.multiplier,
+            "status": self.status,
+            "created_at": self.created_at,
+            "settled_at": self.settled_at,
+            "btcpay_status": self.btcpay_status,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InvoiceRecord:
+        return cls(
+            invoice_id=str(data.get("invoice_id", "")),
+            amount_sats=int(data.get("amount_sats", 0)),
+            api_sats_credited=int(data.get("api_sats_credited", 0)),
+            multiplier=int(data.get("multiplier", 1)),
+            status=str(data.get("status", "Pending")),
+            created_at=str(data.get("created_at", "")),
+            settled_at=data.get("settled_at"),
+            btcpay_status=data.get("btcpay_status"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# UserLedger
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UserLedger:
+    """Per-user credit balance and usage tracking.
+
+    All balance/cost values are in api_sats (integer API credits).
+    ``debit()`` returns False on insufficient balance (not exceptional).
+    ``from_json()`` returns a fresh ledger on corrupt data (never blocks a user).
+    """
+
+    balance_api_sats: int = 0
+    total_deposited_api_sats: int = 0
+    total_consumed_api_sats: int = 0
+    pending_invoices: list[str] = field(default_factory=list)
+    credited_invoices: list[str] = field(default_factory=list)
+    last_deposit_at: str | None = None
+    daily_log: dict[str, dict[str, ToolUsage]] = field(default_factory=dict)
+    history: dict[str, ToolUsage] = field(default_factory=dict)
+    invoices: dict[str, InvoiceRecord] = field(default_factory=dict)
+
+    # -- invoice record helpers ------------------------------------------------
+
+    def record_invoice_created(
+        self, invoice_id: str, amount_sats: int, multiplier: int, created_at: str,
+    ) -> None:
+        """Record a newly created invoice (Pending status)."""
+        self.invoices[invoice_id] = InvoiceRecord(
+            invoice_id=invoice_id,
+            amount_sats=amount_sats,
+            multiplier=multiplier,
+            status="Pending",
+            created_at=created_at,
+            btcpay_status="New",
+        )
+
+    def record_invoice_settled(
+        self,
+        invoice_id: str,
+        api_sats_credited: int,
+        settled_at: str,
+        btcpay_status: str = "Settled",
+    ) -> None:
+        """Update an existing invoice record to Settled with credit info.
+
+        Creates a retroactive record if the invoice wasn't tracked at creation
+        (e.g. invoices created before this feature was deployed).
+        """
+        rec = self.invoices.get(invoice_id)
+        if rec:
+            rec.status = "Settled"
+            rec.api_sats_credited = api_sats_credited
+            rec.settled_at = settled_at
+            rec.btcpay_status = btcpay_status
+        else:
+            self.invoices[invoice_id] = InvoiceRecord(
+                invoice_id=invoice_id,
+                amount_sats=0,  # Unknown — wasn't tracked at creation
+                api_sats_credited=api_sats_credited,
+                multiplier=0,  # Unknown
+                status="Settled",
+                created_at="",  # Unknown
+                settled_at=settled_at,
+                btcpay_status=btcpay_status,
+            )
+
+    def record_invoice_terminal(
+        self, invoice_id: str, status: str, btcpay_status: str,
+    ) -> None:
+        """Update an existing invoice record to a terminal state (Expired/Invalid)."""
+        rec = self.invoices.get(invoice_id)
+        if rec:
+            rec.status = status
+            rec.btcpay_status = btcpay_status
+
+    # -- mutations ------------------------------------------------------------
+
+    def debit(self, tool_name: str, api_sats: int) -> bool:
+        """Deduct ``api_sats`` from balance. Returns False if insufficient."""
+        if api_sats < 0:
+            return False
+        if self.balance_api_sats < api_sats:
+            return False
+
+        self.balance_api_sats -= api_sats
+        self.total_consumed_api_sats += api_sats
+
+        today = date.today().isoformat()
+        day_log = self.daily_log.setdefault(today, {})
+        usage = day_log.setdefault(tool_name, ToolUsage())
+        usage.calls += 1
+        usage.api_sats += api_sats
+
+        agg = self.history.setdefault(tool_name, ToolUsage())
+        agg.calls += 1
+        agg.api_sats += api_sats
+
+        return True
+
+    def credit_deposit(self, api_sats: int, invoice_id: str) -> None:
+        """Add credits from a settled invoice."""
+        self.balance_api_sats += api_sats
+        self.total_deposited_api_sats += api_sats
+        self.last_deposit_at = date.today().isoformat()
+        if invoice_id in self.pending_invoices:
+            self.pending_invoices.remove(invoice_id)
+        if invoice_id not in self.credited_invoices:
+            self.credited_invoices.append(invoice_id)
+
+    def rollback_debit(self, tool_name: str, api_sats: int) -> None:
+        """Undo a previous debit (e.g. tool call failed)."""
+        self.balance_api_sats += api_sats
+        self.total_consumed_api_sats -= api_sats
+
+        today = date.today().isoformat()
+        day_log = self.daily_log.get(today, {})
+        usage = day_log.get(tool_name)
+        if usage:
+            usage.calls = max(0, usage.calls - 1)
+            usage.api_sats = max(0, usage.api_sats - api_sats)
+
+        agg = self.history.get(tool_name)
+        if agg:
+            agg.calls = max(0, agg.calls - 1)
+            agg.api_sats = max(0, agg.api_sats - api_sats)
+
+    def rotate_daily_log(self, retention_days: int = 30) -> None:
+        """Fold daily entries older than ``retention_days`` into ``history``."""
+        cutoff = (date.today() - timedelta(days=retention_days)).isoformat()
+        expired_keys = [d for d in self.daily_log if d < cutoff]
+        for day_key in expired_keys:
+            for tool_name, usage in self.daily_log[day_key].items():
+                # daily_log entries are already counted in history via debit(),
+                # so we only remove the daily entry — no double-counting.
+                pass
+            del self.daily_log[day_key]
+
+    # -- serialization --------------------------------------------------------
+
+    def to_json(self) -> str:
+        """Serialize to JSON string with schema version."""
+        return json.dumps({
+            "v": _SCHEMA_VERSION,
+            "balance_api_sats": self.balance_api_sats,
+            "total_deposited_api_sats": self.total_deposited_api_sats,
+            "total_consumed_api_sats": self.total_consumed_api_sats,
+            "pending_invoices": self.pending_invoices,
+            "credited_invoices": self.credited_invoices,
+            "last_deposit_at": self.last_deposit_at,
+            "daily_log": {
+                day: {tool: u.to_dict() for tool, u in tools.items()}
+                for day, tools in self.daily_log.items()
+            },
+            "history": {
+                tool: u.to_dict() for tool, u in self.history.items()
+            },
+            "invoices": {
+                iid: rec.to_dict() for iid, rec in self.invoices.items()
+            },
+        }, indent=2)
+
+    @classmethod
+    def from_json(cls, data: str) -> UserLedger:
+        """Deserialize from JSON. Returns fresh ledger on corrupt/missing data.
+
+        Handles migration from v1 (``*_sats``) to v2 (``*_api_sats``) keys.
+        """
+        try:
+            obj = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Ledger data is corrupt; returning fresh ledger.")
+            return cls()
+
+        if not isinstance(obj, dict):
+            logger.warning("Ledger data is not a dict; returning fresh ledger.")
+            return cls()
+
+        daily_log: dict[str, dict[str, ToolUsage]] = {}
+        raw_daily = obj.get("daily_log", {})
+        if isinstance(raw_daily, dict):
+            for day, tools in raw_daily.items():
+                if isinstance(tools, dict):
+                    daily_log[day] = {
+                        t: ToolUsage.from_dict(u)
+                        for t, u in tools.items()
+                        if isinstance(u, dict)
+                    }
+
+        history: dict[str, ToolUsage] = {}
+        raw_history = obj.get("history", {})
+        if isinstance(raw_history, dict):
+            history = {
+                t: ToolUsage.from_dict(u)
+                for t, u in raw_history.items()
+                if isinstance(u, dict)
+            }
+
+        invoices: dict[str, InvoiceRecord] = {}
+        raw_invoices = obj.get("invoices", {})
+        if isinstance(raw_invoices, dict):
+            for iid, rec_data in raw_invoices.items():
+                if isinstance(rec_data, dict):
+                    invoices[iid] = InvoiceRecord.from_dict(rec_data)
+
+        # Migration: accept v1 keys (*_sats) or v2 keys (*_api_sats)
+        def _get_int(new_key: str, old_key: str) -> int:
+            return int(obj.get(new_key, obj.get(old_key, 0)))
+
+        return cls(
+            balance_api_sats=_get_int("balance_api_sats", "balance_sats"),
+            total_deposited_api_sats=_get_int("total_deposited_api_sats", "total_deposited_sats"),
+            total_consumed_api_sats=_get_int("total_consumed_api_sats", "total_consumed_sats"),
+            pending_invoices=list(obj.get("pending_invoices", [])),
+            credited_invoices=list(obj.get("credited_invoices", [])),
+            last_deposit_at=obj.get("last_deposit_at"),
+            daily_log=daily_log,
+            history=history,
+            invoices=invoices,
+        )

--- a/src/tollbooth/ledger_cache.py
+++ b/src/tollbooth/ledger_cache.py
@@ -1,0 +1,249 @@
+"""In-memory LRU cache for UserLedger with write-behind flush to vault.
+
+The cache is the hot path for all credit operations. The vault is the
+durable backing store, updated asynchronously every ``flush_interval_secs``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from tollbooth.ledger import UserLedger
+
+if TYPE_CHECKING:
+    from tollbooth.vault_backend import VaultBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CacheEntry:
+    """Internal cache entry wrapping a UserLedger with dirty tracking."""
+
+    ledger: UserLedger
+    dirty: bool = False
+
+
+class LedgerCache:
+    """LRU cache for UserLedger objects with write-behind flush.
+
+    - ``get()`` returns a cached ledger or loads from vault on miss.
+    - Mutations should be followed by ``mark_dirty(user_id)``.
+    - A background task flushes dirty entries to the vault periodically.
+    - On LRU eviction, dirty entries are flushed synchronously.
+    - Per-user asyncio locks prevent concurrent access races.
+    """
+
+    def __init__(
+        self,
+        vault: VaultBackend,
+        maxsize: int = 20,
+        flush_interval_secs: int = 60,
+    ) -> None:
+        self._vault = vault
+        self._maxsize = maxsize
+        self._flush_interval = flush_interval_secs
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._flush_task: asyncio.Task[None] | None = None
+        self._last_flush_at: str | None = None
+        self._total_flushes: int = 0
+        self._last_flush_check: float = time.monotonic()
+
+    def _get_lock(self, user_id: str) -> asyncio.Lock:
+        """Get or create a per-user lock."""
+        if user_id not in self._locks:
+            self._locks[user_id] = asyncio.Lock()
+        return self._locks[user_id]
+
+    async def _maybe_flush(self) -> None:
+        """Flush dirty entries if enough time has passed since the last flush.
+
+        Called from get() to piggyback on request-driven event loop activity.
+        In serverless environments where asyncio.sleep() doesn't advance
+        between requests, this ensures dirty entries are eventually persisted.
+        """
+        now = time.monotonic()
+        if now - self._last_flush_check < self._flush_interval:
+            return
+        self._last_flush_check = now
+        if self.dirty_count > 0:
+            count = await self.flush_dirty()
+            if count > 0:
+                logger.info("Opportunistic flush: wrote %d ledger(s).", count)
+
+    async def get(self, user_id: str) -> UserLedger:
+        """Return the cached ledger, loading from vault on miss."""
+        await self._maybe_flush()
+        lock = self._get_lock(user_id)
+        async with lock:
+            if user_id in self._entries:
+                self._entries.move_to_end(user_id)
+                return self._entries[user_id].ledger
+
+            # Cache miss — load from vault
+            ledger = await self._load_from_vault(user_id)
+
+            # Evict LRU if at capacity
+            while len(self._entries) >= self._maxsize:
+                await self._evict_lru()
+
+            self._entries[user_id] = _CacheEntry(ledger=ledger)
+            self._entries.move_to_end(user_id)
+            return ledger
+
+    def mark_dirty(self, user_id: str) -> None:
+        """Mark a cached entry as dirty (needs flush to vault)."""
+        entry = self._entries.get(user_id)
+        if entry:
+            entry.dirty = True
+
+    async def flush_user(self, user_id: str) -> bool:
+        """Immediately flush a single user's entry to vault.
+
+        Use for credit-critical paths (check_payment, purchase_credits)
+        where data MUST be durable before returning success.
+        Returns True on success, False on failure (logged, not raised).
+        """
+        entry = self._entries.get(user_id)
+        if not entry or not entry.dirty:
+            return True  # Nothing to flush
+        return await self._flush_entry(user_id, entry)
+
+    async def _load_from_vault(self, user_id: str) -> UserLedger:
+        """Load ledger JSON from vault, returning fresh ledger on miss/error."""
+        try:
+            ledger_json = await self._vault.fetch_ledger(user_id)
+        except Exception:
+            logger.warning("Failed to load ledger from vault for %s.", user_id)
+            return UserLedger()
+
+        if ledger_json is None:
+            return UserLedger()
+        return UserLedger.from_json(ledger_json)
+
+    async def _evict_lru(self) -> None:
+        """Evict the least-recently-used entry, flushing if dirty."""
+        if not self._entries:
+            return
+        user_id, entry = next(iter(self._entries.items()))
+        if entry.dirty:
+            await self._flush_entry(user_id, entry)
+        del self._entries[user_id]
+        self._locks.pop(user_id, None)
+
+    async def _flush_entry(self, user_id: str, entry: _CacheEntry) -> bool:
+        """Flush a single entry to vault. Returns True on success."""
+        from datetime import datetime, timezone
+
+        try:
+            await self._vault.store_ledger(user_id, entry.ledger.to_json())
+            entry.dirty = False
+            self._last_flush_at = datetime.now(timezone.utc).isoformat()
+            self._total_flushes += 1
+            return True
+        except Exception:
+            logger.warning("Failed to flush ledger to vault for %s.", user_id)
+            return False
+
+    async def flush_dirty(self) -> int:
+        """Flush all dirty entries to vault. Returns count of flushed entries."""
+        flushed = 0
+        for user_id, entry in list(self._entries.items()):
+            if entry.dirty:
+                if await self._flush_entry(user_id, entry):
+                    flushed += 1
+        return flushed
+
+    async def snapshot_all(self, timestamp: str) -> int:
+        """Snapshot all cached ledgers to vault. Returns count of snapshots created."""
+        snapped = 0
+        for user_id, entry in list(self._entries.items()):
+            try:
+                result = await self._vault.snapshot_ledger(
+                    user_id, entry.ledger.to_json(), timestamp
+                )
+                if result is not None:
+                    snapped += 1
+            except Exception:
+                logger.warning("Failed to snapshot ledger for %s.", user_id)
+        return snapped
+
+    async def flush_all(self) -> int:
+        """Flush every dirty entry (used during shutdown). Returns flush count."""
+        return await self.flush_dirty()
+
+    async def start_background_flush(self) -> None:
+        """Start the periodic background flush task."""
+        if self._flush_task is not None:
+            return
+        self._flush_task = asyncio.create_task(self._background_flush_loop())
+
+    async def _background_flush_loop(self) -> None:
+        """Periodically flush dirty entries until cancelled."""
+        logger.warning(
+            "Background flush loop started (interval=%ds). "
+            "In serverless envs, opportunistic flush handles persistence instead.",
+            self._flush_interval,
+        )
+        cycles = 0
+        try:
+            while True:
+                await asyncio.sleep(self._flush_interval)
+                count = await self.flush_dirty()
+                cycles += 1
+                if count > 0:
+                    logger.info(
+                        "Background flush: wrote %d ledger(s) "
+                        "(cycle %d, total flushes: %d).",
+                        count, cycles, self._total_flushes,
+                    )
+                elif cycles % 10 == 0:
+                    # Heartbeat every 10 cycles even when idle
+                    logger.info(
+                        "Background flush heartbeat: cycle %d, "
+                        "cache size %d, dirty %d, total flushes %d.",
+                        cycles, self.size, self.dirty_count, self._total_flushes,
+                    )
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self) -> None:
+        """Cancel background flush and flush all remaining dirty entries."""
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
+        await self.flush_all()
+
+    @property
+    def size(self) -> int:
+        """Number of entries currently in cache."""
+        return len(self._entries)
+
+    @property
+    def dirty_count(self) -> int:
+        """Number of dirty (unflushed) entries in cache."""
+        return sum(1 for e in self._entries.values() if e.dirty)
+
+    def health(self) -> dict[str, object]:
+        """Return cache health metrics for monitoring."""
+        return {
+            "cache_size": self.size,
+            "dirty_entries": self.dirty_count,
+            "last_flush_at": self._last_flush_at,
+            "total_flushes": self._total_flushes,
+            "background_flush_running": self._flush_task is not None
+                                        and not self._flush_task.done(),
+            "last_flush_check_age_secs": round(
+                time.monotonic() - self._last_flush_check, 1
+            ),
+        }

--- a/src/tollbooth/tools/__init__.py
+++ b/src/tollbooth/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tollbooth credit management tools."""

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -1,0 +1,549 @@
+"""Credit management tools: purchase_credits, check_payment, check_balance, btcpay_status."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timezone
+from typing import Any
+
+from tollbooth.btcpay_client import BTCPayClient, BTCPayAuthError, BTCPayError
+from tollbooth.config import TollboothConfig
+from tollbooth.ledger import UserLedger
+from tollbooth.ledger_cache import LedgerCache
+from tollbooth.constants import LOW_BALANCE_FLOOR_API_SATS, MAX_INVOICE_SATS
+
+logger = logging.getLogger(__name__)
+
+# Default credit multiplier for users not in tier config
+_DEFAULT_MULTIPLIER = 1
+
+# Sanity ceiling for royalty payouts (independent of sats_to_btc_string ceiling).
+# 2% of a 5M-sat purchase = 100,000 sats — anything above is suspect.
+ROYALTY_PAYOUT_MAX_SATS = 100_000
+
+
+async def _attempt_royalty_payout(
+    btcpay: BTCPayClient,
+    invoice_amount_sats: int,
+    royalty_address: str,
+    royalty_percent: float,
+    royalty_min_sats: int,
+) -> dict[str, Any] | None:
+    """Attempt a royalty payout to the originator's Lightning Address.
+
+    Returns a result dict on success or partial failure, None if below minimum.
+    Never raises — catches all BTCPayError exceptions.
+    """
+    royalty_sats = int(invoice_amount_sats * royalty_percent)
+    if royalty_sats < royalty_min_sats:
+        return None
+
+    if royalty_sats > ROYALTY_PAYOUT_MAX_SATS:
+        logger.error(
+            "Royalty payout %d sats exceeds ceiling of %d — refusing payout. "
+            "Check royalty_percent (%.4f) or invoice amount (%d).",
+            royalty_sats, ROYALTY_PAYOUT_MAX_SATS,
+            royalty_percent, invoice_amount_sats,
+        )
+        return {
+            "royalty_sats": royalty_sats,
+            "royalty_address": royalty_address,
+            "royalty_error": (
+                f"Royalty amount ({royalty_sats:,} sats) exceeds safety ceiling "
+                f"({ROYALTY_PAYOUT_MAX_SATS:,} sats). Payout refused."
+            ),
+        }
+
+    try:
+        payout = await btcpay.create_payout(royalty_address, royalty_sats)
+        return {
+            "royalty_sats": royalty_sats,
+            "royalty_address": royalty_address,
+            "payout_id": payout.get("id", ""),
+            "payout_state": payout.get("state", "Unknown"),
+        }
+    except BTCPayError as e:
+        logger.warning("Royalty payout failed: %s", e)
+        return {
+            "royalty_sats": royalty_sats,
+            "royalty_address": royalty_address,
+            "royalty_error": str(e),
+        }
+
+
+def _get_tier_info(
+    user_id: str,
+    tier_config_json: str | None,
+    user_tiers_json: str | None,
+) -> tuple[str, int]:
+    """Look up tier name and credit multiplier for a user.
+
+    Returns (tier_name, multiplier).
+    """
+    if not tier_config_json or not user_tiers_json:
+        return "default", _DEFAULT_MULTIPLIER
+
+    try:
+        tier_config = json.loads(tier_config_json)
+        user_tiers = json.loads(user_tiers_json)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Invalid tier config JSON; using default multiplier.")
+        return "default", _DEFAULT_MULTIPLIER
+
+    tier_name = user_tiers.get(user_id, "default")
+    tier = tier_config.get(tier_name, tier_config.get("default", {}))
+    return tier_name, int(tier.get("credit_multiplier", _DEFAULT_MULTIPLIER))
+
+
+def _get_multiplier(
+    user_id: str,
+    tier_config_json: str | None,
+    user_tiers_json: str | None,
+) -> int:
+    """Look up credit multiplier for a user based on tier config."""
+    _, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+    return multiplier
+
+
+async def purchase_credits_tool(
+    btcpay: BTCPayClient,
+    cache: LedgerCache,
+    user_id: str,
+    amount_sats: int,
+    tier_config_json: str | None = None,
+    user_tiers_json: str | None = None,
+) -> dict[str, Any]:
+    """Create a BTCPay invoice and record it as pending in the user's ledger."""
+    if amount_sats <= 0:
+        return {"success": False, "error": "amount_sats must be positive."}
+
+    if amount_sats > MAX_INVOICE_SATS:
+        return {
+            "success": False,
+            "error": f"amount_sats exceeds maximum of {MAX_INVOICE_SATS:,} sats (0.01 BTC) per invoice.",
+        }
+
+    try:
+        invoice = await btcpay.create_invoice(
+            amount_sats,
+            metadata={"user_id": user_id, "purpose": "credit_purchase"},
+        )
+    except BTCPayError as e:
+        return {"success": False, "error": f"BTCPay error: {e}"}
+
+    invoice_id = invoice.get("id", "")
+    checkout_link = invoice.get("checkoutLink", "")
+    expiry = invoice.get("expirationTime", "")
+
+    tier_name, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+    expected_credits = amount_sats * multiplier
+
+    # Record pending invoice — flush immediately so the invoice survives cache loss
+    ledger = await cache.get(user_id)
+    ledger.pending_invoices.append(invoice_id)
+    ledger.record_invoice_created(
+        invoice_id=invoice_id,
+        amount_sats=amount_sats,
+        multiplier=multiplier,
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+    cache.mark_dirty(user_id)
+    if not await cache.flush_user(user_id):
+        logger.warning("Failed to flush pending invoice %s for %s.", invoice_id, user_id)
+
+    result: dict[str, Any] = {
+        "success": True,
+        "invoice_id": invoice_id,
+        "amount_sats": amount_sats,
+        "checkout_link": checkout_link,
+        "expiration": expiry,
+        "tier": tier_name,
+        "multiplier": multiplier,
+        "expected_credits": expected_credits,
+        "message": (
+            f"Invoice created for {amount_sats:,} sats.\n\n"
+            f"Pay here: {checkout_link}\n"
+            f"Expires: {expiry}\n"
+            f"Tier: {tier_name} ({multiplier}x) — "
+            f"you will receive {expected_credits:,} credits on settlement.\n\n"
+            f'After paying, call check_payment with invoice_id: "{invoice_id}"'
+        ),
+    }
+    return result
+
+
+async def check_payment_tool(
+    btcpay: BTCPayClient,
+    cache: LedgerCache,
+    user_id: str,
+    invoice_id: str,
+    tier_config_json: str | None = None,
+    user_tiers_json: str | None = None,
+    royalty_address: str | None = None,
+    royalty_percent: float = 0.02,
+    royalty_min_sats: int = 10,
+) -> dict[str, Any]:
+    """Poll BTCPay invoice status. Credit balance on settlement (idempotent)."""
+    try:
+        invoice = await btcpay.get_invoice(invoice_id)
+    except BTCPayError as e:
+        return {"success": False, "error": f"BTCPay error: {e}"}
+
+    status = invoice.get("status", "Unknown")
+    additional = invoice.get("additionalStatus", "")
+    ledger = await cache.get(user_id)
+
+    result: dict[str, Any] = {
+        "success": True,
+        "invoice_id": invoice_id,
+        "status": status,
+    }
+    if additional:
+        result["additional_status"] = additional
+
+    if status == "New":
+        result["message"] = "Invoice created, awaiting payment."
+
+    elif status == "Processing":
+        result["message"] = "Payment seen, waiting for confirmation."
+
+    elif status == "Settled":
+        if invoice_id in ledger.credited_invoices:
+            # Already credited — true idempotency check
+            result["message"] = "Payment already credited."
+            result["credits_granted"] = 0
+        else:
+            # Credit the user — flush immediately so credits survive cache loss
+            amount_str = invoice.get("amount", "0")
+            amount_sats = int(float(amount_str))
+            multiplier = _get_multiplier(user_id, tier_config_json, user_tiers_json)
+            credited = amount_sats * multiplier
+            ledger.credit_deposit(credited, invoice_id)
+            ledger.record_invoice_settled(
+                invoice_id=invoice_id,
+                api_sats_credited=credited,
+                settled_at=datetime.now(timezone.utc).isoformat(),
+                btcpay_status=status,
+            )
+            cache.mark_dirty(user_id)
+            if not await cache.flush_user(user_id):
+                logger.error(
+                    "CRITICAL: Failed to flush %d credits for %s (invoice %s). "
+                    "Credits are in memory but may be lost on restart.",
+                    credited, user_id, invoice_id,
+                )
+            result["credits_granted"] = credited
+            result["multiplier"] = multiplier
+            result["message"] = f"Payment settled! {credited:,} credits added to your balance."
+
+            # Attempt royalty payout (never blocks credit settlement)
+            if royalty_address:
+                royalty_result = await _attempt_royalty_payout(
+                    btcpay, amount_sats, royalty_address,
+                    royalty_percent, royalty_min_sats,
+                )
+                if royalty_result is not None:
+                    result["royalty_payout"] = royalty_result
+
+    elif status == "Expired":
+        if invoice_id in ledger.pending_invoices:
+            ledger.pending_invoices.remove(invoice_id)
+        ledger.record_invoice_terminal(invoice_id, "Expired", status)
+        cache.mark_dirty(user_id)
+        await cache.flush_user(user_id)
+        result["message"] = "Invoice expired. Create a new one with purchase_credits."
+
+    elif status == "Invalid":
+        if invoice_id in ledger.pending_invoices:
+            ledger.pending_invoices.remove(invoice_id)
+        ledger.record_invoice_terminal(invoice_id, "Invalid", status)
+        cache.mark_dirty(user_id)
+        await cache.flush_user(user_id)
+        result["message"] = "Payment invalid."
+
+    else:
+        result["message"] = f"Unknown invoice status: {status}"
+
+    result["balance_api_sats"] = ledger.balance_api_sats
+    return result
+
+
+async def check_balance_tool(
+    cache: LedgerCache,
+    user_id: str,
+    tier_config_json: str | None = None,
+    user_tiers_json: str | None = None,
+) -> dict[str, Any]:
+    """Return the user's current credit balance and usage summary."""
+    ledger = await cache.get(user_id)
+    today = date.today().isoformat()
+
+    tier_name, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+
+    result: dict[str, Any] = {
+        "success": True,
+        "tier": tier_name,
+        "multiplier": multiplier,
+        "balance_api_sats": ledger.balance_api_sats,
+        "total_deposited_api_sats": ledger.total_deposited_api_sats,
+        "total_consumed_api_sats": ledger.total_consumed_api_sats,
+        "pending_invoices": len(ledger.pending_invoices),
+        "last_deposit_at": ledger.last_deposit_at,
+    }
+
+    if "seed_balance_v1" in ledger.credited_invoices:
+        result["seed_balance_granted"] = True
+
+    # Include today's usage if available
+    today_log = ledger.daily_log.get(today)
+    if today_log:
+        result["today_usage"] = {
+            tool: {"calls": u.calls, "api_sats": u.api_sats}
+            for tool, u in today_log.items()
+        }
+
+    # Invoice history summary
+    if ledger.invoices:
+        settled = [r for r in ledger.invoices.values() if r.status == "Settled"]
+        pending = [r for r in ledger.invoices.values() if r.status == "Pending"]
+        result["invoice_summary"] = {
+            "total_invoices": len(ledger.invoices),
+            "settled_count": len(settled),
+            "pending_count": len(pending),
+            "total_real_sats": sum(r.amount_sats for r in settled),
+            "total_api_sats_credited": sum(r.api_sats_credited for r in settled),
+        }
+
+    return result
+
+
+async def restore_credits_tool(
+    btcpay: BTCPayClient,
+    cache: LedgerCache,
+    user_id: str,
+    invoice_id: str,
+    tier_config_json: str | None = None,
+    user_tiers_json: str | None = None,
+) -> dict[str, Any]:
+    """Restore credits from a paid invoice that was lost due to cache/vault issues.
+
+    Verifies the invoice is Settled with BTCPay, then credits the balance.
+    Idempotent via credited_invoices — won't double-credit.
+    """
+    # Check idempotency first
+    ledger = await cache.get(user_id)
+    if invoice_id in ledger.credited_invoices:
+        return {
+            "success": True,
+            "invoice_id": invoice_id,
+            "credits_granted": 0,
+            "balance_api_sats": ledger.balance_api_sats,
+            "message": "Invoice already credited — no duplicate credits applied.",
+        }
+
+    # Vault-first: check if we have a settled invoice record in the ledger
+    vault_record = ledger.invoices.get(invoice_id)
+    if vault_record and vault_record.status == "Settled" and vault_record.api_sats_credited > 0:
+        # Restore from vault record — no BTCPay call needed
+        credited = vault_record.api_sats_credited
+        ledger.credit_deposit(credited, invoice_id)
+        cache.mark_dirty(user_id)
+        if not await cache.flush_user(user_id):
+            logger.error(
+                "CRITICAL: Failed to flush vault-restored %d credits for %s (invoice %s).",
+                credited, user_id, invoice_id,
+            )
+        return {
+            "success": True,
+            "invoice_id": invoice_id,
+            "source": "vault_record",
+            "amount_sats": vault_record.amount_sats,
+            "multiplier": vault_record.multiplier,
+            "credits_granted": credited,
+            "balance_api_sats": ledger.balance_api_sats,
+            "message": f"Restored {credited:,} credits from vault invoice record.",
+        }
+
+    # Fall back to BTCPay verification
+    try:
+        invoice = await btcpay.get_invoice(invoice_id)
+    except BTCPayError as e:
+        return {"success": False, "error": f"BTCPay error: {e}"}
+
+    status = invoice.get("status", "Unknown")
+    if status != "Settled":
+        return {
+            "success": False,
+            "error": f"Invoice status is '{status}', not 'Settled'. Cannot restore.",
+            "invoice_id": invoice_id,
+        }
+
+    # Credit the balance
+    amount_str = invoice.get("amount", "0")
+    amount_sats = int(float(amount_str))
+    multiplier = _get_multiplier(user_id, tier_config_json, user_tiers_json)
+    credited = amount_sats * multiplier
+
+    ledger.credit_deposit(credited, invoice_id)
+    ledger.record_invoice_settled(
+        invoice_id=invoice_id,
+        api_sats_credited=credited,
+        settled_at=datetime.now(timezone.utc).isoformat(),
+        btcpay_status=status,
+    )
+    cache.mark_dirty(user_id)
+    if not await cache.flush_user(user_id):
+        logger.error(
+            "CRITICAL: Failed to flush restored %d credits for %s (invoice %s).",
+            credited, user_id, invoice_id,
+        )
+
+    return {
+        "success": True,
+        "invoice_id": invoice_id,
+        "source": "btcpay",
+        "amount_sats": amount_sats,
+        "multiplier": multiplier,
+        "credits_granted": credited,
+        "balance_api_sats": ledger.balance_api_sats,
+        "message": f"Restored {credited:,} credits from invoice {invoice_id}.",
+    }
+
+
+def compute_low_balance_warning(
+    ledger: UserLedger,
+    seed_balance_sats: int,
+    low_balance_floor: int = LOW_BALANCE_FLOOR_API_SATS,
+) -> dict[str, Any] | None:
+    """Compute a low-balance warning dict if balance is running low.
+
+    Returns None if balance is healthy (>= threshold).
+    """
+    # Find reference amount from last settled invoice
+    settled = [r for r in ledger.invoices.values() if r.status == "Settled"]
+    if settled:
+        last = settled[-1]
+        reference = last.api_sats_credited
+    elif seed_balance_sats > 0 and "seed_balance_v1" in ledger.credited_invoices:
+        reference = seed_balance_sats
+    else:
+        reference = low_balance_floor
+
+    threshold = max(reference // 5, low_balance_floor)
+
+    if ledger.balance_api_sats >= threshold:
+        return None
+
+    # Suggested top-up: last invoice's real amount_sats, capped
+    if settled:
+        suggested = settled[-1].amount_sats
+        if suggested <= 0:
+            suggested = 1000
+    else:
+        suggested = 1000
+    suggested = min(suggested, MAX_INVOICE_SATS)
+
+    return {
+        "balance_api_sats": ledger.balance_api_sats,
+        "threshold_api_sats": threshold,
+        "suggested_top_up_sats": suggested,
+        "purchase_command": f'Use purchase_credits with amount_sats={suggested}',
+        "message": (
+            f"Low balance: {ledger.balance_api_sats} api_sats remaining "
+            f"(warning threshold: {threshold}). "
+            f"Consider topping up with purchase_credits."
+        ),
+    }
+
+
+async def btcpay_status_tool(
+    config: TollboothConfig,
+    btcpay: BTCPayClient | None,
+) -> dict[str, Any]:
+    """Report BTCPay configuration state and connectivity for diagnostics."""
+    result: dict[str, Any] = {
+        "btcpay_host": config.btcpay_host or None,
+        "btcpay_store_id": config.btcpay_store_id or None,
+        "btcpay_api_key_status": "present" if config.btcpay_api_key else "missing",
+    }
+
+    # Tier config
+    if config.btcpay_tier_config:
+        try:
+            tiers = json.loads(config.btcpay_tier_config)
+            result["tier_config"] = f"{len(tiers)} tier(s)"
+        except (json.JSONDecodeError, TypeError):
+            result["tier_config"] = "invalid JSON"
+    else:
+        result["tier_config"] = "missing"
+
+    # User tiers
+    if config.btcpay_user_tiers:
+        try:
+            users = json.loads(config.btcpay_user_tiers)
+            result["user_tiers"] = f"{len(users)} user(s)"
+        except (json.JSONDecodeError, TypeError):
+            result["user_tiers"] = "invalid JSON"
+    else:
+        result["user_tiers"] = "missing"
+
+    # Connectivity checks — only if all 3 connection vars present and client available
+    connection_vars_present = bool(
+        config.btcpay_host and config.btcpay_store_id and config.btcpay_api_key
+    )
+
+    # Royalty config
+    royalty_enabled = bool(config.tollbooth_royalty_address)
+    result["royalty_config"] = {
+        "enabled": royalty_enabled,
+        "address": config.tollbooth_royalty_address,
+        "percent": config.tollbooth_royalty_percent,
+        "min_sats": config.tollbooth_royalty_min_sats,
+    }
+
+    if connection_vars_present and btcpay is not None:
+        # Health check
+        try:
+            await btcpay.health_check()
+            result["server_reachable"] = True
+        except BTCPayError:
+            result["server_reachable"] = False
+        except Exception:
+            result["server_reachable"] = False
+
+        # Store check
+        try:
+            store = await btcpay.get_store()
+            result["store_name"] = store.get("name", "unknown")
+        except BTCPayAuthError:
+            result["store_name"] = "unauthorized"
+        except BTCPayError:
+            result["store_name"] = None
+        except Exception:
+            result["store_name"] = None
+
+        # API key permissions check
+        try:
+            key_info = await btcpay.get_api_key_info()
+            permissions = key_info.get("permissions", [])
+            required = ["btcpay.store.cancreateinvoice", "btcpay.store.canviewinvoices"]
+            if royalty_enabled:
+                required.append("btcpay.store.cancreatenonapprovedpullpayments")
+            present = [p for p in required if p in permissions]
+            missing = [p for p in required if p not in permissions]
+            result["api_key_permissions"] = {
+                "permissions": permissions,
+                "required": required,
+                "present": present,
+                "missing": missing,
+            }
+        except BTCPayError as e:
+            result["api_key_permissions"] = {"error": str(e)}
+        except Exception as e:
+            result["api_key_permissions"] = {"error": str(e)}
+    else:
+        result["server_reachable"] = None
+        result["store_name"] = None
+
+    return result

--- a/src/tollbooth/vault_backend.py
+++ b/src/tollbooth/vault_backend.py
@@ -1,0 +1,26 @@
+"""Abstract persistence interface for commerce state (ledger storage).
+
+Defines the VaultBackend Protocol that LedgerCache depends on.
+Concrete implementations (e.g., PersonalBrainVault) live elsewhere.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class VaultBackend(Protocol):
+    """Async persistence backend for user ledger data.
+
+    Any object implementing these three methods can serve as the
+    durable backing store for LedgerCache.
+    """
+
+    async def store_ledger(self, user_id: str, ledger_json: str) -> str: ...
+
+    async def fetch_ledger(self, user_id: str) -> str | None: ...
+
+    async def snapshot_ledger(
+        self, user_id: str, ledger_json: str, timestamp: str
+    ) -> str | None: ...

--- a/tests/test_btcpay_client.py
+++ b/tests/test_btcpay_client.py
@@ -1,0 +1,333 @@
+"""Tests for BTCPay Greenfield API client."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from tollbooth.btcpay_client import (
+    BTCPayAuthError,
+    BTCPayClient,
+    BTCPayConnectionError,
+    BTCPayError,
+    BTCPayNotFoundError,
+    BTCPayServerError,
+    BTCPayTimeoutError,
+    BTCPayValidationError,
+    sats_to_btc_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# sats_to_btc_string
+# ---------------------------------------------------------------------------
+
+
+class TestSatsToBtcString:
+    def test_20_sats(self) -> None:
+        assert sats_to_btc_string(20) == "0.00000020"
+
+    def test_1000_sats(self) -> None:
+        assert sats_to_btc_string(1000) == "0.00001000"
+
+    def test_zero(self) -> None:
+        assert sats_to_btc_string(0) == "0.00000000"
+
+    def test_one_btc(self) -> None:
+        assert sats_to_btc_string(100_000_000) == "1.00000000"
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            sats_to_btc_string(-1)
+
+    def test_rejects_above_default_ceiling(self) -> None:
+        with pytest.raises(ValueError, match="exceeds ceiling"):
+            sats_to_btc_string(100_000_001)
+
+    def test_custom_ceiling(self) -> None:
+        # Custom ceiling allows values above default
+        assert sats_to_btc_string(200_000_000, max_sats=300_000_000) == "2.00000000"
+
+    def test_custom_ceiling_rejects_above(self) -> None:
+        with pytest.raises(ValueError, match="exceeds ceiling"):
+            sats_to_btc_string(200, max_sats=100)
+
+    def test_8_decimal_precision(self) -> None:
+        """1 sat = 0.00000001 BTC — verify no floating-point drift."""
+        assert sats_to_btc_string(1) == "0.00000001"
+        assert sats_to_btc_string(99_999_999) == "0.99999999"
+
+
+# ---------------------------------------------------------------------------
+# Init / constructor
+# ---------------------------------------------------------------------------
+
+
+class TestBTCPayClientInit:
+    def test_fields_stored(self) -> None:
+        client = BTCPayClient("https://btcpay.example.com", "key123", "store-abc")
+        assert client._store_id == "store-abc"
+        assert str(client._client.base_url).rstrip("/") == "https://btcpay.example.com/api/v1"
+
+    def test_trailing_slash_stripped(self) -> None:
+        client = BTCPayClient("https://btcpay.example.com/", "key123", "store-abc")
+        assert str(client._client.base_url).rstrip("/") == "https://btcpay.example.com/api/v1"
+
+    def test_auth_header_format(self) -> None:
+        client = BTCPayClient("https://btcpay.example.com", "my-api-key", "s1")
+        assert client._client.headers["authorization"] == "token my-api-key"
+
+    def test_timeout_configured(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        t = client._client.timeout
+        assert t.connect == 5.0
+        assert t.read == 15.0
+        assert t.write == 10.0
+        assert t.pool == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Request methods (mocked transport)
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status: int = 200, json_data: dict | None = None) -> httpx.Response:
+    resp = httpx.Response(
+        status_code=status,
+        json=json_data or {},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    return resp
+
+
+class TestBTCPayClientRequests:
+    @pytest.mark.asyncio
+    async def test_health_check(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"synchronized": True})
+        )
+        result = await client.health_check()
+        assert result == {"synchronized": True}
+        client._client.request.assert_called_once_with("GET", "/health", json=None)
+
+    @pytest.mark.asyncio
+    async def test_get_store(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "my-store")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "my-store", "name": "Test"})
+        )
+        result = await client.get_store()
+        assert result["id"] == "my-store"
+        client._client.request.assert_called_once_with(
+            "GET", "/stores/my-store", json=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_minimal(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s1")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "inv-1"})
+        )
+        result = await client.create_invoice(1000)
+        assert result["id"] == "inv-1"
+        call_args = client._client.request.call_args
+        assert call_args[0] == ("POST", "/stores/s1/invoices")
+        payload = call_args[1]["json"]
+        assert payload["amount"] == "1000"
+        assert payload["currency"] == "SATS"
+        assert "metadata" not in payload
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_with_metadata(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s1")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "inv-2"})
+        )
+        meta = {"user": "u1", "purpose": "credits"}
+        result = await client.create_invoice(500, metadata=meta)
+        assert result["id"] == "inv-2"
+        payload = client._client.request.call_args[1]["json"]
+        assert payload["metadata"] == meta
+
+    @pytest.mark.asyncio
+    async def test_get_invoice(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s1")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "inv-3", "status": "Settled"})
+        )
+        result = await client.get_invoice("inv-3")
+        assert result["status"] == "Settled"
+        client._client.request.assert_called_once_with(
+            "GET", "/stores/s1/invoices/inv-3", json=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Exception mapping
+# ---------------------------------------------------------------------------
+
+
+class TestBTCPayExceptionMapping:
+    @pytest.mark.asyncio
+    async def test_401_raises_auth_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(401))
+        with pytest.raises(BTCPayAuthError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_403_raises_auth_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(403))
+        with pytest.raises(BTCPayAuthError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_404_raises_not_found(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(404))
+        with pytest.raises(BTCPayNotFoundError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_422_raises_validation(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(422))
+        with pytest.raises(BTCPayValidationError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_500_raises_server_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(500))
+        with pytest.raises(BTCPayServerError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_connect_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(side_effect=httpx.ConnectError("DNS failed"))
+        with pytest.raises(BTCPayConnectionError, match="DNS failed"):
+            await client.health_check()
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(
+            side_effect=httpx.ReadTimeout("read timed out")
+        )
+        with pytest.raises(BTCPayTimeoutError, match="read timed out"):
+            await client.health_check()
+
+    @pytest.mark.asyncio
+    async def test_unknown_4xx_raises_base(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(418))
+        with pytest.raises(BTCPayError) as exc_info:
+            await client.health_check()
+        assert exc_info.value.status_code == 418
+        assert type(exc_info.value) is BTCPayError
+
+
+# ---------------------------------------------------------------------------
+# get_api_key_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetApiKeyInfo:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {
+                "apiKey": "k",
+                "permissions": ["btcpay.store.cancreateinvoice", "btcpay.store.canviewinvoices"],
+            })
+        )
+        result = await client.get_api_key_info()
+        assert "permissions" in result
+        assert len(result["permissions"]) == 2
+        client._client.request.assert_called_once_with("GET", "/api-keys/current", json=None)
+
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        client = BTCPayClient("https://x.com", "bad-key", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(401))
+        with pytest.raises(BTCPayAuthError) as exc_info:
+            await client.get_api_key_info()
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# create_payout
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePayout:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "my-store")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "payout-1", "state": "AwaitingApproval"})
+        )
+        result = await client.create_payout("user@ln.addr", 100)
+        assert result["id"] == "payout-1"
+        assert result["state"] == "AwaitingApproval"
+        call_args = client._client.request.call_args
+        assert call_args[0] == ("POST", "/stores/my-store/payouts")
+        payload = call_args[1]["json"]
+        assert payload["destination"] == "user@ln.addr"
+        assert payload["amount"] == "0.00000100"
+        assert payload["payoutMethodId"] == "BTC-LN"
+
+    @pytest.mark.asyncio
+    async def test_custom_payment_method(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(
+            return_value=_mock_response(200, {"id": "payout-2"})
+        )
+        await client.create_payout("addr", 50, payout_method="BTC-CHAIN")
+        payload = client._client.request.call_args[1]["json"]
+        assert payload["payoutMethodId"] == "BTC-CHAIN"
+
+    @pytest.mark.asyncio
+    async def test_validation_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(422))
+        with pytest.raises(BTCPayValidationError) as exc_info:
+            await client.create_payout("bad", 0)
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(403))
+        with pytest.raises(BTCPayAuthError) as exc_info:
+            await client.create_payout("addr", 100)
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestBTCPayClientContextManager:
+    @pytest.mark.asyncio
+    async def test_async_with(self) -> None:
+        async with BTCPayClient("https://x.com", "k", "s") as client:
+            assert isinstance(client, BTCPayClient)
+        assert client._client.is_closed
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        assert not client._client.is_closed
+        await client.close()
+        assert client._client.is_closed

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -1,0 +1,925 @@
+"""Tests for credit management tools: purchase_credits, check_payment, check_balance, btcpay_status."""
+
+import json
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tollbooth.btcpay_client import (
+    BTCPayAuthError,
+    BTCPayClient,
+    BTCPayConnectionError,
+    BTCPayServerError,
+)
+from tollbooth.config import TollboothConfig
+from tollbooth.ledger import UserLedger
+from tollbooth.ledger_cache import LedgerCache
+from tollbooth.tools.credits import (
+    ROYALTY_PAYOUT_MAX_SATS,
+    _attempt_royalty_payout,
+    _get_multiplier,
+    _get_tier_info,
+    btcpay_status_tool,
+    check_balance_tool,
+    check_payment_tool,
+    compute_low_balance_warning,
+    purchase_credits_tool,
+)
+from tollbooth.constants import MAX_INVOICE_SATS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_btcpay(invoice_response: dict | None = None, error: Exception | None = None):
+    """Create a mock BTCPayClient."""
+    client = AsyncMock(spec=BTCPayClient)
+    if error:
+        client.create_invoice = AsyncMock(side_effect=error)
+        client.get_invoice = AsyncMock(side_effect=error)
+    else:
+        resp = invoice_response or {"id": "inv-1", "checkoutLink": "https://pay.example.com/inv-1"}
+        client.create_invoice = AsyncMock(return_value=resp)
+        client.get_invoice = AsyncMock(return_value=resp)
+    return client
+
+
+def _mock_cache(ledger: UserLedger | None = None):
+    """Create a mock LedgerCache."""
+    cache = AsyncMock(spec=LedgerCache)
+    cache.get = AsyncMock(return_value=ledger or UserLedger())
+    cache.mark_dirty = MagicMock()  # sync method, not async
+    return cache
+
+
+TIER_CONFIG = json.dumps({
+    "default": {"credit_multiplier": 1},
+    "vip": {"credit_multiplier": 100},
+})
+
+USER_TIERS = json.dumps({
+    "user-vip": "vip",
+    "user-standard": "default",
+})
+
+
+def _make_config(**overrides) -> TollboothConfig:
+    """Create a TollboothConfig with sensible defaults."""
+    defaults = {
+        "btcpay_host": "https://btcpay.example.com",
+        "btcpay_store_id": "store-123",
+        "btcpay_api_key": "key-abc",
+        "btcpay_tier_config": TIER_CONFIG,
+        "btcpay_user_tiers": USER_TIERS,
+        "tollbooth_royalty_address": None,
+        "tollbooth_royalty_percent": 0.02,
+        "tollbooth_royalty_min_sats": 10,
+    }
+    defaults.update(overrides)
+    return TollboothConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _get_multiplier
+# ---------------------------------------------------------------------------
+
+
+class TestGetMultiplier:
+    def test_default_when_no_config(self) -> None:
+        assert _get_multiplier("user1", None, None) == 1
+
+    def test_default_tier(self) -> None:
+        assert _get_multiplier("user-standard", TIER_CONFIG, USER_TIERS) == 1
+
+    def test_vip_tier(self) -> None:
+        assert _get_multiplier("user-vip", TIER_CONFIG, USER_TIERS) == 100
+
+    def test_unknown_user_gets_default(self) -> None:
+        assert _get_multiplier("user-unknown", TIER_CONFIG, USER_TIERS) == 1
+
+    def test_corrupt_json_returns_default(self) -> None:
+        assert _get_multiplier("user1", "not json", "also not json") == 1
+
+
+class TestGetTierInfo:
+    def test_default_when_no_config(self) -> None:
+        name, mult = _get_tier_info("user1", None, None)
+        assert name == "default"
+        assert mult == 1
+
+    def test_vip_tier(self) -> None:
+        name, mult = _get_tier_info("user-vip", TIER_CONFIG, USER_TIERS)
+        assert name == "vip"
+        assert mult == 100
+
+    def test_standard_tier(self) -> None:
+        name, mult = _get_tier_info("user-standard", TIER_CONFIG, USER_TIERS)
+        assert name == "default"
+        assert mult == 1
+
+    def test_unknown_user(self) -> None:
+        name, mult = _get_tier_info("user-unknown", TIER_CONFIG, USER_TIERS)
+        assert name == "default"
+        assert mult == 1
+
+    def test_corrupt_json(self) -> None:
+        name, mult = _get_tier_info("user1", "bad", "bad")
+        assert name == "default"
+        assert mult == 1
+
+
+# ---------------------------------------------------------------------------
+# purchase_credits
+# ---------------------------------------------------------------------------
+
+
+class TestPurchaseCredits:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-42",
+            "checkoutLink": "https://pay.example.com/inv-42",
+            "expirationTime": "2026-02-16T01:00:00Z",
+        })
+        cache = _mock_cache()
+        result = await purchase_credits_tool(btcpay, cache, "user1", 1000)
+        assert result["success"] is True
+        assert result["invoice_id"] == "inv-42"
+        assert result["amount_sats"] == 1000
+        assert "checkout_link" in result
+        btcpay.create_invoice.assert_called_once()
+        cache.mark_dirty.assert_called_once_with("user1")
+
+    @pytest.mark.asyncio
+    async def test_zero_amount_rejected(self) -> None:
+        btcpay = _mock_btcpay()
+        cache = _mock_cache()
+        result = await purchase_credits_tool(btcpay, cache, "user1", 0)
+        assert result["success"] is False
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_negative_amount_rejected(self) -> None:
+        btcpay = _mock_btcpay()
+        cache = _mock_cache()
+        result = await purchase_credits_tool(btcpay, cache, "user1", -100)
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_btcpay_error(self) -> None:
+        btcpay = _mock_btcpay(error=BTCPayConnectionError("DNS failed"))
+        cache = _mock_cache()
+        result = await purchase_credits_tool(btcpay, cache, "user1", 1000)
+        assert result["success"] is False
+        assert "BTCPay error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invoice_added_to_pending(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-99", "checkoutLink": "https://x.com"})
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        await purchase_credits_tool(btcpay, cache, "user1", 500)
+        assert "inv-99" in ledger.pending_invoices
+
+    @pytest.mark.asyncio
+    async def test_default_tier_shown(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "checkoutLink": "https://x.com"})
+        cache = _mock_cache()
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", 1000,
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["tier"] == "default"
+        assert result["multiplier"] == 1
+        assert result["expected_credits"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_vip_tier_shown(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "checkoutLink": "https://x.com"})
+        cache = _mock_cache()
+        result = await purchase_credits_tool(
+            btcpay, cache, "user-vip", 500,
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["tier"] == "vip"
+        assert result["multiplier"] == 100
+        assert result["expected_credits"] == 50000
+
+
+# ---------------------------------------------------------------------------
+# check_payment
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPayment:
+    @pytest.mark.asyncio
+    async def test_new_status(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "status": "New"})
+        cache = _mock_cache()
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["success"] is True
+        assert result["status"] == "New"
+        assert "awaiting" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_processing_status(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "status": "Processing"})
+        cache = _mock_cache()
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["status"] == "Processing"
+        assert "confirmation" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_settled_credits_granted(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        ledger = UserLedger(pending_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["success"] is True
+        assert result["credits_granted"] == 1000  # default multiplier = 1
+        assert result["balance_api_sats"] == 1000
+        assert "inv-1" not in ledger.pending_invoices
+        cache.mark_dirty.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_settled_vip_multiplier(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "500",
+        })
+        ledger = UserLedger(pending_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user-vip", "inv-1",
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["credits_granted"] == 50000  # 500 * 100
+        assert result["multiplier"] == 100
+
+    @pytest.mark.asyncio
+    async def test_settled_idempotent(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["credits_granted"] == 0
+        assert result["balance_api_sats"] == 1000
+        assert "already credited" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_expired_removes_pending(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "status": "Expired"})
+        ledger = UserLedger(pending_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["status"] == "Expired"
+        assert "inv-1" not in ledger.pending_invoices
+        assert "expired" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_removes_pending(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "status": "Invalid"})
+        ledger = UserLedger(pending_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["status"] == "Invalid"
+        assert "inv-1" not in ledger.pending_invoices
+
+    @pytest.mark.asyncio
+    async def test_btcpay_error(self) -> None:
+        btcpay = _mock_btcpay(error=BTCPayServerError("500", status_code=500))
+        cache = _mock_cache()
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["success"] is False
+        assert "BTCPay error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_status(self) -> None:
+        btcpay = _mock_btcpay({"id": "inv-1", "status": "SomethingNew"})
+        cache = _mock_cache()
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert "Unknown" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_additional_status_included(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Processing", "additionalStatus": "PaidPartial",
+        })
+        cache = _mock_cache()
+        result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert result["additional_status"] == "PaidPartial"
+
+
+# ---------------------------------------------------------------------------
+# check_balance
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBalance:
+    @pytest.mark.asyncio
+    async def test_fresh_user(self) -> None:
+        cache = _mock_cache()
+        result = await check_balance_tool(cache, "user1")
+        assert result["success"] is True
+        assert result["balance_api_sats"] == 0
+        assert result["pending_invoices"] == 0
+
+    @pytest.mark.asyncio
+    async def test_with_balance(self) -> None:
+        ledger = UserLedger(
+            balance_api_sats=5000,
+            total_deposited_api_sats=10000,
+            total_consumed_api_sats=5000,
+            pending_invoices=["inv-a"],
+            last_deposit_at="2026-02-15",
+        )
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert result["balance_api_sats"] == 5000
+        assert result["total_deposited_api_sats"] == 10000
+        assert result["total_consumed_api_sats"] == 5000
+        assert result["pending_invoices"] == 1
+        assert result["last_deposit_at"] == "2026-02-15"
+
+    @pytest.mark.asyncio
+    async def test_today_usage_included(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 10)
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert "today_usage" in result
+        assert result["today_usage"]["search"]["calls"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_today_usage(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert "today_usage" not in result
+
+    @pytest.mark.asyncio
+    async def test_does_not_modify_state(self) -> None:
+        ledger = UserLedger(balance_api_sats=500)
+        cache = _mock_cache(ledger)
+        await check_balance_tool(cache, "user1")
+        cache.mark_dirty.assert_not_called()
+        assert ledger.balance_api_sats == 500
+
+    @pytest.mark.asyncio
+    async def test_default_tier_shown(self) -> None:
+        cache = _mock_cache()
+        result = await check_balance_tool(
+            cache, "user1",
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["tier"] == "default"
+        assert result["multiplier"] == 1
+
+    @pytest.mark.asyncio
+    async def test_vip_tier_shown(self) -> None:
+        cache = _mock_cache()
+        result = await check_balance_tool(
+            cache, "user-vip",
+            tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
+        )
+        assert result["tier"] == "vip"
+        assert result["multiplier"] == 100
+
+    @pytest.mark.asyncio
+    async def test_seed_balance_granted_shown(self) -> None:
+        """check_balance shows seed_balance_granted when seed sentinel is present."""
+        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["seed_balance_v1"])
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert result["seed_balance_granted"] is True
+
+    @pytest.mark.asyncio
+    async def test_seed_balance_granted_absent(self) -> None:
+        """check_balance omits seed_balance_granted when no seed was applied."""
+        ledger = UserLedger(balance_api_sats=500)
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert "seed_balance_granted" not in result
+
+
+# ---------------------------------------------------------------------------
+# compute_low_balance_warning
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLowBalanceWarning:
+    def test_above_threshold_returns_none(self) -> None:
+        """Balance well above threshold -> no warning."""
+        ledger = UserLedger(balance_api_sats=5000)
+        assert compute_low_balance_warning(ledger, seed_balance_sats=1000) is None
+
+    def test_at_threshold_returns_none(self) -> None:
+        """Balance exactly at threshold -> no warning (>= means safe)."""
+        # seed_balance_sats=500, threshold = max(500//5, 100) = 100
+        ledger = UserLedger(
+            balance_api_sats=100,
+            credited_invoices=["seed_balance_v1"],
+        )
+        assert compute_low_balance_warning(ledger, seed_balance_sats=500) is None
+
+    def test_below_threshold_returns_warning(self) -> None:
+        """Balance below threshold -> warning dict."""
+        ledger = UserLedger(
+            balance_api_sats=50,
+            credited_invoices=["seed_balance_v1"],
+        )
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=500)
+        assert warning is not None
+        assert warning["balance_api_sats"] == 50
+        assert warning["threshold_api_sats"] == 100
+        assert "purchase_credits" in warning["purchase_command"]
+        assert "message" in warning
+
+    def test_settled_invoice_reference(self) -> None:
+        """Threshold is 20% of last settled invoice's api_sats_credited."""
+        ledger = UserLedger(balance_api_sats=50)
+        ledger.record_invoice_created("inv-1", amount_sats=1000, multiplier=1, created_at="")
+        ledger.record_invoice_settled("inv-1", api_sats_credited=1000, settled_at="")
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
+        assert warning is not None
+        # threshold = max(1000 // 5, 100) = 200
+        assert warning["threshold_api_sats"] == 200
+
+    def test_seed_only_user(self) -> None:
+        """Seed-only user: reference is seed_balance_sats."""
+        ledger = UserLedger(
+            balance_api_sats=10,
+            credited_invoices=["seed_balance_v1"],
+        )
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=1000)
+        assert warning is not None
+        # threshold = max(1000 // 5, 100) = 200
+        assert warning["threshold_api_sats"] == 200
+
+    def test_no_history_uses_floor(self) -> None:
+        """No invoices, no seed: reference is the floor."""
+        ledger = UserLedger(balance_api_sats=50)
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
+        assert warning is not None
+        # reference = floor (100), threshold = max(100//5, 100) = 100
+        assert warning["threshold_api_sats"] == 100
+
+    def test_retroactive_invoice_suggested_defaults(self) -> None:
+        """Retroactive invoice (amount_sats=0) -> suggested defaults to 1000."""
+        ledger = UserLedger(balance_api_sats=5)
+        ledger.record_invoice_settled("inv-retro", api_sats_credited=500, settled_at="")
+        # retroactive: amount_sats=0 in the record
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
+        assert warning is not None
+        assert warning["suggested_top_up_sats"] == 1000
+
+    def test_suggested_capped_at_max(self) -> None:
+        """Suggested top-up capped at MAX_INVOICE_SATS."""
+        ledger = UserLedger(balance_api_sats=5)
+        ledger.record_invoice_created(
+            "inv-big", amount_sats=5_000_000, multiplier=1, created_at="",
+        )
+        ledger.record_invoice_settled("inv-big", api_sats_credited=5_000_000, settled_at="")
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
+        assert warning is not None
+        assert warning["suggested_top_up_sats"] == MAX_INVOICE_SATS
+
+    def test_zero_seed_no_invoices(self) -> None:
+        """Zero seed + no invoices -> floor path."""
+        ledger = UserLedger(balance_api_sats=50)
+        warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
+        assert warning is not None
+        assert warning["threshold_api_sats"] == 100
+        assert warning["suggested_top_up_sats"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# purchase cap
+# ---------------------------------------------------------------------------
+
+
+class TestPurchaseCap:
+    @pytest.mark.asyncio
+    async def test_max_accepted(self) -> None:
+        """Exactly MAX_INVOICE_SATS is accepted."""
+        btcpay = _mock_btcpay({
+            "id": "inv-max", "checkoutLink": "https://pay.example.com/inv-max",
+        })
+        cache = _mock_cache()
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", MAX_INVOICE_SATS,
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_over_max_rejected(self) -> None:
+        """MAX_INVOICE_SATS + 1 is rejected."""
+        btcpay = _mock_btcpay()
+        cache = _mock_cache()
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", MAX_INVOICE_SATS + 1,
+        )
+        assert result["success"] is False
+        assert "maximum" in result["error"]
+        assert "1,000,000" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# _attempt_royalty_payout
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptRoyaltyPayout:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(
+            return_value={"id": "payout-1", "state": "AwaitingApproval"}
+        )
+        result = await _attempt_royalty_payout(btcpay, 1000, "addr@ln", 0.02, 10)
+        assert result is not None
+        assert result["royalty_sats"] == 20
+        assert result["royalty_address"] == "addr@ln"
+        assert result["payout_id"] == "payout-1"
+        assert result["payout_state"] == "AwaitingApproval"
+        btcpay.create_payout.assert_called_once_with("addr@ln", 20)
+
+    @pytest.mark.asyncio
+    async def test_below_minimum_returns_none(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        result = await _attempt_royalty_payout(btcpay, 100, "addr@ln", 0.02, 10)
+        # 100 * 0.02 = 2, below min of 10
+        assert result is None
+        btcpay.create_payout.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_at_minimum(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(return_value={"id": "p-2", "state": "OK"})
+        result = await _attempt_royalty_payout(btcpay, 500, "addr@ln", 0.02, 10)
+        # 500 * 0.02 = 10, exactly at min
+        assert result is not None
+        assert result["royalty_sats"] == 10
+
+    @pytest.mark.asyncio
+    async def test_btcpay_error_returns_dict_never_raises(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(
+            side_effect=BTCPayServerError("500 oops", status_code=500)
+        )
+        result = await _attempt_royalty_payout(btcpay, 1000, "addr@ln", 0.02, 10)
+        assert result is not None
+        assert result["royalty_sats"] == 20
+        assert "royalty_error" in result
+        assert "500 oops" in result["royalty_error"]
+
+    @pytest.mark.asyncio
+    async def test_percentage_math(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(return_value={"id": "p", "state": "OK"})
+        result = await _attempt_royalty_payout(btcpay, 5000, "a@b", 0.05, 10)
+        assert result is not None
+        assert result["royalty_sats"] == 250  # 5000 * 0.05
+
+    @pytest.mark.asyncio
+    async def test_int_truncation_rounding(self) -> None:
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(return_value={"id": "p", "state": "OK"})
+        # 999 * 0.02 = 19.98, int() truncates to 19
+        result = await _attempt_royalty_payout(btcpay, 999, "a@b", 0.02, 10)
+        assert result is not None
+        assert result["royalty_sats"] == 19
+
+
+# ---------------------------------------------------------------------------
+# Royalty payout ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestRoyaltyPayoutCeiling:
+    @pytest.mark.asyncio
+    async def test_above_ceiling_refused(self) -> None:
+        """Royalty exceeding ROYALTY_PAYOUT_MAX_SATS is refused without calling BTCPay."""
+        btcpay = AsyncMock(spec=BTCPayClient)
+        # 10M * 0.02 = 200,000 sats — above 100K ceiling
+        result = await _attempt_royalty_payout(btcpay, 10_000_000, "addr@ln", 0.02, 10)
+        assert result is not None
+        assert "royalty_error" in result
+        assert "safety ceiling" in result["royalty_error"]
+        assert result["royalty_sats"] == 200_000
+        btcpay.create_payout.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_at_ceiling_allowed(self) -> None:
+        """Royalty exactly at ROYALTY_PAYOUT_MAX_SATS is allowed."""
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(return_value={"id": "p-1", "state": "OK"})
+        # 5M * 0.02 = 100,000 sats — exactly at ceiling
+        result = await _attempt_royalty_payout(btcpay, 5_000_000, "addr@ln", 0.02, 10)
+        assert result is not None
+        assert "royalty_error" not in result
+        assert result["royalty_sats"] == ROYALTY_PAYOUT_MAX_SATS
+        btcpay.create_payout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_just_below_ceiling_allowed(self) -> None:
+        """Royalty just below ceiling is allowed."""
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.create_payout = AsyncMock(return_value={"id": "p-2", "state": "OK"})
+        # 4,999,999 * 0.02 = 99,999.98 -> int() = 99,999
+        result = await _attempt_royalty_payout(btcpay, 4_999_999, "addr@ln", 0.02, 10)
+        assert result is not None
+        assert "royalty_error" not in result
+        assert result["royalty_sats"] == 99_999
+
+    @pytest.mark.asyncio
+    async def test_ceiling_catches_bad_percentage(self) -> None:
+        """A mis-configured 100% royalty rate is caught by the ceiling."""
+        btcpay = AsyncMock(spec=BTCPayClient)
+        # 500,000 * 1.0 = 500,000 sats — way above ceiling
+        result = await _attempt_royalty_payout(btcpay, 500_000, "addr@ln", 1.0, 10)
+        assert result is not None
+        assert "royalty_error" in result
+        assert "safety ceiling" in result["royalty_error"]
+        btcpay.create_payout.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_payment with royalty
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPaymentWithRoyalty:
+    @pytest.mark.asyncio
+    async def test_settled_triggers_payout(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        btcpay.create_payout = AsyncMock(
+            return_value={"id": "payout-1", "state": "AwaitingApproval"}
+        )
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
+        )
+        assert result["credits_granted"] == 1000
+        assert "royalty_payout" in result
+        assert result["royalty_payout"]["royalty_sats"] == 20
+        assert result["royalty_payout"]["payout_id"] == "payout-1"
+
+    @pytest.mark.asyncio
+    async def test_no_payout_when_address_none(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            royalty_address=None,
+        )
+        assert result["credits_granted"] == 1000
+        assert "royalty_payout" not in result
+
+    @pytest.mark.asyncio
+    async def test_payout_failure_doesnt_block_credits(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        btcpay.create_payout = AsyncMock(
+            side_effect=BTCPayServerError("fail", status_code=500)
+        )
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
+        )
+        assert result["success"] is True
+        assert result["credits_granted"] == 1000
+        assert result["royalty_payout"]["royalty_error"] is not None
+
+    @pytest.mark.asyncio
+    async def test_idempotent_path_skips_payout(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "1000",
+        })
+        btcpay.create_payout = AsyncMock()
+        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["inv-1"])
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
+        )
+        assert result["credits_granted"] == 0
+        assert "royalty_payout" not in result
+        btcpay.create_payout.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_below_minimum_skips_payout(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "100",
+        })
+        btcpay.create_payout = AsyncMock()
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        result = await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
+        )
+        # 100 * 0.02 = 2, below min 10 -> no royalty_payout key
+        assert result["credits_granted"] == 100
+        assert "royalty_payout" not in result
+        btcpay.create_payout.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# btcpay_status with royalty (uses TollboothConfig)
+# ---------------------------------------------------------------------------
+
+
+class TestBTCPayStatusRoyalty:
+    @pytest.mark.asyncio
+    async def test_royalty_config_shown(self) -> None:
+        config = _make_config(tollbooth_royalty_address="toll@ln")
+
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
+        btcpay.get_api_key_info = AsyncMock(return_value={
+            "permissions": [
+                "btcpay.store.cancreateinvoice",
+                "btcpay.store.canviewinvoices",
+                "btcpay.store.cancreatenonapprovedpullpayments",
+            ]
+        })
+
+        result = await btcpay_status_tool(config, btcpay)
+        assert result["royalty_config"]["enabled"] is True
+        assert result["royalty_config"]["address"] == "toll@ln"
+        assert result["royalty_config"]["percent"] == 0.02
+        assert result["royalty_config"]["min_sats"] == 10
+
+    @pytest.mark.asyncio
+    async def test_royalty_disabled_shown(self) -> None:
+        config = _make_config(
+            btcpay_host=None, btcpay_store_id=None, btcpay_api_key=None,
+            btcpay_tier_config=None, btcpay_user_tiers=None,
+        )
+        result = await btcpay_status_tool(config, None)
+        assert result["royalty_config"]["enabled"] is False
+        assert result["royalty_config"]["address"] is None
+
+    @pytest.mark.asyncio
+    async def test_permissions_success(self) -> None:
+        config = _make_config(tollbooth_royalty_address="toll@ln")
+
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
+        btcpay.get_api_key_info = AsyncMock(return_value={
+            "permissions": [
+                "btcpay.store.cancreateinvoice",
+                "btcpay.store.canviewinvoices",
+                "btcpay.store.cancreatenonapprovedpullpayments",
+            ]
+        })
+
+        result = await btcpay_status_tool(config, btcpay)
+        perms = result["api_key_permissions"]
+        assert perms["missing"] == []
+        assert len(perms["present"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_missing_payout_perm(self) -> None:
+        config = _make_config(tollbooth_royalty_address="toll@ln")
+
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
+        btcpay.get_api_key_info = AsyncMock(return_value={
+            "permissions": [
+                "btcpay.store.cancreateinvoice",
+                "btcpay.store.canviewinvoices",
+            ]
+        })
+
+        result = await btcpay_status_tool(config, btcpay)
+        perms = result["api_key_permissions"]
+        assert "btcpay.store.cancreatenonapprovedpullpayments" in perms["missing"]
+
+    @pytest.mark.asyncio
+    async def test_api_key_info_error(self) -> None:
+        config = _make_config()
+
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
+        btcpay.get_api_key_info = AsyncMock(
+            side_effect=BTCPayAuthError("unauthorized", status_code=401)
+        )
+
+        result = await btcpay_status_tool(config, btcpay)
+        assert "error" in result["api_key_permissions"]
+
+
+# ---------------------------------------------------------------------------
+# btcpay_status (uses TollboothConfig)
+# ---------------------------------------------------------------------------
+
+
+class TestBTCPayStatus:
+    @pytest.mark.asyncio
+    async def test_all_configured_and_reachable(self) -> None:
+        """Full config, server reachable, store accessible."""
+        config = _make_config()
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(return_value={"name": "My Store"})
+        btcpay.get_api_key_info = AsyncMock(return_value={
+            "permissions": ["btcpay.store.cancreateinvoice", "btcpay.store.canviewinvoices"]
+        })
+
+        result = await btcpay_status_tool(config, btcpay)
+
+        assert result["btcpay_host"] == "https://btcpay.example.com"
+        assert result["btcpay_store_id"] == "store-123"
+        assert result["btcpay_api_key_status"] == "present"
+        assert result["tier_config"] == "2 tier(s)"
+        assert result["user_tiers"] == "2 user(s)"
+        assert result["server_reachable"] is True
+        assert result["store_name"] == "My Store"
+
+    @pytest.mark.asyncio
+    async def test_api_key_missing(self) -> None:
+        """Missing API key — network checks skipped."""
+        config = _make_config(btcpay_api_key=None)
+
+        result = await btcpay_status_tool(config, None)
+
+        assert result["btcpay_api_key_status"] == "missing"
+        assert result["server_reachable"] is None
+        assert result["store_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_host_missing(self) -> None:
+        """Missing host — network checks skipped."""
+        config = _make_config(btcpay_host=None)
+
+        result = await btcpay_status_tool(config, None)
+
+        assert result["btcpay_host"] is None
+        assert result["server_reachable"] is None
+        assert result["store_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_tier_config_json(self) -> None:
+        """Invalid tier config JSON reported."""
+        config = _make_config(btcpay_tier_config="not valid json{")
+
+        result = await btcpay_status_tool(config, None)
+
+        assert result["tier_config"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_server_unreachable(self) -> None:
+        """Server unreachable — health check fails."""
+        config = _make_config()
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(
+            side_effect=BTCPayConnectionError("DNS failed")
+        )
+        btcpay.get_store = AsyncMock(return_value={"name": "My Store"})
+        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
+
+        result = await btcpay_status_tool(config, btcpay)
+
+        assert result["server_reachable"] is False
+        assert result["store_name"] == "My Store"
+
+    @pytest.mark.asyncio
+    async def test_store_auth_failure(self) -> None:
+        """Store returns 401 — reported as unauthorized."""
+        config = _make_config()
+        btcpay = AsyncMock(spec=BTCPayClient)
+        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
+        btcpay.get_store = AsyncMock(
+            side_effect=BTCPayAuthError("Unauthorized", status_code=401)
+        )
+        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
+
+        result = await btcpay_status_tool(config, btcpay)
+
+        assert result["server_reachable"] is True
+        assert result["store_name"] == "unauthorized"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,215 @@
+"""Tests for UserLedger model and serialization."""
+
+import json
+from datetime import date
+
+import pytest
+
+from tollbooth.ledger import ToolUsage, UserLedger
+
+
+# ---------------------------------------------------------------------------
+# ToolUsage
+# ---------------------------------------------------------------------------
+
+
+class TestToolUsage:
+    def test_defaults(self) -> None:
+        u = ToolUsage()
+        assert u.calls == 0
+        assert u.api_sats == 0
+
+    def test_to_dict(self) -> None:
+        u = ToolUsage(calls=5, api_sats=100)
+        assert u.to_dict() == {"calls": 5, "api_sats": 100}
+
+    def test_from_dict(self) -> None:
+        u = ToolUsage.from_dict({"calls": 3, "api_sats": 42})
+        assert u.calls == 3
+        assert u.api_sats == 42
+
+    def test_from_dict_missing_fields(self) -> None:
+        u = ToolUsage.from_dict({})
+        assert u.calls == 0
+        assert u.api_sats == 0
+
+    def test_roundtrip(self) -> None:
+        original = ToolUsage(calls=10, api_sats=200)
+        restored = ToolUsage.from_dict(original.to_dict())
+        assert restored.calls == original.calls
+        assert restored.api_sats == original.api_sats
+
+
+# ---------------------------------------------------------------------------
+# UserLedger — debit / credit / rollback
+# ---------------------------------------------------------------------------
+
+
+class TestUserLedger:
+    def test_debit_success(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        assert ledger.debit("search", 30) is True
+        assert ledger.balance_api_sats == 70
+        assert ledger.total_consumed_api_sats == 30
+
+    def test_debit_insufficient_balance(self) -> None:
+        ledger = UserLedger(balance_api_sats=10)
+        assert ledger.debit("search", 20) is False
+        assert ledger.balance_api_sats == 10
+        assert ledger.total_consumed_api_sats == 0
+
+    def test_debit_exact_balance(self) -> None:
+        ledger = UserLedger(balance_api_sats=50)
+        assert ledger.debit("search", 50) is True
+        assert ledger.balance_api_sats == 0
+
+    def test_debit_negative_amount_rejected(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        assert ledger.debit("search", -5) is False
+        assert ledger.balance_api_sats == 100
+
+    def test_debit_zero(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        assert ledger.debit("search", 0) is True
+        assert ledger.balance_api_sats == 100
+
+    def test_debit_updates_daily_log(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 10)
+        today = date.today().isoformat()
+        assert today in ledger.daily_log
+        assert ledger.daily_log[today]["search"].calls == 1
+        assert ledger.daily_log[today]["search"].api_sats == 10
+
+    def test_debit_updates_history(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 10)
+        ledger.debit("search", 20)
+        assert ledger.history["search"].calls == 2
+        assert ledger.history["search"].api_sats == 30
+
+    def test_credit_deposit(self) -> None:
+        ledger = UserLedger(balance_api_sats=50, pending_invoices=["inv-1"])
+        ledger.credit_deposit(100, "inv-1")
+        assert ledger.balance_api_sats == 150
+        assert ledger.total_deposited_api_sats == 100
+        assert ledger.last_deposit_at == date.today().isoformat()
+        assert "inv-1" not in ledger.pending_invoices
+
+    def test_credit_deposit_unknown_invoice(self) -> None:
+        ledger = UserLedger(pending_invoices=["inv-1"])
+        ledger.credit_deposit(50, "inv-other")
+        assert ledger.balance_api_sats == 50
+        assert "inv-1" in ledger.pending_invoices
+
+    def test_rollback_debit(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 30)
+        assert ledger.balance_api_sats == 70
+        ledger.rollback_debit("search", 30)
+        assert ledger.balance_api_sats == 100
+        assert ledger.total_consumed_api_sats == 0
+
+    def test_rollback_clamps_to_zero(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 10)
+        # Rollback more than was debited
+        ledger.rollback_debit("search", 20)
+        assert ledger.history["search"].calls == 0
+        assert ledger.history["search"].api_sats == 0
+
+    def test_seed_via_credit_deposit(self) -> None:
+        """Seed balance via credit_deposit with sentinel ID."""
+        ledger = UserLedger()
+        ledger.credit_deposit(1000, "seed_balance_v1")
+        assert ledger.balance_api_sats == 1000
+        assert ledger.total_deposited_api_sats == 1000
+        assert "seed_balance_v1" in ledger.credited_invoices
+
+    def test_seed_sentinel_prevents_double_credit(self) -> None:
+        """Second credit_deposit with same sentinel is a no-op for credited_invoices."""
+        ledger = UserLedger()
+        ledger.credit_deposit(1000, "seed_balance_v1")
+        # Calling again adds balance but sentinel already present (idempotency
+        # is checked by the caller, not credit_deposit itself)
+        assert "seed_balance_v1" in ledger.credited_invoices
+        # Caller should check `sentinel not in ledger.credited_invoices` before calling
+        assert ledger.credited_invoices.count("seed_balance_v1") == 1
+
+    def test_seed_balance_is_spendable(self) -> None:
+        """Seeded balance can be spent via debit()."""
+        ledger = UserLedger()
+        ledger.credit_deposit(1000, "seed_balance_v1")
+        assert ledger.debit("search", 100) is True
+        assert ledger.balance_api_sats == 900
+
+    def test_rotate_daily_log(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        # Add an old entry
+        ledger.daily_log["2020-01-01"] = {"search": ToolUsage(calls=5, api_sats=50)}
+        # Add today's entry
+        today = date.today().isoformat()
+        ledger.daily_log[today] = {"search": ToolUsage(calls=1, api_sats=10)}
+        ledger.rotate_daily_log(retention_days=30)
+        assert "2020-01-01" not in ledger.daily_log
+        assert today in ledger.daily_log
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerSerialization:
+    def test_roundtrip(self) -> None:
+        ledger = UserLedger(balance_api_sats=500, total_deposited_api_sats=1000)
+        ledger.debit("search", 100)
+        restored = UserLedger.from_json(ledger.to_json())
+        assert restored.balance_api_sats == 400
+        assert restored.total_deposited_api_sats == 1000
+        assert restored.total_consumed_api_sats == 100
+        assert "search" in restored.history
+        assert restored.history["search"].calls == 1
+
+    def test_schema_version(self) -> None:
+        ledger = UserLedger()
+        obj = json.loads(ledger.to_json())
+        assert obj["v"] == 3
+
+    def test_from_json_missing_fields(self) -> None:
+        restored = UserLedger.from_json('{"v": 1}')
+        assert restored.balance_api_sats == 0
+        assert restored.pending_invoices == []
+
+    def test_from_json_corrupt_data(self) -> None:
+        restored = UserLedger.from_json("not json at all")
+        assert restored.balance_api_sats == 0
+
+    def test_from_json_none(self) -> None:
+        restored = UserLedger.from_json(None)  # type: ignore[arg-type]
+        assert restored.balance_api_sats == 0
+
+    def test_from_json_non_dict(self) -> None:
+        restored = UserLedger.from_json('"just a string"')
+        assert restored.balance_api_sats == 0
+
+    def test_daily_log_survives_roundtrip(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        ledger.debit("search", 10)
+        ledger.debit("create", 20)
+        restored = UserLedger.from_json(ledger.to_json())
+        today = date.today().isoformat()
+        assert restored.daily_log[today]["search"].api_sats == 10
+        assert restored.daily_log[today]["create"].api_sats == 20
+
+    def test_pending_invoices_survive_roundtrip(self) -> None:
+        ledger = UserLedger(pending_invoices=["inv-a", "inv-b"])
+        restored = UserLedger.from_json(ledger.to_json())
+        assert restored.pending_invoices == ["inv-a", "inv-b"]
+
+    def test_to_json_is_pretty_printed(self) -> None:
+        ledger = UserLedger(balance_api_sats=100)
+        output = ledger.to_json()
+        assert "\n" in output
+        parsed = json.loads(output)
+        assert parsed["balance_api_sats"] == 100

--- a/tests/test_ledger_cache.py
+++ b/tests/test_ledger_cache.py
@@ -1,0 +1,362 @@
+"""Tests for LedgerCache: LRU eviction, background flush, concurrency."""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock
+
+from tollbooth.ledger import UserLedger
+from tollbooth.ledger_cache import LedgerCache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_vault(ledger_json: str | None = None, fail_store: bool = False):
+    """Create a mock vault with fetch_ledger/store_ledger."""
+    vault = AsyncMock()
+    vault.fetch_ledger = AsyncMock(return_value=ledger_json)
+    if fail_store:
+        vault.store_ledger = AsyncMock(side_effect=Exception("vault write failed"))
+    else:
+        vault.store_ledger = AsyncMock(return_value="ledger-thought-id")
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# Cache miss / hit
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheGetMiss:
+    @pytest.mark.asyncio
+    async def test_cache_miss_returns_fresh_ledger(self) -> None:
+        vault = _mock_vault(ledger_json=None)
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        assert ledger.balance_api_sats == 0
+        vault.fetch_ledger.assert_called_once_with("user1")
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_loads_from_vault(self) -> None:
+        stored = UserLedger(balance_api_sats=500)
+        vault = _mock_vault(ledger_json=stored.to_json())
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        assert ledger.balance_api_sats == 500
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_vault_error_returns_fresh(self) -> None:
+        vault = AsyncMock()
+        vault.fetch_ledger = AsyncMock(side_effect=Exception("network error"))
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        assert ledger.balance_api_sats == 0
+
+
+class TestLedgerCacheGetHit:
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_same_object(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        ledger1 = await cache.get("user1")
+        ledger2 = await cache.get("user1")
+        assert ledger1 is ledger2
+        # Vault should only be called once
+        vault.fetch_ledger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mutations_visible_on_cache_hit(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        ledger.balance_api_sats = 999
+        cache.mark_dirty("user1")
+        ledger2 = await cache.get("user1")
+        assert ledger2.balance_api_sats == 999
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheEviction:
+    @pytest.mark.asyncio
+    async def test_eviction_at_capacity(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=2)
+        await cache.get("user1")
+        await cache.get("user2")
+        await cache.get("user3")  # should evict user1
+        assert cache.size == 2
+        # user1 was evicted, next access should reload from vault
+        vault.fetch_ledger.reset_mock()
+        await cache.get("user1")
+        vault.fetch_ledger.assert_called_with("user1")
+
+    @pytest.mark.asyncio
+    async def test_eviction_flushes_dirty_entry(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=2)
+        ledger1 = await cache.get("user1")
+        ledger1.balance_api_sats = 42
+        cache.mark_dirty("user1")
+        await cache.get("user2")
+        await cache.get("user3")  # evicts user1
+        vault.store_ledger.assert_called_once()
+        args = vault.store_ledger.call_args[0]
+        assert args[0] == "user1"
+
+    @pytest.mark.asyncio
+    async def test_eviction_does_not_flush_clean_entry(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=2)
+        await cache.get("user1")  # clean
+        await cache.get("user2")
+        await cache.get("user3")  # evicts user1 (clean)
+        vault.store_ledger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lru_order_access_refreshes(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=2)
+        await cache.get("user1")
+        await cache.get("user2")
+        await cache.get("user1")   # refresh user1 — user2 is now LRU
+        await cache.get("user3")   # evicts user2
+        assert cache.size == 2
+        # user1 should still be cached (no vault call)
+        vault.fetch_ledger.reset_mock()
+        ledger = await cache.get("user1")
+        vault.fetch_ledger.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dirty tracking and flush
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheFlush:
+    @pytest.mark.asyncio
+    async def test_mark_dirty_and_flush(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        ledger.balance_api_sats = 100
+        cache.mark_dirty("user1")
+        count = await cache.flush_dirty()
+        assert count == 1
+        vault.store_ledger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_flush_skips_clean_entries(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")  # clean
+        count = await cache.flush_dirty()
+        assert count == 0
+        vault.store_ledger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flush_clears_dirty_flag(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        ledger = await cache.get("user1")
+        cache.mark_dirty("user1")
+        await cache.flush_dirty()
+        # Second flush should be a no-op
+        vault.store_ledger.reset_mock()
+        count = await cache.flush_dirty()
+        assert count == 0
+        vault.store_ledger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flush_failure_keeps_dirty(self) -> None:
+        vault = _mock_vault(fail_store=True)
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        cache.mark_dirty("user1")
+        count = await cache.flush_dirty()
+        assert count == 0  # failed, entry still dirty
+        # Retry should attempt again
+        vault.store_ledger.reset_mock()
+        vault.store_ledger = AsyncMock(return_value="ok")
+        count = await cache.flush_dirty()
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_flush_all(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        await cache.get("user2")
+        cache.mark_dirty("user1")
+        cache.mark_dirty("user2")
+        count = await cache.flush_all()
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_mark_dirty_nonexistent_noop(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        cache.mark_dirty("ghost")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Snapshot all
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheSnapshotAll:
+    @pytest.mark.asyncio
+    async def test_snapshot_all_iterates_entries(self) -> None:
+        vault = _mock_vault()
+        vault.snapshot_ledger = AsyncMock(return_value="snap-id")
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        await cache.get("user2")
+        count = await cache.snapshot_all("2026-02-16T12:00:00Z")
+        assert count == 2
+        assert vault.snapshot_ledger.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_snapshot_all_empty_cache(self) -> None:
+        vault = _mock_vault()
+        vault.snapshot_ledger = AsyncMock(return_value="snap-id")
+        cache = LedgerCache(vault, maxsize=5)
+        count = await cache.snapshot_all("2026-02-16T12:00:00Z")
+        assert count == 0
+        vault.snapshot_ledger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_all_skips_failures(self) -> None:
+        vault = _mock_vault()
+        call_count = 0
+
+        async def snapshot_side_effect(user_id, ledger_json, ts):
+            nonlocal call_count
+            call_count += 1
+            if user_id == "user1":
+                raise Exception("vault error")
+            return "snap-id"
+
+        vault.snapshot_ledger = AsyncMock(side_effect=snapshot_side_effect)
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        await cache.get("user2")
+        count = await cache.snapshot_all("2026-02-16T12:00:00Z")
+        assert count == 1  # user1 failed, user2 succeeded
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_snapshot_all_counts_none_as_skipped(self) -> None:
+        vault = _mock_vault()
+        vault.snapshot_ledger = AsyncMock(return_value=None)
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        count = await cache.snapshot_all("2026-02-16T12:00:00Z")
+        assert count == 0  # None means no ledger thought existed
+
+
+# ---------------------------------------------------------------------------
+# Background flush
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheBackgroundFlush:
+    @pytest.mark.asyncio
+    async def test_start_and_stop(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5, flush_interval_secs=1)
+        await cache.start_background_flush()
+        assert cache._flush_task is not None
+        await cache.stop()
+        assert cache._flush_task is None
+
+    @pytest.mark.asyncio
+    async def test_background_flush_writes_dirty(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5, flush_interval_secs=0.1)
+        ledger = await cache.get("user1")
+        ledger.balance_api_sats = 77
+        cache.mark_dirty("user1")
+        await cache.start_background_flush()
+        await asyncio.sleep(0.3)  # wait for at least one flush cycle
+        await cache.stop()
+        vault.store_ledger.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_flushes_remaining(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5, flush_interval_secs=999)
+        await cache.start_background_flush()
+        ledger = await cache.get("user1")
+        cache.mark_dirty("user1")
+        await cache.stop()  # should flush before returning
+        vault.store_ledger.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_double_start_idempotent(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5, flush_interval_secs=1)
+        await cache.start_background_flush()
+        task1 = cache._flush_task
+        await cache.start_background_flush()
+        assert cache._flush_task is task1  # same task, not duplicated
+        await cache.stop()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheConcurrency:
+    @pytest.mark.asyncio
+    async def test_concurrent_get_same_user(self) -> None:
+        """Two concurrent gets for the same user should both see the same ledger."""
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+
+        results = await asyncio.gather(
+            cache.get("user1"),
+            cache.get("user1"),
+        )
+        assert results[0] is results[1]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_different_users(self) -> None:
+        """Concurrent gets for different users should not interfere."""
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+
+        results = await asyncio.gather(
+            cache.get("user1"),
+            cache.get("user2"),
+        )
+        assert results[0] is not results[1]
+        assert cache.size == 2
+
+
+# ---------------------------------------------------------------------------
+# Size property
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerCacheSize:
+    @pytest.mark.asyncio
+    async def test_size_empty(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        assert cache.size == 0
+
+    @pytest.mark.asyncio
+    async def test_size_after_gets(self) -> None:
+        vault = _mock_vault()
+        cache = LedgerCache(vault, maxsize=5)
+        await cache.get("user1")
+        await cache.get("user2")
+        assert cache.size == 2


### PR DESCRIPTION
## Summary
- Extracts pure-commerce modules from thebrain-mcp into standalone tollbooth-dpyc package (Task 42 Phase 1)
- Includes UserLedger, BTCPayClient, VaultBackend Protocol, LedgerCache, credit tools, TollboothConfig, and ToolTier constants
- All 163 tests pass with only httpx as a runtime dependency — zero TheBrain dependencies

## Test plan
- [x] `pytest tests/ -q` — 163 tests pass
- [x] `python -c "from tollbooth import TollboothConfig, UserLedger, BTCPayClient, LedgerCache"` — imports work
- [x] No `thebrain` references in source: `grep -r "thebrain" src/` returns nothing
- [ ] After merge: Phase 2 PR in thebrain-mcp will import tollbooth-dpyc and verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)