### PR TITLE
Bump version to 0.1.2 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.1"
+version = "0.1.2"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Version bump 0.1.1 → 0.1.2
- **P0**: thebrain-mcp deploy is crashing because the installed tollbooth-dpyc on Horizon (0.1.1) doesn't have `authority_public_key` in `TollboothConfig`
- After merge, publish to PyPI and redeploy thebrain-mcp

## What's new in 0.1.2
- `authority_public_key` and `authority_url` fields in `TollboothConfig`
- `certificate.py` — Ed25519 JWT verification with anti-replay
- Mandatory trust chain in `purchase_credits_tool`
- `authority_config` diagnostics in `btcpay_status_tool`
- `PyJWT[crypto]` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)