### PR TITLE
Accept bare base64 keys, remove authority_url scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ async with BTCPayClient(config.btcpay_host, config.btcpay_api_key, config.btcpay
 | `tollbooth_royalty_address` | `str \| None` | `None` | Lightning Address for the 2% royalty payout to the Tollbooth originator |
 | `tollbooth_royalty_percent` | `float` | `0.02` | Royalty percentage (0.02 = 2%) |
 | `tollbooth_royalty_min_sats` | `int` | `10` | Minimum royalty payout in sats (below this, no payout fires) |
-| `authority_public_key` | `str \| None` | `None` | Authority's Ed25519 PEM public key for certificate verification. When set, `purchase_credits` requires a valid Authority JWT. |
-| `authority_url` | `str \| None` | `None` | Authority MCP endpoint URL (scaffolding for future use) |
+| `authority_public_key` | `str \| None` | `None` | Authority's Ed25519 public key — bare base64 or full PEM. Required for `purchase_credits` (every purchase needs a valid Authority JWT). |
 
 ## Tool Functions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.2"
+version = "0.1.3"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,9 +3,9 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.3"
 
-from tollbooth.certificate import CertificateError, verify_certificate
+from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -28,4 +28,6 @@ __all__ = [
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",
     "verify_certificate",
+    "normalize_public_key",
+    "key_fingerprint",
 ]

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -19,4 +19,3 @@ class TollboothConfig:
     tollbooth_royalty_percent: float = 0.02
     tollbooth_royalty_min_sats: int = 10
     authority_public_key: str | None = None
-    authority_url: str | None = None

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -95,6 +95,17 @@ class TestVerifyCertificateValid:
         assert result["net_sats"] == 980
         assert result["jti"] == "jti-unique-1"
 
+    def test_bare_base64_key_accepted(self, keypair):
+        """Bare base64 key (no PEM headers) works for verification."""
+        private_key, public_pem = keypair
+        # Strip PEM headers to get bare base64
+        lines = [ln for ln in public_pem.strip().splitlines() if not ln.startswith("-----")]
+        bare_b64 = "".join(lines).strip()
+        token = _sign_certificate(private_key, jti="jti-bare-b64")
+        result = verify_certificate(token, bare_b64)
+        assert result["operator_id"] == "op-1"
+        assert result["jti"] == "jti-bare-b64"
+
     def test_extracts_all_claims(self, keypair):
         private_key, public_pem = keypair
         token = _sign_certificate(


### PR DESCRIPTION
## Summary
- `AUTHORITY_PUBLIC_KEY` now accepts bare base64 (e.g. `MCowBQYDK2VwAyEA...`) — no PEM headers needed
- `normalize_public_key()` and `key_fingerprint()` exported for reuse
- Removed `authority_url` from TollboothConfig, btcpay_status, README (dead code)
- Fixed empty fingerprint bug (now works with both bare base64 and full PEM)
- Bumped to 0.1.3

## Test plan
- [x] 187 tests pass
- [x] New test: bare base64 key accepted in `verify_certificate`
- [x] New test: bare base64 key works in `btcpay_status` diagnostics
- [x] New test: fingerprint matches between PEM and bare base64 formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)