### PR TITLE
Add runtime version provenance to btcpay_status

### DIFF
--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import logging
+import platform
 from datetime import date, datetime, timezone
 from typing import Any
 
@@ -637,6 +639,15 @@ async def btcpay_status_tool(
         "btcpay_store_id": config.btcpay_store_id or None,
         "btcpay_api_key_status": "present" if config.btcpay_api_key else "missing",
     }
+
+    # Runtime version provenance — what's actually imported in this process
+    versions: dict[str, str] = {"python": platform.python_version()}
+    for pkg in ("tollbooth-dpyc", "fastmcp"):
+        try:
+            versions[pkg.replace("-", "_")] = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            versions[pkg.replace("-", "_")] = "unknown"
+    result["versions"] = versions
 
     # Tier config
     if config.btcpay_tier_config:


### PR DESCRIPTION
## Summary
- Adds `versions` section to `btcpay_status_tool` output with `tollbooth_dpyc`, `python`, and `fastmcp` versions
- Uses `importlib.metadata.version()` for runtime truth (what's actually imported, not what's pinned)
- Graceful fallback to "unknown" if package metadata unavailable

## Test plan
- [x] All 187 tests pass
- [ ] Deploy and verify `btcpay_status` shows `versions` section with correct values

Task: `d192e1c6` — Surface Dependency Versions in btcpay_status Diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)