### PR TITLE
Vault flush durability: retry + reconciliation (v0.1.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.5"
+version = "0.1.6"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/tools/__init__.py
+++ b/src/tollbooth/tools/__init__.py
@@ -1,1 +1,5 @@
 """Tollbooth credit management tools."""
+
+from tollbooth.tools.credits import reconcile_pending_invoices
+
+__all__ = ["reconcile_pending_invoices"]


### PR DESCRIPTION
## Summary
- **Flush retry** in `LedgerCache._flush_entry()`: default 1 retry with 2s delay, so transient vault errors don't lose dirty entries on shutdown
- **`reconcile_pending_invoices()`**: startup recovery function that checks BTCPay for each pending invoice — auto-credits settled ones, removes expired/invalid ones
- **Version bump** to 0.1.6

## Test plan
- [ ] 4 new retry tests: transient success, retry exhaustion, zero-retry config, default config
- [ ] 5 new reconciliation tests: credit settled, remove expired, noop on empty, skip BTCPay errors, idempotent
- [ ] All 196 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)