### PR TITLE
Add Nostr keypair generation script and DPYC identity docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ Authority BTCPay                  BTCPayClient                      TOOL_COSTS m
 
 Dependency flows one way: `your-mcp-server --> tollbooth-dpyc`. Authority is a network peer, not a code dependency. Only runtime dependency: `httpx`.
 
+## DPYC Identity (Nostr npub)
+
+Every participant in the Tollbooth ecosystem — Authorities, Operators, and Users — is identified by a [Nostr](https://nostr.com/) keypair. The `npub` (public key) is your identity on the DPYC Honor Chain. The `nsec` (private key) stays with you — never shared, never sent to a service.
+
+Generate a keypair:
+
+```bash
+pip install nostr-sdk
+python scripts/generate_nostr_keypair.py
+```
+
+Then set the appropriate environment variable in your `.env`:
+
+| Role | Variable | Purpose |
+|------|----------|---------|
+| Authority | `DPYC_AUTHORITY_NPUB` | This Authority's identity on the Honor Chain |
+| Authority | `DPYC_UPSTREAM_AUTHORITY_NPUB` | The Authority above in the chain (empty for Prime) |
+| Operator | `DPYC_OPERATOR_NPUB` | This Operator's identity on the Honor Chain |
+| Operator | `DPYC_AUTHORITY_NPUB` | The Authority this Operator is registered with |
+
+Users provide their npub at session time via `activate_dpyc()` — no env var needed.
+
 ## Development
 
 ```bash

--- a/scripts/generate_nostr_keypair.py
+++ b/scripts/generate_nostr_keypair.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generate a Nostr keypair for DPYC identity.
+
+Outputs an npub (public key) and nsec (private key) in bech32 format.
+The npub is used as your identity in the DPYC Honor Chain:
+
+  - Operators set DPYC_OPERATOR_NPUB in their .env
+  - Authorities set DPYC_AUTHORITY_NPUB in their .env
+  - Users provide their npub at session time via activate_dpyc()
+
+Requires: pip install nostr-sdk
+"""
+
+from __future__ import annotations
+
+import sys
+
+try:
+    from nostr_sdk import Keys
+except ImportError:
+    print("Error: nostr-sdk not installed. Run: pip install nostr-sdk", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    keys = Keys.generate()
+
+    npub = keys.public_key().to_bech32()
+    nsec = keys.secret_key().to_bech32()
+    hex_pubkey = keys.public_key().to_hex()
+
+    print("=== Nostr Keypair (DPYC Identity) ===")
+    print()
+    print("npub (public key — share freely, set in .env):")
+    print(f"  {npub}")
+    print()
+    print("nsec (PRIVATE key — back up securely, never commit to git):")
+    print(f"  {nsec}")
+    print()
+    print(f"hex pubkey: {hex_pubkey}")
+    print()
+    print("--- Environment variable usage ---")
+    print()
+    print("For an Authority (.env):")
+    print(f"  DPYC_AUTHORITY_NPUB={npub}")
+    print()
+    print("For an Operator (.env):")
+    print(f"  DPYC_OPERATOR_NPUB={npub}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `scripts/generate_nostr_keypair.py` — generates npub/nsec for DPYC Honor Chain identity
- README: added "DPYC Identity" section with env var reference table for Authority, Operator, and User roles

## Test plan
- [ ] Run `python scripts/generate_nostr_keypair.py` and verify output format
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)