### PR TITLE
Fix certificate sub claim extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.6"
+version = "0.1.7"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/certificate.py
+++ b/src/tollbooth/certificate.py
@@ -124,7 +124,7 @@ def verify_certificate(token: str, public_key_pem: str) -> dict[str, Any]:
         raise CertificateError(f"Certificate replay detected — jti {jti} already used.")
 
     return {
-        "operator_id": claims.get("operator_id", ""),
+        "operator_id": claims.get("sub", ""),
         "amount_sats": claims.get("amount_sats", 0),
         "tax_paid_sats": claims.get("tax_paid_sats", 0),
         "net_sats": claims.get("net_sats", 0),

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -52,7 +52,7 @@ def _sign_certificate(
 ) -> str:
     """Sign a test certificate JWT."""
     claims = {
-        "operator_id": operator_id,
+        "sub": operator_id,
         "amount_sats": amount_sats,
         "tax_paid_sats": tax_paid_sats,
         "net_sats": net_sats,


### PR DESCRIPTION
## Summary
- Fix `verify_certificate` to read `sub` claim (not `operator_id`) from JWT — the Authority writes operator ID into the standard `sub` field
- Bump version to v0.1.7

## Test plan
- [x] `test_extracts_all_claims` updated to verify `operator_id` is correctly extracted
- [x] Full test suite passes (196 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)