### PR TITLE
Add dpyc_protocol verification (v0.1.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.7"
+version = "0.1.8"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,9 +3,9 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.8"
 
-from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint
+from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -30,4 +30,5 @@ __all__ = [
     "verify_certificate",
     "normalize_public_key",
     "key_fingerprint",
+    "UNDERSTOOD_PROTOCOLS",
 ]


### PR DESCRIPTION
## Summary
- Adds `UNDERSTOOD_PROTOCOLS` frozenset and protocol verification to `verify_certificate()`
- Rejects certificates missing `dpyc_protocol` or with unrecognized protocol identifiers
- Supports custom `understood_protocols` parameter for forward compatibility
- Bumps version to 0.1.8; exports `UNDERSTOOD_PROTOCOLS` from `__init__.py`

## Test plan
- [x] `test_missing_protocol_rejected` — certificate without claim raises CertificateError
- [x] `test_unknown_protocol_rejected` — `dpyp-99-future` raises CertificateError
- [x] `test_valid_protocol_accepted` — happy path returns `dpyc_protocol` in result
- [x] `test_custom_understood_protocols` — custom frozenset overrides default
- [x] All 23 tests pass

## Deploy order
Merge **tollbooth-authority** first → tag release. Then merge this → tag + wait for PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)