### PR TITLE
Fix test certificates for dpyc_protocol claim

### DIFF
--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -53,13 +53,14 @@ def _test_certificate(net_sats: int = 980, amount_sats: int = 1000) -> str:
     global _jti_counter
     _jti_counter += 1
     claims = {
-        "operator_id": "test-op",
+        "sub": "test-op",
         "amount_sats": amount_sats,
         "tax_paid_sats": amount_sats - net_sats,
         "net_sats": net_sats,
         "jti": f"test-jti-{_jti_counter}-{time.time_ns()}",
         "iat": int(time.time()),
         "exp": int(time.time()) + 600,
+        "dpyc_protocol": "dpyp-01-base-certificate",
     }
     return pyjwt.encode(claims, _TEST_PRIVATE_KEY, algorithm="EdDSA")
 


### PR DESCRIPTION
## Summary
- `_test_certificate` helper in `test_credit_tools.py` was missing `dpyc_protocol` and used `operator_id` instead of `sub`
- Caused 8 test failures after the protocol versioning merge (PR #14)

## Test plan
- [x] All 200 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)