### PR TITLE
Detect missing payout processor in btcpay_status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.9"
+version = "0.1.10"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/btcpay_client.py
+++ b/src/tollbooth/btcpay_client.py
@@ -107,7 +107,7 @@ class BTCPayClient:
         method: str,
         endpoint: str,
         json_data: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """Send a request and map errors to the BTCPay exception hierarchy."""
         try:
             response = await self._client.request(method, endpoint, json=json_data)
@@ -181,6 +181,12 @@ class BTCPayClient:
         }
         return await self._request(
             "POST", f"/stores/{self._store_id}/payouts", json_data=payload
+        )
+
+    async def get_payout_processors(self) -> list[dict[str, Any]]:
+        """GET /stores/{storeId}/payout-processors — list configured payout processors."""
+        return await self._request(
+            "GET", f"/stores/{self._store_id}/payout-processors"
         )
 
     # -- lifecycle ------------------------------------------------------------

--- a/tests/test_btcpay_client.py
+++ b/tests/test_btcpay_client.py
@@ -314,6 +314,51 @@ class TestCreatePayout:
 
 
 # ---------------------------------------------------------------------------
+# get_payout_processors
+# ---------------------------------------------------------------------------
+
+
+class TestGetPayoutProcessors:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "my-store")
+        processors = [
+            {"name": "AutomatedPayoutBlob", "friendlyName": "Automated Lightning Sender"},
+        ]
+        resp = httpx.Response(
+            status_code=200,
+            json=processors,
+            request=httpx.Request("GET", "https://example.com"),
+        )
+        client._client.request = AsyncMock(return_value=resp)
+        result = await client.get_payout_processors()
+        assert result == processors
+        client._client.request.assert_called_once_with(
+            "GET", "/stores/my-store/payout-processors", json=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_list(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        resp = httpx.Response(
+            status_code=200,
+            json=[],
+            request=httpx.Request("GET", "https://example.com"),
+        )
+        client._client.request = AsyncMock(return_value=resp)
+        result = await client.get_payout_processors()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        client = BTCPayClient("https://x.com", "k", "s")
+        client._client.request = AsyncMock(return_value=_mock_response(403))
+        with pytest.raises(BTCPayAuthError) as exc_info:
+            await client.get_payout_processors()
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
 # Context manager
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `get_payout_processors()` to `BTCPayClient` — queries BTCPay's `/stores/{storeId}/payout-processors` endpoint
- `btcpay_status_tool` now checks for a Lightning Payout Processor when royalties are enabled and warns if none is configured
- `_attempt_royalty_payout` adds a `payout_hint` when payout state is `AwaitingApproval` to surface the silent failure mode
- Adds `btcpay.store.canviewstoresettings` to required permissions when royalties are enabled
- Version bump to 0.1.10

## Test plan
- [x] 209 tests pass (`pytest -v`)
- [x] New `TestGetPayoutProcessors` class: success, empty list, auth error
- [x] New payout processor tests in `TestBTCPayStatusRoyalty`: processor present, missing (with warning), error, skipped when no royalty, viewstoresettings in required perms
- [x] New `test_payout_awaiting_approval_includes_hint` in `TestCheckPaymentWithRoyalty`
- [ ] Live test on FastMCP Cloud after merge + PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)