### PR TITLE
Add TheBrainVault as canonical VaultBackend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.10"
+version = "0.1.11"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
@@ -12,6 +12,7 @@ from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
+from tollbooth.vaults import TheBrainVault
 
 __all__ = [
     "CertificateError",
@@ -24,6 +25,7 @@ __all__ = [
     "BTCPayAuthError",
     "VaultBackend",
     "LedgerCache",
+    "TheBrainVault",
     "ToolTier",
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",

--- a/src/tollbooth/vaults/__init__.py
+++ b/src/tollbooth/vaults/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in VaultBackend implementations for tollbooth-dpyc."""
+
+from tollbooth.vaults.thebrain import TheBrainVault
+
+__all__ = ["TheBrainVault"]

--- a/src/tollbooth/vaults/thebrain.py
+++ b/src/tollbooth/vaults/thebrain.py
@@ -1,0 +1,257 @@
+"""TheBrainVault — VaultBackend implementation using TheBrain Cloud API.
+
+Self-contained: uses raw httpx, no thebrain-mcp dependency. Persists
+commerce ledgers via TheBrain's thought/note API in a daily-child pattern.
+
+Correct API endpoints (TheBrain Cloud API):
+- Base URL: https://api.bra.in
+- Read note: GET /notes/{brain_id}/{thought_id} -> JSON with ``markdown`` field
+- Write note: POST /notes/{brain_id}/{thought_id}/update -> JSON body ``{"markdown": "..."}``
+- Create thought: POST /thoughts/{brain_id} -> tolerate HTTP 500 with valid ``{"id": "..."}`` body
+- Get graph: GET /thoughts/{brain_id}/{thought_id}/graph -> JSON with ``children`` array
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.bra.in"
+
+
+class TheBrainVault:
+    """Commerce ledger persistence via TheBrain Cloud API.
+
+    Implements the tollbooth ``VaultBackend`` protocol:
+
+    - ``store_ledger(user_id, ledger_json) -> str``
+    - ``fetch_ledger(user_id) -> str | None``
+    - ``snapshot_ledger(user_id, ledger_json, timestamp) -> str | None``
+
+    Index pattern: home thought note stores JSON ``{user_id: thought_id}``.
+
+    Caching strategy:
+
+    - ``_index_cache``: Read once per process, invalidated on ledger parent creation.
+    - ``_daily_child_cache``: Maps ``"{user_id}/{YYYY-MM-DD}"`` to thought ID.
+      On cache hit, ``store_ledger`` is a single ``_set_note`` call (1 API call
+      instead of 3-4). On stale cache (set_note fails), evicts and falls through.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        brain_id: str,
+        home_thought_id: str,
+    ) -> None:
+        self._api_key = api_key
+        self._brain_id = brain_id
+        self._home_thought_id = home_thought_id
+        self._client = httpx.AsyncClient(
+            base_url=_BASE_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30.0,
+        )
+        self._index_cache: dict[str, str] | None = None
+        self._daily_child_cache: dict[str, str] = {}
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # -- TheBrain API helpers ------------------------------------------------
+
+    async def _get_note(self, thought_id: str) -> str | None:
+        """Fetch a thought's note as markdown. Returns None on failure."""
+        try:
+            resp = await self._client.get(
+                f"/notes/{self._brain_id}/{thought_id}"
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("markdown") or None
+        except httpx.HTTPError:
+            logger.warning("Failed to read note for thought %s", thought_id)
+        return None
+
+    async def _set_note(self, thought_id: str, markdown: str) -> None:
+        """Create or update a thought's note."""
+        resp = await self._client.post(
+            f"/notes/{self._brain_id}/{thought_id}/update",
+            json={"markdown": markdown},
+        )
+        resp.raise_for_status()
+
+    async def _create_thought(
+        self, name: str, parent_id: str
+    ) -> dict[str, Any]:
+        """Create a child thought. Returns ``{"id": "..."}``.
+
+        TheBrain API may return HTTP 500 on successful creates, so we
+        check for an ``id`` field in the response body before raising.
+        """
+        resp = await self._client.post(
+            f"/thoughts/{self._brain_id}",
+            json={
+                "name": name,
+                "kind": 1,
+                "acType": 1,  # Private
+                "sourceThoughtId": parent_id,
+                "relation": 1,  # Child
+            },
+        )
+        try:
+            data = resp.json()
+        except Exception:
+            resp.raise_for_status()
+            return {}
+        if "id" in data:
+            return data
+        resp.raise_for_status()
+        return data
+
+    async def _get_children(self, thought_id: str) -> list[dict[str, Any]]:
+        """Get a thought's children via the graph endpoint."""
+        try:
+            resp = await self._client.get(
+                f"/thoughts/{self._brain_id}/{thought_id}/graph"
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("children", [])
+        except httpx.HTTPError:
+            logger.warning("Failed to read graph for thought %s", thought_id)
+        return []
+
+    # -- Index management ----------------------------------------------------
+
+    async def _read_index(self) -> dict[str, str]:
+        """Read the user_id -> thought_id index from the home thought."""
+        if self._index_cache is not None:
+            return self._index_cache
+        text = await self._get_note(self._home_thought_id)
+        if text:
+            try:
+                self._index_cache = json.loads(text)
+                return self._index_cache
+            except json.JSONDecodeError:
+                logger.warning("Vault index is corrupted (invalid JSON).")
+        return {}
+
+    async def _write_index(self, index: dict[str, str]) -> None:
+        """Write the user_id -> thought_id index to the home thought."""
+        await self._set_note(self._home_thought_id, json.dumps(index))
+        self._index_cache = dict(index)
+
+    # -- VaultBackend protocol -----------------------------------------------
+
+    async def store_ledger(self, user_id: str, ledger_json: str) -> str:
+        """Store ledger JSON in a daily child thought under the ledger parent.
+
+        Creates one child per day (named ``YYYY-MM-DD`` in UTC). Subsequent
+        flushes on the same day update the existing child's note. Previous
+        days are preserved as immutable history.
+
+        Uses index key ``"{user_id}/ledger"`` to track the ledger parent thought ID.
+        Returns the daily child thought ID.
+        """
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        cache_key = f"{user_id}/{today}"
+
+        # Fast path: cached daily child ID -> single set_note call
+        cached_id = self._daily_child_cache.get(cache_key)
+        if cached_id:
+            try:
+                await self._set_note(cached_id, ledger_json)
+                return cached_id
+            except httpx.HTTPError:
+                logger.warning(
+                    "Stale daily child cache for %s, falling through to full lookup.",
+                    cache_key,
+                )
+                del self._daily_child_cache[cache_key]
+
+        # Slow path: full index read + graph traversal
+        index = await self._read_index()
+        ledger_key = f"{user_id}/ledger"
+        ledger_parent_id = index.get(ledger_key)
+
+        # Create ledger parent if needed
+        if not ledger_parent_id:
+            parent_id = index.get(user_id, self._home_thought_id)
+            result = await self._create_thought(f"{user_id}/ledger", parent_id)
+            ledger_parent_id = result["id"]
+            index[ledger_key] = ledger_parent_id
+            self._index_cache = None  # Invalidate -- new key added
+            await self._write_index(index)
+
+        # Find or create today's daily child
+        children = await self._get_children(ledger_parent_id)
+        daily_child_id: str | None = None
+        for child in children:
+            if child.get("name") == today:
+                daily_child_id = child.get("id")
+                break
+
+        if daily_child_id:
+            await self._set_note(daily_child_id, ledger_json)
+        else:
+            result = await self._create_thought(today, ledger_parent_id)
+            daily_child_id = result["id"]
+            await self._set_note(daily_child_id, ledger_json)
+
+        # Populate cache for subsequent flushes
+        self._daily_child_cache[cache_key] = daily_child_id
+        return daily_child_id
+
+    async def fetch_ledger(self, user_id: str) -> str | None:
+        """Fetch the most recent ledger JSON for a user.
+
+        Reads the most recent daily child (sorted by ``YYYY-MM-DD`` name
+        descending). Falls back to the parent thought's note for pre-migration
+        ledgers that haven't been flushed since the upgrade.
+        Returns None if no ledger exists.
+        """
+        index = await self._read_index()
+        ledger_key = f"{user_id}/ledger"
+        ledger_parent_id = index.get(ledger_key)
+        if not ledger_parent_id:
+            return None
+
+        children = await self._get_children(ledger_parent_id)
+        if children:
+            # Sort by name descending -- ISO dates sort lexicographically
+            children_sorted = sorted(
+                children, key=lambda t: t.get("name", ""), reverse=True
+            )
+            most_recent = children_sorted[0]
+            note = await self._get_note(most_recent["id"])
+            if note:
+                return note
+
+        # Fallback: read parent note (pre-migration state)
+        return await self._get_note(ledger_parent_id)
+
+    async def snapshot_ledger(
+        self, user_id: str, ledger_json: str, timestamp: str
+    ) -> str | None:
+        """Create a timestamped snapshot under the ledger parent.
+
+        Returns the snapshot thought ID, or None if no ledger thought exists.
+        """
+        index = await self._read_index()
+        ledger_key = f"{user_id}/ledger"
+        ledger_parent_id = index.get(ledger_key)
+        if not ledger_parent_id:
+            return None
+
+        result = await self._create_thought(timestamp, ledger_parent_id)
+        snapshot_id = result["id"]
+        await self._set_note(snapshot_id, ledger_json)
+        return snapshot_id

--- a/tests/test_thebrain_vault.py
+++ b/tests/test_thebrain_vault.py
@@ -1,0 +1,415 @@
+"""Tests for TheBrainVault — VaultBackend via TheBrain Cloud API."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from tollbooth.vaults.thebrain import TheBrainVault
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BRAIN_ID = "test-brain-id"
+HOME_ID = "home-thought-id"
+API_KEY = "test-api-key"
+
+
+def _vault() -> TheBrainVault:
+    return TheBrainVault(api_key=API_KEY, brain_id=BRAIN_ID, home_thought_id=HOME_ID)
+
+
+def _response(status_code: int = 200, json_data: dict | list | None = None) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    resp = httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("GET", "https://api.bra.in/test"),
+    )
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _get_note
+# ---------------------------------------------------------------------------
+
+
+class TestGetNote:
+    @pytest.mark.asyncio
+    async def test_returns_markdown(self) -> None:
+        vault = _vault()
+        vault._client.get = AsyncMock(return_value=_response(200, {"markdown": "hello"}))
+        result = await vault._get_note("thought-1")
+        assert result == "hello"
+        vault._client.get.assert_called_once_with(f"/notes/{BRAIN_ID}/thought-1")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_markdown(self) -> None:
+        vault = _vault()
+        vault._client.get = AsyncMock(return_value=_response(200, {"markdown": ""}))
+        result = await vault._get_note("thought-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_404(self) -> None:
+        vault = _vault()
+        vault._client.get = AsyncMock(return_value=_response(404, {}))
+        result = await vault._get_note("thought-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_http_error(self) -> None:
+        vault = _vault()
+        vault._client.get = AsyncMock(side_effect=httpx.ConnectError("timeout"))
+        result = await vault._get_note("thought-1")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _set_note
+# ---------------------------------------------------------------------------
+
+
+class TestSetNote:
+    @pytest.mark.asyncio
+    async def test_posts_to_update_endpoint(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(return_value=_response(200, {}))
+        await vault._set_note("thought-1", "new content")
+        vault._client.post.assert_called_once_with(
+            f"/notes/{BRAIN_ID}/thought-1/update",
+            json={"markdown": "new content"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_on_failure(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(return_value=_response(500, {}))
+        with pytest.raises(httpx.HTTPStatusError):
+            await vault._set_note("thought-1", "content")
+
+
+# ---------------------------------------------------------------------------
+# _create_thought — 500-tolerant behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCreateThought:
+    @pytest.mark.asyncio
+    async def test_returns_id_on_200(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, {"id": "new-id"})
+        )
+        result = await vault._create_thought("test", "parent-1")
+        assert result == {"id": "new-id"}
+
+    @pytest.mark.asyncio
+    async def test_returns_id_on_500_with_body(self) -> None:
+        """TheBrain sometimes returns HTTP 500 but with a valid ID body."""
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(500, {"id": "created-id"})
+        )
+        result = await vault._create_thought("test", "parent-1")
+        assert result == {"id": "created-id"}
+
+    @pytest.mark.asyncio
+    async def test_raises_on_500_without_id(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(500, {"error": "internal"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await vault._create_thought("test", "parent-1")
+
+    @pytest.mark.asyncio
+    async def test_sends_correct_payload(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, {"id": "new-id"})
+        )
+        await vault._create_thought("my thought", "parent-1")
+        vault._client.post.assert_called_once_with(
+            f"/thoughts/{BRAIN_ID}",
+            json={
+                "name": "my thought",
+                "kind": 1,
+                "acType": 1,
+                "sourceThoughtId": "parent-1",
+                "relation": 1,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# _get_children
+# ---------------------------------------------------------------------------
+
+
+class TestGetChildren:
+    @pytest.mark.asyncio
+    async def test_returns_children_list(self) -> None:
+        vault = _vault()
+        children = [{"id": "c1", "name": "2026-02-20"}, {"id": "c2", "name": "2026-02-21"}]
+        vault._client.get = AsyncMock(
+            return_value=_response(200, {"children": children})
+        )
+        result = await vault._get_children("parent-1")
+        assert len(result) == 2
+        assert result[0]["name"] == "2026-02-20"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_failure(self) -> None:
+        vault = _vault()
+        vault._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+        result = await vault._get_children("parent-1")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Index management
+# ---------------------------------------------------------------------------
+
+
+class TestIndex:
+    @pytest.mark.asyncio
+    async def test_read_index_caches_result(self) -> None:
+        vault = _vault()
+        index = {"user1/ledger": "ledger-id"}
+        vault._get_note = AsyncMock(return_value=json.dumps(index))
+        result1 = await vault._read_index()
+        result2 = await vault._read_index()
+        assert result1 == index
+        # Second call should use cache, not call _get_note again
+        vault._get_note.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_read_index_returns_empty_on_no_note(self) -> None:
+        vault = _vault()
+        vault._get_note = AsyncMock(return_value=None)
+        result = await vault._read_index()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_read_index_returns_empty_on_bad_json(self) -> None:
+        vault = _vault()
+        vault._get_note = AsyncMock(return_value="not valid json")
+        result = await vault._read_index()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_write_index_updates_cache(self) -> None:
+        vault = _vault()
+        vault._set_note = AsyncMock()
+        index = {"user1": "thought-1"}
+        await vault._write_index(index)
+        assert vault._index_cache == index
+        vault._set_note.assert_called_once_with(HOME_ID, json.dumps(index))
+
+
+# ---------------------------------------------------------------------------
+# store_ledger
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLedger:
+    @pytest.mark.asyncio
+    async def test_creates_ledger_parent_and_daily_child(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={})
+        vault._write_index = AsyncMock()
+        vault._create_thought = AsyncMock(
+            side_effect=[
+                {"id": "ledger-parent-id"},   # ledger parent
+                {"id": "daily-child-id"},      # daily child
+            ]
+        )
+        vault._get_children = AsyncMock(return_value=[])
+        vault._set_note = AsyncMock()
+
+        result = await vault.store_ledger("user1", '{"balance": 100}')
+        assert result == "daily-child-id"
+
+        # Should have created ledger parent under home thought
+        vault._create_thought.assert_any_call("user1/ledger", HOME_ID)
+        # Should have written index
+        vault._write_index.assert_called_once()
+        # Should have set note on daily child
+        vault._set_note.assert_called_once_with("daily-child-id", '{"balance": 100}')
+
+    @pytest.mark.asyncio
+    async def test_reuses_existing_daily_child(self) -> None:
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent-id"})
+        vault._get_children = AsyncMock(
+            return_value=[{"id": "existing-child", "name": today}]
+        )
+        vault._set_note = AsyncMock()
+
+        result = await vault.store_ledger("user1", '{"balance": 200}')
+        assert result == "existing-child"
+        vault._set_note.assert_called_once_with("existing-child", '{"balance": 200}')
+
+    @pytest.mark.asyncio
+    async def test_fast_path_uses_daily_child_cache(self) -> None:
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._daily_child_cache[f"user1/{today}"] = "cached-child-id"
+        vault._set_note = AsyncMock()
+
+        result = await vault.store_ledger("user1", '{"balance": 300}')
+        assert result == "cached-child-id"
+        vault._set_note.assert_called_once_with("cached-child-id", '{"balance": 300}')
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_falls_through(self) -> None:
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._daily_child_cache[f"user1/{today}"] = "stale-id"
+
+        # First _set_note call (cached path) fails, second (fresh path) succeeds
+        call_count = 0
+        async def _set_note_side_effect(thought_id: str, markdown: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.HTTPStatusError(
+                    "gone", request=httpx.Request("POST", "https://api.bra.in"), response=_response(404)
+                )
+
+        vault._set_note = AsyncMock(side_effect=_set_note_side_effect)
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(
+            return_value=[{"id": "fresh-child", "name": today}]
+        )
+
+        result = await vault.store_ledger("user1", '{"balance": 400}')
+        assert result == "fresh-child"
+        # Cache should be updated
+        assert vault._daily_child_cache[f"user1/{today}"] == "fresh-child"
+
+
+# ---------------------------------------------------------------------------
+# fetch_ledger
+# ---------------------------------------------------------------------------
+
+
+class TestFetchLedger:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_ledger(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={})
+        result = await vault.fetch_ledger("user1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_most_recent_daily_child(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(return_value=[
+            {"id": "c1", "name": "2026-02-19"},
+            {"id": "c2", "name": "2026-02-21"},
+            {"id": "c3", "name": "2026-02-20"},
+        ])
+        vault._get_note = AsyncMock(return_value='{"balance": 999}')
+
+        result = await vault.fetch_ledger("user1")
+        assert result == '{"balance": 999}'
+        # Should read note from most recent (2026-02-21)
+        vault._get_note.assert_called_once_with("c2")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_parent_note(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(return_value=[])
+        vault._get_note = AsyncMock(return_value='{"balance": 42}')
+
+        result = await vault.fetch_ledger("user1")
+        assert result == '{"balance": 42}'
+        vault._get_note.assert_called_once_with("ledger-parent")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_child_note_empty(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(
+            return_value=[{"id": "c1", "name": "2026-02-21"}]
+        )
+
+        # First call (child note) returns None, second (parent) returns data
+        call_count = 0
+        async def _get_note_side_effect(thought_id: str) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            return '{"balance": 42}'
+
+        vault._get_note = AsyncMock(side_effect=_get_note_side_effect)
+
+        result = await vault.fetch_ledger("user1")
+        assert result == '{"balance": 42}'
+
+
+# ---------------------------------------------------------------------------
+# snapshot_ledger
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotLedger:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_ledger(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={})
+        result = await vault.snapshot_ledger("user1", '{"balance": 100}', "2026-02-21T12:00:00Z")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_creates_snapshot_child(self) -> None:
+        vault = _vault()
+        vault._read_index = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._create_thought = AsyncMock(return_value={"id": "snapshot-id"})
+        vault._set_note = AsyncMock()
+
+        result = await vault.snapshot_ledger("user1", '{"balance": 100}', "2026-02-21T12:00:00Z")
+        assert result == "snapshot-id"
+        vault._create_thought.assert_called_once_with("2026-02-21T12:00:00Z", "ledger-parent")
+        vault._set_note.assert_called_once_with("snapshot-id", '{"balance": 100}')
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_closes_http_client(self) -> None:
+        vault = _vault()
+        vault._client.aclose = AsyncMock()
+        await vault.close()
+        vault._client.aclose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# VaultBackend protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_implements_vault_backend(self) -> None:
+        from tollbooth.vault_backend import VaultBackend
+        vault = _vault()
+        assert isinstance(vault, VaultBackend)


### PR DESCRIPTION
## Summary
- Adds `tollbooth.vaults.thebrain.TheBrainVault` — a self-contained VaultBackend using raw httpx (no thebrain-mcp dependency)
- Consolidates duplicate vault logic from thebrain-mcp (`PersonalBrainVault`) and tollbooth-authority (`TheBrainVault`) into one canonical implementation
- Eliminates the DRY violation that caused 3 bugs (wrong API URL, wrong note endpoints, 500-on-success crash) in the Authority's vault
- 28 unit tests covering all API helpers, 500-tolerant creates, index caching, daily-child flows, and `VaultBackend` protocol conformance
- Version bump to 0.1.11

## Test plan
- [x] All 237 tests pass (209 existing + 28 new)
- [ ] After merge + tag, wait for PyPI publish
- [ ] Then update tollbooth-authority and thebrain-mcp to import from `tollbooth.vaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)