### PR TITLE
Replace JSON-note vault index with link-based member discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.11"
+version = "0.1.12"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/vaults/thebrain.py
+++ b/src/tollbooth/vaults/thebrain.py
@@ -2,13 +2,18 @@
 
 Self-contained: uses raw httpx, no thebrain-mcp dependency. Persists
 commerce ledgers via TheBrain's thought/note API in a daily-child pattern.
+Also provides generic member discovery and storage for credential vaults.
+
+Member discovery uses labeled child links (``name == "hasMember"``) on
+the vault home thought — no JSON note index.
 
 Correct API endpoints (TheBrain Cloud API):
 - Base URL: https://api.bra.in
 - Read note: GET /notes/{brain_id}/{thought_id} -> JSON with ``markdown`` field
 - Write note: POST /notes/{brain_id}/{thought_id}/update -> JSON body ``{"markdown": "..."}``
 - Create thought: POST /thoughts/{brain_id} -> tolerate HTTP 500 with valid ``{"id": "..."}`` body
-- Get graph: GET /thoughts/{brain_id}/{thought_id}/graph -> JSON with ``children`` array
+- Get graph: GET /thoughts/{brain_id}/{thought_id}/graph -> JSON with ``children``, ``links`` arrays
+- Update link: PATCH /links/{brain_id}/{link_id} -> JSON Patch body
 """
 
 from __future__ import annotations
@@ -26,7 +31,7 @@ _BASE_URL = "https://api.bra.in"
 
 
 class TheBrainVault:
-    """Commerce ledger persistence via TheBrain Cloud API.
+    """Vault persistence via TheBrain Cloud API using link-based member discovery.
 
     Implements the tollbooth ``VaultBackend`` protocol:
 
@@ -34,11 +39,18 @@ class TheBrainVault:
     - ``fetch_ledger(user_id) -> str | None``
     - ``snapshot_ledger(user_id, ledger_json, timestamp) -> str | None``
 
-    Index pattern: home thought note stores JSON ``{user_id: thought_id}``.
+    Also provides generic member operations for credential storage:
+
+    - ``store_member_note(user_id, content) -> str``
+    - ``fetch_member_note(user_id) -> str | None``
+
+    Member discovery: child links from the home thought labeled
+    ``name == "hasMember"`` identify vault members. No JSON note index.
 
     Caching strategy:
 
-    - ``_index_cache``: Read once per process, invalidated on ledger parent creation.
+    - ``_index_cache``: Members discovered via ``_discover_members()``,
+      invalidated when a new member is registered.
     - ``_daily_child_cache``: Maps ``"{user_id}/{YYYY-MM-DD}"`` to thought ID.
       On cache hit, ``store_ledger`` is a single ``_set_note`` call (1 API call
       instead of 3-4). On stale cache (set_note fails), evicts and falls through.
@@ -129,25 +141,154 @@ class TheBrainVault:
             logger.warning("Failed to read graph for thought %s", thought_id)
         return []
 
-    # -- Index management ----------------------------------------------------
+    async def _get_graph(self, thought_id: str) -> dict[str, Any]:
+        """GET /thoughts/{brainId}/{thoughtId}/graph -> full graph dict.
 
-    async def _read_index(self) -> dict[str, str]:
-        """Read the user_id -> thought_id index from the home thought."""
-        if self._index_cache is not None:
-            return self._index_cache
-        text = await self._get_note(self._home_thought_id)
-        if text:
-            try:
-                self._index_cache = json.loads(text)
-                return self._index_cache
-            except json.JSONDecodeError:
-                logger.warning("Vault index is corrupted (invalid JSON).")
+        Returns the raw graph response including ``children``, ``links``,
+        ``parents``, ``jumps``, etc. Returns empty dict on failure.
+        """
+        try:
+            resp = await self._client.get(
+                f"/thoughts/{self._brain_id}/{thought_id}/graph"
+            )
+            if resp.status_code == 200:
+                return resp.json()
+        except httpx.HTTPError:
+            logger.warning("Failed to read graph for thought %s", thought_id)
         return {}
 
-    async def _write_index(self, index: dict[str, str]) -> None:
-        """Write the user_id -> thought_id index to the home thought."""
-        await self._set_note(self._home_thought_id, json.dumps(index))
-        self._index_cache = dict(index)
+    async def _update_link(self, link_id: str, updates: dict[str, Any]) -> None:
+        """PATCH /links/{brainId}/{linkId} with JSON Patch format.
+
+        ``updates`` is a dict of field -> value, e.g. ``{"name": "hasMember"}``.
+        Converted to JSON Patch format internally.
+        """
+        patch = [
+            {"op": "replace", "path": f"/{field}", "value": value}
+            for field, value in updates.items()
+        ]
+        resp = await self._client.patch(
+            f"/links/{self._brain_id}/{link_id}",
+            json=patch,
+            headers={"Content-Type": "application/json-patch+json"},
+        )
+        resp.raise_for_status()
+
+    # -- Link-based member discovery -----------------------------------------
+
+    async def _discover_members(self) -> dict[str, str]:
+        """Discover vault members via hasMember-labeled child links.
+
+        Scans the home thought's graph for child links (relation == 1) with
+        ``name == "hasMember"``. Returns ``{member_name: thought_id}``.
+
+        Results are cached in ``_index_cache``; call ``_invalidate_index()``
+        after registering new members.
+        """
+        if self._index_cache is not None:
+            return self._index_cache
+
+        graph = await self._get_graph(self._home_thought_id)
+        if not graph:
+            return {}
+
+        children = graph.get("children", [])
+        links = graph.get("links", [])
+
+        # Build child lookup: {child_id: child_name}
+        child_map = {c["id"]: c.get("name", "") for c in children}
+
+        # Filter links: relation == 1 (child), name == "hasMember",
+        # one endpoint is home_thought_id
+        members: dict[str, str] = {}
+        home = self._home_thought_id
+        for link in links:
+            if link.get("relation") != 1:
+                continue
+            if link.get("name") != "hasMember":
+                continue
+            a = link.get("thoughtIdA", "")
+            b = link.get("thoughtIdB", "")
+            if a == home:
+                child_id = b
+            elif b == home:
+                child_id = a
+            else:
+                continue
+            child_name = child_map.get(child_id)
+            if child_name is not None:
+                members[child_name] = child_id
+
+        self._index_cache = members
+        return members
+
+    async def _register_member(
+        self, thought_id: str, graph: dict[str, Any] | None = None,
+    ) -> None:
+        """Label the child link from home -> thought_id as 'hasMember'.
+
+        Scans the graph for the child link connecting the home thought to
+        the given thought_id, then PATCHes the link name.
+        """
+        if graph is None:
+            graph = await self._get_graph(self._home_thought_id)
+
+        links = graph.get("links", [])
+        home = self._home_thought_id
+        for link in links:
+            if link.get("relation") != 1:
+                continue
+            a = link.get("thoughtIdA", "")
+            b = link.get("thoughtIdB", "")
+            if (a == home and b == thought_id) or (b == home and a == thought_id):
+                await self._update_link(link["id"], {"name": "hasMember"})
+                self._index_cache = None  # Invalidate cache
+                return
+
+        logger.warning(
+            "No child link found from %s to %s — cannot register member.",
+            home, thought_id,
+        )
+
+    # -- Generic member operations -------------------------------------------
+
+    async def store_member_note(self, user_id: str, content: str) -> str:
+        """Find or create a member thought and write content to its note.
+
+        If a member thought already exists (discovered via hasMember links),
+        updates its note. Otherwise creates a new child thought under the
+        home thought and labels the link as hasMember.
+
+        Returns the member thought ID.
+        """
+        members = await self._discover_members()
+        thought_id = members.get(user_id)
+
+        if thought_id:
+            await self._set_note(thought_id, content)
+            return thought_id
+
+        # Create new member thought
+        result = await self._create_thought(user_id, self._home_thought_id)
+        thought_id = result["id"]
+        await self._set_note(thought_id, content)
+
+        # Label the new child link as hasMember
+        graph = await self._get_graph(self._home_thought_id)
+        await self._register_member(thought_id, graph)
+
+        return thought_id
+
+    async def fetch_member_note(self, user_id: str) -> str | None:
+        """Find a member by user_id and return its note content.
+
+        Returns None if the member is not found.
+        """
+        members = await self._discover_members()
+        thought_id = members.get(user_id)
+        if not thought_id:
+            return None
+        return await self._get_note(thought_id)
 
     # -- VaultBackend protocol -----------------------------------------------
 
@@ -158,7 +299,8 @@ class TheBrainVault:
         flushes on the same day update the existing child's note. Previous
         days are preserved as immutable history.
 
-        Uses index key ``"{user_id}/ledger"`` to track the ledger parent thought ID.
+        The ledger parent is discovered via hasMember links using the key
+        ``"{user_id}/ledger"``.
         Returns the daily child thought ID.
         """
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -177,19 +319,18 @@ class TheBrainVault:
                 )
                 del self._daily_child_cache[cache_key]
 
-        # Slow path: full index read + graph traversal
-        index = await self._read_index()
+        # Slow path: discover members via links + graph traversal
+        members = await self._discover_members()
         ledger_key = f"{user_id}/ledger"
-        ledger_parent_id = index.get(ledger_key)
+        ledger_parent_id = members.get(ledger_key)
 
         # Create ledger parent if needed
         if not ledger_parent_id:
-            parent_id = index.get(user_id, self._home_thought_id)
-            result = await self._create_thought(f"{user_id}/ledger", parent_id)
+            result = await self._create_thought(ledger_key, self._home_thought_id)
             ledger_parent_id = result["id"]
-            index[ledger_key] = ledger_parent_id
-            self._index_cache = None  # Invalidate -- new key added
-            await self._write_index(index)
+            # Label the new child link as hasMember
+            graph = await self._get_graph(self._home_thought_id)
+            await self._register_member(ledger_parent_id, graph)
 
         # Find or create today's daily child
         children = await self._get_children(ledger_parent_id)
@@ -218,9 +359,9 @@ class TheBrainVault:
         ledgers that haven't been flushed since the upgrade.
         Returns None if no ledger exists.
         """
-        index = await self._read_index()
+        members = await self._discover_members()
         ledger_key = f"{user_id}/ledger"
-        ledger_parent_id = index.get(ledger_key)
+        ledger_parent_id = members.get(ledger_key)
         if not ledger_parent_id:
             return None
 
@@ -245,9 +386,9 @@ class TheBrainVault:
 
         Returns the snapshot thought ID, or None if no ledger thought exists.
         """
-        index = await self._read_index()
+        members = await self._discover_members()
         ledger_key = f"{user_id}/ledger"
-        ledger_parent_id = index.get(ledger_key)
+        ledger_parent_id = members.get(ledger_key)
         if not ledger_parent_id:
             return None
 


### PR DESCRIPTION
## Summary
- TheBrainVault now discovers members via `hasMember`-labeled child links instead of a JSON index in the home thought's note
- Eliminates the index clobber bug when CredentialVault and TheBrainVault share a home thought
- New generic member operations (`store_member_note`, `fetch_member_note`) enable CredentialVault to delegate storage

## Changes
- **`src/tollbooth/vaults/thebrain.py`**: Added `_get_graph`, `_update_link`, `_discover_members`, `_register_member`, `store_member_note`, `fetch_member_note`; deleted `_read_index`, `_write_index`; refactored `store_ledger`/`fetch_ledger`/`snapshot_ledger` to use `_discover_members`
- **`tests/test_thebrain_vault.py`**: Added 18 new tests for link-based methods; updated ledger tests to use `_discover_members`; total 44 tests passing
- Bumped version to 0.1.12

## Test plan
- [x] `venv/bin/pytest -v` — all 253 tests pass
- [ ] Tag release and publish to PyPI after merge
- [ ] Live test: `activate_session` loads credentials via link discovery
- [ ] Live test: `check_balance` loads ledger via link discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)