### PR TITLE
Fix Azure affinity causing stale vault member discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.12"
+version = "0.1.13"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig


### PR DESCRIPTION
## Summary
- TheBrain Cloud API runs on Azure App Service with ARRAffinity session pinning
- Long-lived httpx connections get pinned to a server instance whose link-name cache may be stale
- The graph endpoint (and individual link GETs) on stale instances omit the `name` field
- `_discover_members()` found zero hasMember links, causing `activate_session` to fail with "No credentials found"

## Fix
- When graph response contains unnamed child links, use a temporary httpx client with `Connection: close` to fetch each link individually
- This forces a fresh TCP connection to a potentially different, up-to-date Azure instance
- Added `_get_link()` helper method for individual link fetches
- Added 6 new tests covering the fallback behavior

## Test plan
- [x] All 258 tollbooth-dpyc tests pass
- [x] All 611 thebrain-mcp tests pass (with local editable install)
- [x] All 63 tollbooth-authority tests pass
- [x] Live validation: `_discover_members()` returns correct credential member via fresh-connection fallback
- [ ] Production validation: `activate_session("Open Sesame")` succeeds after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)