### PR TITLE
Fix vault discovery: use children array instead of link labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.13"
+version = "0.1.14"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig


### PR DESCRIPTION
## Summary
- **Root cause**: TheBrain Cloud's Azure App Service caching makes link metadata unreliable — `_discover_members()` filtered by `hasMember`-labeled links, but the graph endpoint returned `name=None` for hours after labels were set
- **Fix**: Rewrite `_discover_members()` to enumerate ALL children by name instead of filtering by link labels. Children data in graph responses is always reliable.
- **Vault home hygiene**: Only member thoughts should be direct children. Non-member children should be linked as jumps/siblings.
- Bumps version to 0.1.14

## Test plan
- [x] All 256 tollbooth-dpyc tests pass
- [x] All 611 thebrain-mcp tests pass  
- [x] All 63 tollbooth-authority tests pass
- [ ] After merge + PyPI publish: update downstream pins, deploy, verify `activate_session("Open Sesame")` succeeds in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)