### PR TITLE
Add tranche-based credit expiration with FIFO consumption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.15"
+version = "0.1.16"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,11 +3,11 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
-from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord
+from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
 from tollbooth.ledger_cache import LedgerCache
@@ -20,6 +20,7 @@ __all__ = [
     "UserLedger",
     "ToolUsage",
     "InvoiceRecord",
+    "Tranche",
     "BTCPayClient",
     "BTCPayError",
     "BTCPayAuthError",

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -19,3 +19,4 @@ class TollboothConfig:
     tollbooth_royalty_percent: float = 0.02
     tollbooth_royalty_min_sats: int = 10
     authority_public_key: str | None = None
+    credit_ttl_seconds: int | None = 604800  # 7 days default, None = never

--- a/src/tollbooth/ledger.py
+++ b/src/tollbooth/ledger.py
@@ -3,6 +3,12 @@
 Pure data model — no I/O. All api_sats values are integer API credits
 (not real Bitcoin satoshis). Real BTC amounts use ``amount_sats`` and
 only appear in invoice/BTCPay contexts.
+
+Credits are stored as ordered tranches. Each tranche has an optional
+TTL (time-to-live). Debits consume FIFO from the oldest non-expired
+tranche. Expired tranches are collected lazily — their remaining
+balance moves to ``total_expired_api_sats`` during debits and
+serialization.
 """
 
 from __future__ import annotations
@@ -10,12 +16,12 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 
 
 # ---------------------------------------------------------------------------
@@ -87,28 +93,93 @@ class InvoiceRecord:
 
 
 # ---------------------------------------------------------------------------
+# Tranche
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Tranche:
+    """A discrete credit allocation with optional expiration.
+
+    Tranches are consumed FIFO — oldest first. Once remaining_sats
+    reaches 0, the tranche is inert. Expired tranches have their
+    remaining balance swept into total_expired_api_sats during debits.
+    """
+
+    granted_at: str  # ISO datetime
+    original_sats: int
+    remaining_sats: int
+    invoice_id: str = ""
+    expires_at: str | None = None  # ISO datetime, None = never expires
+
+    def is_expired_at(self, now: datetime) -> bool:
+        """Check if this tranche is expired at the given time."""
+        if self.expires_at is None:
+            return False
+        try:
+            exp = datetime.fromisoformat(self.expires_at)
+            return now >= exp
+        except (ValueError, TypeError):
+            return False  # Malformed → treat as never-expiring
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "granted_at": self.granted_at,
+            "original_sats": self.original_sats,
+            "remaining_sats": self.remaining_sats,
+            "invoice_id": self.invoice_id,
+        }
+        if self.expires_at is not None:
+            d["expires_at"] = self.expires_at
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Tranche:
+        return cls(
+            granted_at=str(data.get("granted_at", "")),
+            original_sats=int(data.get("original_sats", 0)),
+            remaining_sats=int(data.get("remaining_sats", 0)),
+            invoice_id=str(data.get("invoice_id", "")),
+            expires_at=data.get("expires_at"),
+        )
+
+
+# ---------------------------------------------------------------------------
 # UserLedger
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class UserLedger:
-    """Per-user credit balance and usage tracking.
+    """Per-user credit balance with tranche-based expiration.
 
-    All balance/cost values are in api_sats (integer API credits).
-    ``debit()`` returns False on insufficient balance (not exceptional).
+    Credits live in ordered tranches. ``balance_api_sats`` is a computed
+    property that sums non-expired tranche balances. Debits draw FIFO
+    from the oldest non-expired tranche. Rollbacks create compensating
+    tranches (never-expiring) rather than modifying existing ones.
+
     ``from_json()`` returns a fresh ledger on corrupt data (never blocks a user).
     """
 
-    balance_api_sats: int = 0
+    tranches: list[Tranche] = field(default_factory=list)
     total_deposited_api_sats: int = 0
     total_consumed_api_sats: int = 0
+    total_expired_api_sats: int = 0
     pending_invoices: list[str] = field(default_factory=list)
     credited_invoices: list[str] = field(default_factory=list)
     last_deposit_at: str | None = None
     daily_log: dict[str, dict[str, ToolUsage]] = field(default_factory=dict)
     history: dict[str, ToolUsage] = field(default_factory=dict)
     invoices: dict[str, InvoiceRecord] = field(default_factory=dict)
+
+    @property
+    def balance_api_sats(self) -> int:
+        """Sum of remaining_sats in non-expired tranches (read-only, no mutation)."""
+        now = datetime.now(timezone.utc)
+        return sum(
+            t.remaining_sats for t in self.tranches
+            if t.remaining_sats > 0 and not t.is_expired_at(now)
+        )
 
     # -- invoice record helpers ------------------------------------------------
 
@@ -132,11 +203,7 @@ class UserLedger:
         settled_at: str,
         btcpay_status: str = "Settled",
     ) -> None:
-        """Update an existing invoice record to Settled with credit info.
-
-        Creates a retroactive record if the invoice wasn't tracked at creation
-        (e.g. invoices created before this feature was deployed).
-        """
+        """Update an existing invoice record to Settled with credit info."""
         rec = self.invoices.get(invoice_id)
         if rec:
             rec.status = "Settled"
@@ -166,14 +233,51 @@ class UserLedger:
 
     # -- mutations ------------------------------------------------------------
 
+    def _collect_expired(self, now: datetime | None = None) -> int:
+        """Sweep expired tranches: move their remaining balance to total_expired_api_sats.
+
+        Returns the number of sats newly collected.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+        collected = 0
+        for t in self.tranches:
+            if t.remaining_sats > 0 and t.is_expired_at(now):
+                collected += t.remaining_sats
+                t.remaining_sats = 0
+        self.total_expired_api_sats += collected
+        return collected
+
     def debit(self, tool_name: str, api_sats: int) -> bool:
-        """Deduct ``api_sats`` from balance. Returns False if insufficient."""
+        """Deduct api_sats via FIFO from oldest non-expired tranche.
+
+        Returns False if insufficient balance (no partial debit).
+        """
         if api_sats < 0:
             return False
-        if self.balance_api_sats < api_sats:
+
+        now = datetime.now(timezone.utc)
+        self._collect_expired(now)
+
+        # Compute available from non-expired tranches
+        available = sum(
+            t.remaining_sats for t in self.tranches
+            if t.remaining_sats > 0 and not t.is_expired_at(now)
+        )
+        if available < api_sats:
             return False
 
-        self.balance_api_sats -= api_sats
+        # FIFO draw
+        remaining_to_debit = api_sats
+        for t in self.tranches:
+            if remaining_to_debit <= 0:
+                break
+            if t.remaining_sats <= 0 or t.is_expired_at(now):
+                continue
+            draw = min(remaining_to_debit, t.remaining_sats)
+            t.remaining_sats -= draw
+            remaining_to_debit -= draw
+
         self.total_consumed_api_sats += api_sats
 
         today = date.today().isoformat()
@@ -188,9 +292,23 @@ class UserLedger:
 
         return True
 
-    def credit_deposit(self, api_sats: int, invoice_id: str) -> None:
-        """Add credits from a settled invoice."""
-        self.balance_api_sats += api_sats
+    def credit_deposit(
+        self, api_sats: int, invoice_id: str, ttl_seconds: int | None = None,
+    ) -> None:
+        """Add credits as a new tranche with optional TTL."""
+        now = datetime.now(timezone.utc)
+        expires_at = (
+            (now + timedelta(seconds=ttl_seconds)).isoformat()
+            if ttl_seconds is not None
+            else None
+        )
+        self.tranches.append(Tranche(
+            granted_at=now.isoformat(),
+            original_sats=api_sats,
+            remaining_sats=api_sats,
+            invoice_id=invoice_id,
+            expires_at=expires_at,
+        ))
         self.total_deposited_api_sats += api_sats
         self.last_deposit_at = date.today().isoformat()
         if invoice_id in self.pending_invoices:
@@ -199,8 +317,17 @@ class UserLedger:
             self.credited_invoices.append(invoice_id)
 
     def rollback_debit(self, tool_name: str, api_sats: int) -> None:
-        """Undo a previous debit (e.g. tool call failed)."""
-        self.balance_api_sats += api_sats
+        """Undo a previous debit by creating a compensating tranche (never expires)."""
+        if api_sats <= 0:
+            return
+        now = datetime.now(timezone.utc)
+        self.tranches.append(Tranche(
+            granted_at=now.isoformat(),
+            original_sats=api_sats,
+            remaining_sats=api_sats,
+            invoice_id=f"rollback:{tool_name}",
+            expires_at=None,  # Compensating tranches never expire
+        ))
         self.total_consumed_api_sats -= api_sats
 
         today = date.today().isoformat()
@@ -220,21 +347,56 @@ class UserLedger:
         cutoff = (date.today() - timedelta(days=retention_days)).isoformat()
         expired_keys = [d for d in self.daily_log if d < cutoff]
         for day_key in expired_keys:
-            for tool_name, usage in self.daily_log[day_key].items():
-                # daily_log entries are already counted in history via debit(),
-                # so we only remove the daily entry — no double-counting.
-                pass
             del self.daily_log[day_key]
+
+    # -- expiration analytics -------------------------------------------------
+
+    def expiring_within(self, seconds: int) -> int:
+        """Sum of remaining_sats in tranches expiring within the given window."""
+        now = datetime.now(timezone.utc)
+        cutoff = now + timedelta(seconds=seconds)
+        total = 0
+        for t in self.tranches:
+            if t.remaining_sats <= 0 or t.is_expired_at(now):
+                continue
+            if t.expires_at is not None:
+                try:
+                    exp = datetime.fromisoformat(t.expires_at)
+                    if exp <= cutoff:
+                        total += t.remaining_sats
+                except (ValueError, TypeError):
+                    pass
+        return total
+
+    def next_expiration(self) -> str | None:
+        """ISO datetime of the earliest tranche expiration, or None."""
+        now = datetime.now(timezone.utc)
+        earliest: datetime | None = None
+        for t in self.tranches:
+            if t.remaining_sats <= 0 or t.is_expired_at(now):
+                continue
+            if t.expires_at is not None:
+                try:
+                    exp = datetime.fromisoformat(t.expires_at)
+                    if earliest is None or exp < earliest:
+                        earliest = exp
+                except (ValueError, TypeError):
+                    pass
+        return earliest.isoformat() if earliest else None
 
     # -- serialization --------------------------------------------------------
 
     def to_json(self) -> str:
-        """Serialize to JSON string with schema version."""
+        """Serialize to JSON (schema v4). Prunes empty/expired tranches."""
+        self._collect_expired()
+        # Prune fully consumed tranches
+        active = [t for t in self.tranches if t.remaining_sats > 0]
         return json.dumps({
             "v": _SCHEMA_VERSION,
-            "balance_api_sats": self.balance_api_sats,
+            "tranches": [t.to_dict() for t in active],
             "total_deposited_api_sats": self.total_deposited_api_sats,
             "total_consumed_api_sats": self.total_consumed_api_sats,
+            "total_expired_api_sats": self.total_expired_api_sats,
             "pending_invoices": self.pending_invoices,
             "credited_invoices": self.credited_invoices,
             "last_deposit_at": self.last_deposit_at,
@@ -252,10 +414,7 @@ class UserLedger:
 
     @classmethod
     def from_json(cls, data: str) -> UserLedger:
-        """Deserialize from JSON. Returns fresh ledger on corrupt/missing data.
-
-        Handles migration from v1 (``*_sats``) to v2 (``*_api_sats``) keys.
-        """
+        """Deserialize from JSON. v4 only — non-v4 data returns a fresh ledger."""
         try:
             obj = json.loads(data)
         except (json.JSONDecodeError, TypeError):
@@ -265,6 +424,20 @@ class UserLedger:
         if not isinstance(obj, dict):
             logger.warning("Ledger data is not a dict; returning fresh ledger.")
             return cls()
+
+        version = obj.get("v", 0)
+        if version != 4:
+            logger.warning(
+                "Ledger schema v%s is not supported (expected v4); returning fresh ledger.",
+                version,
+            )
+            return cls()
+
+        # Parse tranches
+        tranches: list[Tranche] = []
+        for t_data in obj.get("tranches", []):
+            if isinstance(t_data, dict):
+                tranches.append(Tranche.from_dict(t_data))
 
         daily_log: dict[str, dict[str, ToolUsage]] = {}
         raw_daily = obj.get("daily_log", {})
@@ -293,14 +466,11 @@ class UserLedger:
                 if isinstance(rec_data, dict):
                     invoices[iid] = InvoiceRecord.from_dict(rec_data)
 
-        # Migration: accept v1 keys (*_sats) or v2 keys (*_api_sats)
-        def _get_int(new_key: str, old_key: str) -> int:
-            return int(obj.get(new_key, obj.get(old_key, 0)))
-
         return cls(
-            balance_api_sats=_get_int("balance_api_sats", "balance_sats"),
-            total_deposited_api_sats=_get_int("total_deposited_api_sats", "total_deposited_sats"),
-            total_consumed_api_sats=_get_int("total_consumed_api_sats", "total_consumed_sats"),
+            tranches=tranches,
+            total_deposited_api_sats=int(obj.get("total_deposited_api_sats", 0)),
+            total_consumed_api_sats=int(obj.get("total_consumed_api_sats", 0)),
+            total_expired_api_sats=int(obj.get("total_expired_api_sats", 0)),
             pending_invoices=list(obj.get("pending_invoices", [])),
             credited_invoices=list(obj.get("credited_invoices", [])),
             last_deposit_at=obj.get("last_deposit_at"),

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -85,24 +85,33 @@ def _get_tier_info(
     user_id: str,
     tier_config_json: str | None,
     user_tiers_json: str | None,
-) -> tuple[str, int]:
-    """Look up tier name and credit multiplier for a user.
+    default_credit_ttl_seconds: int | None = None,
+) -> tuple[str, int, int | None]:
+    """Look up tier name, credit multiplier, and credit TTL for a user.
 
-    Returns (tier_name, multiplier).
+    Returns (tier_name, multiplier, credit_ttl_seconds).
     """
     if not tier_config_json or not user_tiers_json:
-        return "default", _DEFAULT_MULTIPLIER
+        return "default", _DEFAULT_MULTIPLIER, default_credit_ttl_seconds
 
     try:
         tier_config = json.loads(tier_config_json)
         user_tiers = json.loads(user_tiers_json)
     except (json.JSONDecodeError, TypeError):
         logger.warning("Invalid tier config JSON; using default multiplier.")
-        return "default", _DEFAULT_MULTIPLIER
+        return "default", _DEFAULT_MULTIPLIER, default_credit_ttl_seconds
 
     tier_name = user_tiers.get(user_id, "default")
     tier = tier_config.get(tier_name, tier_config.get("default", {}))
-    return tier_name, int(tier.get("credit_multiplier", _DEFAULT_MULTIPLIER))
+    multiplier = int(tier.get("credit_multiplier", _DEFAULT_MULTIPLIER))
+
+    # TTL: per-tier override, then config default, then None (never)
+    ttl_raw = tier.get("credit_ttl_seconds")
+    if ttl_raw is not None:
+        ttl = int(ttl_raw)
+    else:
+        ttl = default_credit_ttl_seconds
+    return tier_name, multiplier, ttl
 
 
 def _get_multiplier(
@@ -111,7 +120,7 @@ def _get_multiplier(
     user_tiers_json: str | None,
 ) -> int:
     """Look up credit multiplier for a user based on tier config."""
-    _, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+    _, multiplier, _ = _get_tier_info(user_id, tier_config_json, user_tiers_json)
     return multiplier
 
 
@@ -123,6 +132,7 @@ async def _create_purchase_invoice(
     tier_config_json: str | None,
     user_tiers_json: str | None,
     extra_metadata: dict[str, Any] | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Shared logic: validate amount, create BTCPay invoice, record in ledger.
 
@@ -156,7 +166,9 @@ async def _create_purchase_invoice(
     checkout_link = invoice.get("checkoutLink", "")
     expiry = invoice.get("expirationTime", "")
 
-    tier_name, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+    tier_name, multiplier, ttl = _get_tier_info(
+        user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+    )
     expected_credits = amount_sats * multiplier
 
     # Record pending invoice — flush immediately so the invoice survives cache loss
@@ -172,7 +184,7 @@ async def _create_purchase_invoice(
     if not await cache.flush_user(user_id):
         logger.warning("Failed to flush pending invoice %s for %s.", invoice_id, user_id)
 
-    return {
+    result: dict[str, Any] = {
         "success": True,
         "invoice_id": invoice_id,
         "amount_sats": amount_sats,
@@ -190,6 +202,9 @@ async def _create_purchase_invoice(
             f'After paying, call check_payment with invoice_id: "{invoice_id}"'
         ),
     }
+    if ttl is not None:
+        result["credit_ttl_seconds"] = ttl
+    return result
 
 
 async def purchase_credits_tool(
@@ -201,19 +216,13 @@ async def purchase_credits_tool(
     authority_public_key: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Create a BTCPay invoice after verifying an Authority certificate.
 
     For OPERATOR use: the certified purchase flow. Every credit purchase
     requires a valid Authority-signed Ed25519 JWT certificate. The
     certificate's net_sats (amount after tax) determines the invoice amount.
-
-    Call flow: user requests credits → operator calls Authority's
-    certify_purchase → Authority returns signed JWT → operator passes JWT
-    here → this function verifies it and creates the BTCPay invoice.
-
-    For Authority-side tax credit purchases (no certificate needed), use
-    purchase_tax_credits_tool instead.
     """
     # Trust gate — no Authority key means the operator is misconfigured
     if not authority_public_key:
@@ -242,6 +251,7 @@ async def purchase_credits_tool(
         btcpay, cache, user_id, net_sats,
         tier_config_json, user_tiers_json,
         extra_metadata={"certificate_jti": cert_claims["jti"]},
+        default_credit_ttl_seconds=default_credit_ttl_seconds,
     )
     if result.get("success"):
         result["certificate_jti"] = cert_claims["jti"]
@@ -255,20 +265,18 @@ async def purchase_tax_credits_tool(
     amount_sats: int,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Create a BTCPay invoice for a direct tax credit purchase.
 
     For AUTHORITY use: operators buy tax credits directly from the Authority.
     No certificate needed — the Authority IS the trust anchor.
-
-    The amount_sats is used directly as the invoice amount (no certificate
-    verification or tax deduction — the Authority handles tax via
-    certify_purchase separately).
     """
     return await _create_purchase_invoice(
         btcpay, cache, user_id, amount_sats,
         tier_config_json, user_tiers_json,
         extra_metadata={"purpose": "tax_credit_purchase"},
+        default_credit_ttl_seconds=default_credit_ttl_seconds,
     )
 
 
@@ -279,6 +287,7 @@ async def check_payment_tool(
     invoice_id: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
     royalty_address: str | None = None,
     royalty_percent: float = 0.02,
     royalty_min_sats: int = 10,
@@ -289,32 +298,6 @@ async def check_payment_tool(
     to call multiple times — credits are only granted once per invoice
     (idempotent via credited_invoices). On settlement, also fires a royalty
     payout to the Tollbooth originator if royalty_address is configured.
-
-    Invoice lifecycle: New → Processing → Settled (credits granted) or
-    Expired/Invalid (invoice removed from pending list).
-
-    Args:
-        btcpay: BTCPay client for the operator's store.
-        cache: Ledger cache for the user.
-        user_id: The user's identity string.
-        invoice_id: BTCPay invoice ID from purchase_credits_tool.
-        tier_config_json: Optional JSON string of tier definitions.
-        user_tiers_json: Optional JSON string mapping user IDs to tier names.
-        royalty_address: Lightning Address for the 2% royalty payout.
-        royalty_percent: Royalty fraction (0.02 = 2%).
-        royalty_min_sats: Minimum sats for a royalty payout to fire.
-
-    Returns dict with:
-        success: True on any valid response.
-        invoice_id: Echo of the input.
-        status: BTCPay status (New, Processing, Settled, Expired, Invalid).
-        credits_granted: Sats credited (only on first Settled check; 0 if already credited).
-        balance_api_sats: Updated balance after any crediting.
-        royalty_payout: Present only on settlement with royalty configured.
-        message: Human-readable status summary.
-
-    Errors: Returns success=False if the invoice_id is invalid or BTCPay
-    is unreachable.
     """
     try:
         invoice = await btcpay.get_invoice(invoice_id)
@@ -348,9 +331,11 @@ async def check_payment_tool(
             # Credit the user — flush immediately so credits survive cache loss
             amount_str = invoice.get("amount", "0")
             amount_sats = int(float(amount_str))
-            multiplier = _get_multiplier(user_id, tier_config_json, user_tiers_json)
+            _, multiplier, ttl = _get_tier_info(
+                user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+            )
             credited = amount_sats * multiplier
-            ledger.credit_deposit(credited, invoice_id)
+            ledger.credit_deposit(credited, invoice_id, ttl_seconds=ttl)
             ledger.record_invoice_settled(
                 invoice_id=invoice_id,
                 api_sats_credited=credited,
@@ -405,34 +390,15 @@ async def check_balance_tool(
     user_id: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
-    """Return the user's current credit balance, tier info, and usage summary.
-
-    Read-only — no side effects. Call anytime to check funding level, review
-    today's per-tool usage breakdown, or inspect invoice history.
-
-    Args:
-        cache: Ledger cache for the user.
-        user_id: The user's identity string.
-        tier_config_json: Optional JSON string of tier definitions.
-        user_tiers_json: Optional JSON string mapping user IDs to tier names.
-
-    Returns dict with:
-        success: Always True.
-        tier/multiplier: User's current tier name and credit multiplier.
-        balance_api_sats: Current available credit balance.
-        total_deposited_api_sats: Lifetime credits purchased.
-        total_consumed_api_sats: Lifetime credits consumed by tool calls.
-        pending_invoices: Count of unpaid invoices.
-        last_deposit_at: Timestamp of most recent credit deposit.
-        seed_balance_granted: True if the user received a starter balance.
-        today_usage: Per-tool call counts and sats consumed today (if any).
-        invoice_summary: Settled/pending counts and totals (if invoices exist).
-    """
+    """Return the user's current credit balance, tier info, and usage summary."""
     ledger = await cache.get(user_id)
     today = date.today().isoformat()
 
-    tier_name, multiplier = _get_tier_info(user_id, tier_config_json, user_tiers_json)
+    tier_name, multiplier, _ = _get_tier_info(
+        user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+    )
 
     result: dict[str, Any] = {
         "success": True,
@@ -447,6 +413,18 @@ async def check_balance_tool(
 
     if "seed_balance_v1" in ledger.credited_invoices:
         result["seed_balance_granted"] = True
+
+    # Tranche expiration info
+    result["total_expired_api_sats"] = ledger.total_expired_api_sats
+    expiring_24h = ledger.expiring_within(86400)
+    if expiring_24h > 0:
+        result["expiring_within_24h_sats"] = expiring_24h
+    next_exp = ledger.next_expiration()
+    if next_exp:
+        result["next_expiration_iso"] = next_exp
+    result["active_tranches"] = len([
+        t for t in ledger.tranches if t.remaining_sats > 0
+    ])
 
     # Include today's usage if available
     today_log = ledger.daily_log.get(today)
@@ -478,34 +456,9 @@ async def restore_credits_tool(
     invoice_id: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
-    """Restore credits from a paid invoice that was lost due to cache or vault issues.
-
-    Emergency recovery tool. Checks three sources in order: (1) idempotency
-    guard (already credited? no-op), (2) vault invoice record (restore without
-    BTCPay call), (3) BTCPay API (verify Settled status, then credit).
-
-    Call this when a user reports "I paid but my balance didn't update" — typically
-    caused by a cache eviction or vault flush failure between payment and crediting.
-    Safe to call multiple times; will never double-credit.
-
-    Args:
-        btcpay: BTCPay client for the operator's store.
-        cache: Ledger cache for the user.
-        user_id: The user's identity string.
-        invoice_id: BTCPay invoice ID that the user claims to have paid.
-        tier_config_json: Optional JSON string of tier definitions.
-        user_tiers_json: Optional JSON string mapping user IDs to tier names.
-
-    Returns dict with:
-        success: True if credits were restored or already credited.
-        source: 'vault_record' or 'btcpay' — where the settlement was confirmed.
-        credits_granted: Sats credited (0 if already credited).
-        balance_api_sats: Updated balance.
-
-    Errors: Returns success=False if invoice is not Settled or BTCPay is
-    unreachable and no vault record exists.
-    """
+    """Restore credits from a paid invoice that was lost due to cache or vault issues."""
     # Check idempotency first
     ledger = await cache.get(user_id)
     if invoice_id in ledger.credited_invoices:
@@ -522,7 +475,10 @@ async def restore_credits_tool(
     if vault_record and vault_record.status == "Settled" and vault_record.api_sats_credited > 0:
         # Restore from vault record — no BTCPay call needed
         credited = vault_record.api_sats_credited
-        ledger.credit_deposit(credited, invoice_id)
+        _, _, ttl = _get_tier_info(
+            user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+        )
+        ledger.credit_deposit(credited, invoice_id, ttl_seconds=ttl)
         cache.mark_dirty(user_id)
         if not await cache.flush_user(user_id):
             logger.error(
@@ -557,10 +513,12 @@ async def restore_credits_tool(
     # Credit the balance
     amount_str = invoice.get("amount", "0")
     amount_sats = int(float(amount_str))
-    multiplier = _get_multiplier(user_id, tier_config_json, user_tiers_json)
+    _, multiplier, ttl = _get_tier_info(
+        user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+    )
     credited = amount_sats * multiplier
 
-    ledger.credit_deposit(credited, invoice_id)
+    ledger.credit_deposit(credited, invoice_id, ttl_seconds=ttl)
     ledger.record_invoice_settled(
         invoice_id=invoice_id,
         api_sats_credited=credited,
@@ -592,17 +550,9 @@ async def reconcile_pending_invoices(
     user_id: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
+    default_credit_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
-    """Reconcile pending invoices on startup: credit settled, remove terminal.
-
-    Iterates pending_invoices, checks each against BTCPay, and:
-    - Settled + not yet credited → credit_deposit + record_invoice_settled
-    - Expired/Invalid → remove from pending + record_invoice_terminal
-    - BTCPay errors → skip (logged, not fatal)
-
-    A single flush_user() is called at the end if any changes were made.
-    Returns {"reconciled": N, "actions": [...]}.
-    """
+    """Reconcile pending invoices on startup: credit settled, remove terminal."""
     ledger = await cache.get(user_id)
     pending_copy = list(ledger.pending_invoices)
     if not pending_copy:
@@ -623,9 +573,11 @@ async def reconcile_pending_invoices(
         if status == "Settled" and invoice_id not in ledger.credited_invoices:
             amount_str = invoice.get("amount", "0")
             amount_sats = int(float(amount_str))
-            multiplier = _get_multiplier(user_id, tier_config_json, user_tiers_json)
+            _, multiplier, ttl = _get_tier_info(
+                user_id, tier_config_json, user_tiers_json, default_credit_ttl_seconds,
+            )
             credited = amount_sats * multiplier
-            ledger.credit_deposit(credited, invoice_id)
+            ledger.credit_deposit(credited, invoice_id, ttl_seconds=ttl)
             ledger.record_invoice_settled(
                 invoice_id=invoice_id,
                 api_sats_credited=credited,
@@ -707,30 +659,7 @@ async def btcpay_status_tool(
     config: TollboothConfig,
     btcpay: BTCPayClient | None,
 ) -> dict[str, Any]:
-    """Report BTCPay configuration state, connectivity, and permissions for diagnostics.
-
-    Admin/operator tool. Checks whether BTCPay is reachable, the store exists,
-    the API key has required permissions (invoice creation, invoice viewing,
-    and payout creation if royalties are enabled), and tier/royalty config
-    is valid.
-
-    Call this during initial setup to verify configuration, or when payments
-    aren't working to diagnose connectivity or permission issues.
-
-    Args:
-        config: TollboothConfig with BTCPay and royalty settings.
-        btcpay: BTCPay client (may be None if connection vars are missing).
-
-    Returns dict with:
-        btcpay_host/btcpay_store_id: Configured endpoints.
-        btcpay_api_key_status: 'present' or 'missing'.
-        authority_config: Trust chain status — key configured/valid, fingerprint.
-        server_reachable: True/False/None (None if not configured).
-        store_name: Store name or error status.
-        api_key_permissions: Required vs present permissions, with missing list.
-        tier_config/user_tiers: Config status summaries.
-        royalty_config: Royalty address, percent, min_sats, enabled flag.
-    """
+    """Report BTCPay configuration state, connectivity, and permissions for diagnostics."""
     result: dict[str, Any] = {
         "btcpay_host": config.btcpay_host or None,
         "btcpay_store_id": config.btcpay_store_id or None,
@@ -765,6 +694,9 @@ async def btcpay_status_tool(
             result["user_tiers"] = "invalid JSON"
     else:
         result["user_tiers"] = "missing"
+
+    # Credit TTL
+    result["credit_ttl_seconds"] = config.credit_ttl_seconds
 
     # Authority trust chain config
     from tollbooth.certificate import normalize_public_key, key_fingerprint

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import jwt as pyjwt
@@ -19,7 +19,7 @@ from tollbooth.btcpay_client import (
 )
 from tollbooth.certificate import reset_jti_store
 from tollbooth.config import TollboothConfig
-from tollbooth.ledger import UserLedger
+from tollbooth.ledger import Tranche, UserLedger
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.tools.credits import (
     ROYALTY_PAYOUT_MAX_SATS,
@@ -78,6 +78,31 @@ def _clean_jti_store():
 # Helpers
 # ---------------------------------------------------------------------------
 
+_PAST = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+
+def _tranche(
+    sats: int,
+    remaining: int | None = None,
+    expires_at: str | None = None,
+    invoice_id: str = "test-init",
+) -> Tranche:
+    return Tranche(
+        granted_at=_PAST,
+        original_sats=sats,
+        remaining_sats=remaining if remaining is not None else sats,
+        invoice_id=invoice_id,
+        expires_at=expires_at,
+    )
+
+
+def _ledger_with_balance(balance: int, **kwargs) -> UserLedger:
+    """Create a UserLedger with initial balance as a single non-expiring tranche."""
+    ledger = UserLedger(**kwargs)
+    if balance > 0:
+        ledger.tranches.append(_tranche(balance))
+    return ledger
+
 
 def _mock_btcpay(invoice_response: dict | None = None, error: Exception | None = None):
     """Create a mock BTCPayClient."""
@@ -103,6 +128,11 @@ def _mock_cache(ledger: UserLedger | None = None):
 TIER_CONFIG = json.dumps({
     "default": {"credit_multiplier": 1},
     "vip": {"credit_multiplier": 100},
+})
+
+TIER_CONFIG_WITH_TTL = json.dumps({
+    "default": {"credit_multiplier": 1, "credit_ttl_seconds": 604800},
+    "vip": {"credit_multiplier": 100, "credit_ttl_seconds": 2592000},
 })
 
 USER_TIERS = json.dumps({
@@ -151,29 +181,61 @@ class TestGetMultiplier:
 
 class TestGetTierInfo:
     def test_default_when_no_config(self) -> None:
-        name, mult = _get_tier_info("user1", None, None)
+        name, mult, ttl = _get_tier_info("user1", None, None)
         assert name == "default"
         assert mult == 1
+        assert ttl is None
 
     def test_vip_tier(self) -> None:
-        name, mult = _get_tier_info("user-vip", TIER_CONFIG, USER_TIERS)
+        name, mult, ttl = _get_tier_info("user-vip", TIER_CONFIG, USER_TIERS)
         assert name == "vip"
         assert mult == 100
+        assert ttl is None  # No TTL in TIER_CONFIG
 
     def test_standard_tier(self) -> None:
-        name, mult = _get_tier_info("user-standard", TIER_CONFIG, USER_TIERS)
+        name, mult, ttl = _get_tier_info("user-standard", TIER_CONFIG, USER_TIERS)
         assert name == "default"
         assert mult == 1
 
     def test_unknown_user(self) -> None:
-        name, mult = _get_tier_info("user-unknown", TIER_CONFIG, USER_TIERS)
+        name, mult, ttl = _get_tier_info("user-unknown", TIER_CONFIG, USER_TIERS)
         assert name == "default"
         assert mult == 1
 
     def test_corrupt_json(self) -> None:
-        name, mult = _get_tier_info("user1", "bad", "bad")
+        name, mult, ttl = _get_tier_info("user1", "bad", "bad")
         assert name == "default"
         assert mult == 1
+        assert ttl is None
+
+    def test_tier_ttl_from_config(self) -> None:
+        """Per-tier TTL is extracted from tier config JSON."""
+        name, mult, ttl = _get_tier_info(
+            "user-standard", TIER_CONFIG_WITH_TTL, USER_TIERS,
+        )
+        assert ttl == 604800
+
+    def test_vip_tier_ttl(self) -> None:
+        name, mult, ttl = _get_tier_info(
+            "user-vip", TIER_CONFIG_WITH_TTL, USER_TIERS,
+        )
+        assert ttl == 2592000
+
+    def test_default_ttl_fallback(self) -> None:
+        """When tier config has no TTL, falls back to default_credit_ttl_seconds."""
+        name, mult, ttl = _get_tier_info(
+            "user1", TIER_CONFIG, USER_TIERS,
+            default_credit_ttl_seconds=86400,
+        )
+        assert ttl == 86400
+
+    def test_tier_ttl_overrides_default(self) -> None:
+        """Per-tier TTL takes precedence over default."""
+        name, mult, ttl = _get_tier_info(
+            "user-standard", TIER_CONFIG_WITH_TTL, USER_TIERS,
+            default_credit_ttl_seconds=86400,
+        )
+        assert ttl == 604800  # tier's TTL, not the default
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +382,43 @@ class TestCheckPayment:
         cache.mark_dirty.assert_called()
 
     @pytest.mark.asyncio
+    async def test_settled_creates_tranche(self) -> None:
+        """Settlement creates a new tranche in the ledger."""
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "500",
+        })
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert len(ledger.tranches) == 1
+        assert ledger.tranches[0].original_sats == 500
+
+    @pytest.mark.asyncio
+    async def test_settled_with_ttl(self) -> None:
+        """Settlement with default TTL creates expiring tranche."""
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "500",
+        })
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        await check_payment_tool(
+            btcpay, cache, "user1", "inv-1",
+            default_credit_ttl_seconds=3600,
+        )
+        assert ledger.tranches[0].expires_at is not None
+
+    @pytest.mark.asyncio
+    async def test_settled_without_ttl(self) -> None:
+        """Settlement without TTL creates non-expiring tranche."""
+        btcpay = _mock_btcpay({
+            "id": "inv-1", "status": "Settled", "amount": "500",
+        })
+        ledger = UserLedger()
+        cache = _mock_cache(ledger)
+        await check_payment_tool(btcpay, cache, "user1", "inv-1")
+        assert ledger.tranches[0].expires_at is None
+
+    @pytest.mark.asyncio
     async def test_settled_vip_multiplier(self) -> None:
         btcpay = _mock_btcpay({
             "id": "inv-1", "status": "Settled", "amount": "500",
@@ -338,7 +437,7 @@ class TestCheckPayment:
         btcpay = _mock_btcpay({
             "id": "inv-1", "status": "Settled", "amount": "1000",
         })
-        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["inv-1"])
+        ledger = _ledger_with_balance(1000, credited_invoices=["inv-1"])
         cache = _mock_cache(ledger)
         result = await check_payment_tool(btcpay, cache, "user1", "inv-1")
         assert result["credits_granted"] == 0
@@ -402,11 +501,12 @@ class TestCheckBalance:
         assert result["success"] is True
         assert result["balance_api_sats"] == 0
         assert result["pending_invoices"] == 0
+        assert result["active_tranches"] == 0
 
     @pytest.mark.asyncio
     async def test_with_balance(self) -> None:
-        ledger = UserLedger(
-            balance_api_sats=5000,
+        ledger = _ledger_with_balance(
+            5000,
             total_deposited_api_sats=10000,
             total_consumed_api_sats=5000,
             pending_invoices=["inv-a"],
@@ -419,10 +519,11 @@ class TestCheckBalance:
         assert result["total_consumed_api_sats"] == 5000
         assert result["pending_invoices"] == 1
         assert result["last_deposit_at"] == "2026-02-15"
+        assert result["active_tranches"] == 1
 
     @pytest.mark.asyncio
     async def test_today_usage_included(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 10)
         cache = _mock_cache(ledger)
         result = await check_balance_tool(cache, "user1")
@@ -431,14 +532,14 @@ class TestCheckBalance:
 
     @pytest.mark.asyncio
     async def test_no_today_usage(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         cache = _mock_cache(ledger)
         result = await check_balance_tool(cache, "user1")
         assert "today_usage" not in result
 
     @pytest.mark.asyncio
     async def test_does_not_modify_state(self) -> None:
-        ledger = UserLedger(balance_api_sats=500)
+        ledger = _ledger_with_balance(500)
         cache = _mock_cache(ledger)
         await check_balance_tool(cache, "user1")
         cache.mark_dirty.assert_not_called()
@@ -467,7 +568,7 @@ class TestCheckBalance:
     @pytest.mark.asyncio
     async def test_seed_balance_granted_shown(self) -> None:
         """check_balance shows seed_balance_granted when seed sentinel is present."""
-        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["seed_balance_v1"])
+        ledger = _ledger_with_balance(1000, credited_invoices=["seed_balance_v1"])
         cache = _mock_cache(ledger)
         result = await check_balance_tool(cache, "user1")
         assert result["seed_balance_granted"] is True
@@ -475,10 +576,35 @@ class TestCheckBalance:
     @pytest.mark.asyncio
     async def test_seed_balance_granted_absent(self) -> None:
         """check_balance omits seed_balance_granted when no seed was applied."""
-        ledger = UserLedger(balance_api_sats=500)
+        ledger = _ledger_with_balance(500)
         cache = _mock_cache(ledger)
         result = await check_balance_tool(cache, "user1")
         assert "seed_balance_granted" not in result
+
+    @pytest.mark.asyncio
+    async def test_expiration_fields_present(self) -> None:
+        """check_balance includes tranche expiration analytics."""
+        soon = (datetime.now(timezone.utc) + timedelta(hours=12)).isoformat()
+        ledger = UserLedger(tranches=[
+            _tranche(100, expires_at=soon),
+            _tranche(200, expires_at=None),
+        ])
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert result["total_expired_api_sats"] == 0
+        assert result["expiring_within_24h_sats"] == 100
+        assert result["next_expiration_iso"] == soon
+        assert result["active_tranches"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_expiration_fields_when_no_ttl(self) -> None:
+        """No expiration fields when all tranches are non-expiring."""
+        ledger = _ledger_with_balance(500)
+        cache = _mock_cache(ledger)
+        result = await check_balance_tool(cache, "user1")
+        assert result["total_expired_api_sats"] == 0
+        assert "expiring_within_24h_sats" not in result
+        assert "next_expiration_iso" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -489,24 +615,18 @@ class TestCheckBalance:
 class TestComputeLowBalanceWarning:
     def test_above_threshold_returns_none(self) -> None:
         """Balance well above threshold -> no warning."""
-        ledger = UserLedger(balance_api_sats=5000)
+        ledger = _ledger_with_balance(5000)
         assert compute_low_balance_warning(ledger, seed_balance_sats=1000) is None
 
     def test_at_threshold_returns_none(self) -> None:
         """Balance exactly at threshold -> no warning (>= means safe)."""
         # seed_balance_sats=500, threshold = max(500//5, 100) = 100
-        ledger = UserLedger(
-            balance_api_sats=100,
-            credited_invoices=["seed_balance_v1"],
-        )
+        ledger = _ledger_with_balance(100, credited_invoices=["seed_balance_v1"])
         assert compute_low_balance_warning(ledger, seed_balance_sats=500) is None
 
     def test_below_threshold_returns_warning(self) -> None:
         """Balance below threshold -> warning dict."""
-        ledger = UserLedger(
-            balance_api_sats=50,
-            credited_invoices=["seed_balance_v1"],
-        )
+        ledger = _ledger_with_balance(50, credited_invoices=["seed_balance_v1"])
         warning = compute_low_balance_warning(ledger, seed_balance_sats=500)
         assert warning is not None
         assert warning["balance_api_sats"] == 50
@@ -516,7 +636,7 @@ class TestComputeLowBalanceWarning:
 
     def test_settled_invoice_reference(self) -> None:
         """Threshold is 20% of last settled invoice's api_sats_credited."""
-        ledger = UserLedger(balance_api_sats=50)
+        ledger = _ledger_with_balance(50)
         ledger.record_invoice_created("inv-1", amount_sats=1000, multiplier=1, created_at="")
         ledger.record_invoice_settled("inv-1", api_sats_credited=1000, settled_at="")
         warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
@@ -526,10 +646,7 @@ class TestComputeLowBalanceWarning:
 
     def test_seed_only_user(self) -> None:
         """Seed-only user: reference is seed_balance_sats."""
-        ledger = UserLedger(
-            balance_api_sats=10,
-            credited_invoices=["seed_balance_v1"],
-        )
+        ledger = _ledger_with_balance(10, credited_invoices=["seed_balance_v1"])
         warning = compute_low_balance_warning(ledger, seed_balance_sats=1000)
         assert warning is not None
         # threshold = max(1000 // 5, 100) = 200
@@ -537,7 +654,7 @@ class TestComputeLowBalanceWarning:
 
     def test_no_history_uses_floor(self) -> None:
         """No invoices, no seed: reference is the floor."""
-        ledger = UserLedger(balance_api_sats=50)
+        ledger = _ledger_with_balance(50)
         warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
         assert warning is not None
         # reference = floor (100), threshold = max(100//5, 100) = 100
@@ -545,7 +662,7 @@ class TestComputeLowBalanceWarning:
 
     def test_retroactive_invoice_suggested_defaults(self) -> None:
         """Retroactive invoice (amount_sats=0) -> suggested defaults to 1000."""
-        ledger = UserLedger(balance_api_sats=5)
+        ledger = _ledger_with_balance(5)
         ledger.record_invoice_settled("inv-retro", api_sats_credited=500, settled_at="")
         # retroactive: amount_sats=0 in the record
         warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
@@ -554,7 +671,7 @@ class TestComputeLowBalanceWarning:
 
     def test_suggested_capped_at_max(self) -> None:
         """Suggested top-up capped at MAX_INVOICE_SATS."""
-        ledger = UserLedger(balance_api_sats=5)
+        ledger = _ledger_with_balance(5)
         ledger.record_invoice_created(
             "inv-big", amount_sats=5_000_000, multiplier=1, created_at="",
         )
@@ -565,7 +682,7 @@ class TestComputeLowBalanceWarning:
 
     def test_zero_seed_no_invoices(self) -> None:
         """Zero seed + no invoices -> floor path."""
-        ledger = UserLedger(balance_api_sats=50)
+        ledger = _ledger_with_balance(50)
         warning = compute_low_balance_warning(ledger, seed_balance_sats=0)
         assert warning is not None
         assert warning["threshold_api_sats"] == 100
@@ -790,7 +907,7 @@ class TestCheckPaymentWithRoyalty:
             "id": "inv-1", "status": "Settled", "amount": "1000",
         })
         btcpay.create_payout = AsyncMock()
-        ledger = UserLedger(balance_api_sats=1000, credited_invoices=["inv-1"])
+        ledger = _ledger_with_balance(1000, credited_invoices=["inv-1"])
         cache = _mock_cache(ledger)
         result = await check_payment_tool(
             btcpay, cache, "user1", "inv-1",
@@ -932,7 +1049,7 @@ class TestBTCPayStatusRoyalty:
 
     @pytest.mark.asyncio
     async def test_payout_processor_present(self) -> None:
-        """Lightning payout processor configured → lightning_automated True, no warning."""
+        """Lightning payout processor configured -> lightning_automated True, no warning."""
         config = _make_config(tollbooth_royalty_address="toll@ln")
 
         btcpay = AsyncMock(spec=BTCPayClient)
@@ -951,7 +1068,7 @@ class TestBTCPayStatusRoyalty:
 
     @pytest.mark.asyncio
     async def test_payout_processor_missing(self) -> None:
-        """No payout processors → lightning_automated False, warning present."""
+        """No payout processors -> lightning_automated False, warning present."""
         config = _make_config(tollbooth_royalty_address="toll@ln")
 
         btcpay = AsyncMock(spec=BTCPayClient)
@@ -969,7 +1086,7 @@ class TestBTCPayStatusRoyalty:
 
     @pytest.mark.asyncio
     async def test_payout_processor_error(self) -> None:
-        """get_payout_processors fails → error captured, no crash."""
+        """get_payout_processors fails -> error captured, no crash."""
         config = _make_config(tollbooth_royalty_address="toll@ln")
 
         btcpay = AsyncMock(spec=BTCPayClient)
@@ -986,7 +1103,7 @@ class TestBTCPayStatusRoyalty:
 
     @pytest.mark.asyncio
     async def test_payout_processor_skipped_no_royalty(self) -> None:
-        """Royalty disabled → payout_processor not in result."""
+        """Royalty disabled -> payout_processor not in result."""
         config = _make_config(tollbooth_royalty_address=None)
 
         btcpay = AsyncMock(spec=BTCPayClient)
@@ -1039,6 +1156,7 @@ class TestBTCPayStatus:
         assert result["user_tiers"] == "2 user(s)"
         assert result["server_reachable"] is True
         assert result["store_name"] == "My Store"
+        assert result["credit_ttl_seconds"] == 604800
 
     @pytest.mark.asyncio
     async def test_api_key_missing(self) -> None:
@@ -1220,7 +1338,7 @@ class TestReconcilePendingInvoices:
 
     @pytest.mark.asyncio
     async def test_noop_on_empty_pending(self) -> None:
-        """No pending invoices → no actions, no flush."""
+        """No pending invoices -> no actions, no flush."""
         btcpay = _mock_btcpay()
         ledger = UserLedger()
         cache = _mock_cache(ledger)
@@ -1251,8 +1369,8 @@ class TestReconcilePendingInvoices:
     async def test_idempotent_already_credited(self) -> None:
         """Already-credited settled invoice is not double-credited."""
         btcpay = _mock_btcpay({"id": "inv-1", "status": "Settled", "amount": "500"})
-        ledger = UserLedger(
-            balance_api_sats=500,
+        ledger = _ledger_with_balance(
+            500,
             pending_invoices=["inv-1"],
             credited_invoices=["inv-1"],
         )

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,11 +1,45 @@
-"""Tests for UserLedger model and serialization."""
+"""Tests for UserLedger model with tranche-based credit expiration."""
 
 import json
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
-from tollbooth.ledger import ToolUsage, UserLedger
+from tollbooth.ledger import Tranche, ToolUsage, UserLedger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(timezone.utc)
+_PAST = (_NOW - timedelta(hours=1)).isoformat()
+_FUTURE = (_NOW + timedelta(days=7)).isoformat()
+_EXPIRED = (_NOW - timedelta(seconds=1)).isoformat()
+
+
+def _tranche(
+    sats: int,
+    remaining: int | None = None,
+    expires_at: str | None = None,
+    invoice_id: str = "test-init",
+) -> Tranche:
+    """Create a test tranche with sensible defaults."""
+    return Tranche(
+        granted_at=_PAST,
+        original_sats=sats,
+        remaining_sats=remaining if remaining is not None else sats,
+        invoice_id=invoice_id,
+        expires_at=expires_at,
+    )
+
+
+def _ledger_with_balance(balance: int, **kwargs) -> UserLedger:
+    """Create a UserLedger with initial balance as a single non-expiring tranche."""
+    ledger = UserLedger(**kwargs)
+    if balance > 0:
+        ledger.tranches.append(_tranche(balance))
+    return ledger
 
 
 # ---------------------------------------------------------------------------
@@ -41,40 +75,111 @@ class TestToolUsage:
 
 
 # ---------------------------------------------------------------------------
+# Tranche
+# ---------------------------------------------------------------------------
+
+
+class TestTranche:
+    def test_not_expired_when_no_expiry(self) -> None:
+        t = _tranche(100, expires_at=None)
+        assert t.is_expired_at(_NOW) is False
+
+    def test_not_expired_when_future(self) -> None:
+        t = _tranche(100, expires_at=_FUTURE)
+        assert t.is_expired_at(_NOW) is False
+
+    def test_expired_when_past(self) -> None:
+        t = _tranche(100, expires_at=_EXPIRED)
+        assert t.is_expired_at(_NOW) is True
+
+    def test_malformed_expires_at_treated_as_never(self) -> None:
+        t = _tranche(100, expires_at="not-a-datetime")
+        assert t.is_expired_at(_NOW) is False
+
+    def test_to_dict_omits_expires_at_when_none(self) -> None:
+        t = _tranche(100, expires_at=None)
+        d = t.to_dict()
+        assert "expires_at" not in d
+
+    def test_to_dict_includes_expires_at(self) -> None:
+        t = _tranche(100, expires_at=_FUTURE)
+        d = t.to_dict()
+        assert d["expires_at"] == _FUTURE
+
+    def test_roundtrip(self) -> None:
+        t = _tranche(100, remaining=75, expires_at=_FUTURE, invoice_id="inv-42")
+        restored = Tranche.from_dict(t.to_dict())
+        assert restored.original_sats == 100
+        assert restored.remaining_sats == 75
+        assert restored.expires_at == _FUTURE
+        assert restored.invoice_id == "inv-42"
+
+
+# ---------------------------------------------------------------------------
+# UserLedger — balance property
+# ---------------------------------------------------------------------------
+
+
+class TestBalance:
+    def test_empty_ledger_zero_balance(self) -> None:
+        ledger = UserLedger()
+        assert ledger.balance_api_sats == 0
+
+    def test_single_tranche(self) -> None:
+        ledger = _ledger_with_balance(100)
+        assert ledger.balance_api_sats == 100
+
+    def test_multiple_tranches(self) -> None:
+        ledger = UserLedger(tranches=[_tranche(50), _tranche(30)])
+        assert ledger.balance_api_sats == 80
+
+    def test_expired_tranche_excluded(self) -> None:
+        ledger = UserLedger(tranches=[
+            _tranche(100, expires_at=_EXPIRED),
+            _tranche(50),
+        ])
+        assert ledger.balance_api_sats == 50
+
+    def test_empty_tranche_excluded(self) -> None:
+        ledger = UserLedger(tranches=[_tranche(100, remaining=0)])
+        assert ledger.balance_api_sats == 0
+
+
+# ---------------------------------------------------------------------------
 # UserLedger — debit / credit / rollback
 # ---------------------------------------------------------------------------
 
 
 class TestUserLedger:
     def test_debit_success(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         assert ledger.debit("search", 30) is True
         assert ledger.balance_api_sats == 70
         assert ledger.total_consumed_api_sats == 30
 
     def test_debit_insufficient_balance(self) -> None:
-        ledger = UserLedger(balance_api_sats=10)
+        ledger = _ledger_with_balance(10)
         assert ledger.debit("search", 20) is False
         assert ledger.balance_api_sats == 10
         assert ledger.total_consumed_api_sats == 0
 
     def test_debit_exact_balance(self) -> None:
-        ledger = UserLedger(balance_api_sats=50)
+        ledger = _ledger_with_balance(50)
         assert ledger.debit("search", 50) is True
         assert ledger.balance_api_sats == 0
 
     def test_debit_negative_amount_rejected(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         assert ledger.debit("search", -5) is False
         assert ledger.balance_api_sats == 100
 
     def test_debit_zero(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         assert ledger.debit("search", 0) is True
         assert ledger.balance_api_sats == 100
 
     def test_debit_updates_daily_log(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 10)
         today = date.today().isoformat()
         assert today in ledger.daily_log
@@ -82,19 +187,61 @@ class TestUserLedger:
         assert ledger.daily_log[today]["search"].api_sats == 10
 
     def test_debit_updates_history(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 10)
         ledger.debit("search", 20)
         assert ledger.history["search"].calls == 2
         assert ledger.history["search"].api_sats == 30
 
+    def test_debit_fifo_across_tranches(self) -> None:
+        """Debit draws from oldest tranche first, then spills to next."""
+        t1 = _tranche(30, invoice_id="first")
+        t2 = _tranche(70, invoice_id="second")
+        ledger = UserLedger(tranches=[t1, t2])
+        assert ledger.debit("search", 50) is True
+        assert t1.remaining_sats == 0  # fully consumed
+        assert t2.remaining_sats == 50  # 70 - 20
+        assert ledger.balance_api_sats == 50
+
+    def test_debit_skips_expired_tranches(self) -> None:
+        """Expired tranches are skipped during FIFO draw."""
+        t_expired = _tranche(100, expires_at=_EXPIRED, invoice_id="expired")
+        t_fresh = _tranche(50, invoice_id="fresh")
+        ledger = UserLedger(tranches=[t_expired, t_fresh])
+        assert ledger.debit("search", 30) is True
+        assert t_expired.remaining_sats == 0  # collected as expired
+        assert t_fresh.remaining_sats == 20
+        assert ledger.total_expired_api_sats == 100
+
+    def test_debit_insufficient_after_expiration(self) -> None:
+        """If only expired tranches exist, debit fails."""
+        ledger = UserLedger(tranches=[_tranche(100, expires_at=_EXPIRED)])
+        assert ledger.debit("search", 10) is False
+        assert ledger.total_expired_api_sats == 100
+
     def test_credit_deposit(self) -> None:
-        ledger = UserLedger(balance_api_sats=50, pending_invoices=["inv-1"])
+        ledger = _ledger_with_balance(50, pending_invoices=["inv-1"])
         ledger.credit_deposit(100, "inv-1")
         assert ledger.balance_api_sats == 150
         assert ledger.total_deposited_api_sats == 100
         assert ledger.last_deposit_at == date.today().isoformat()
         assert "inv-1" not in ledger.pending_invoices
+        assert len(ledger.tranches) == 2  # original + new
+
+    def test_credit_deposit_with_ttl(self) -> None:
+        """credit_deposit with ttl_seconds creates expiring tranche."""
+        ledger = UserLedger()
+        ledger.credit_deposit(500, "inv-1", ttl_seconds=3600)
+        assert len(ledger.tranches) == 1
+        t = ledger.tranches[0]
+        assert t.original_sats == 500
+        assert t.expires_at is not None
+
+    def test_credit_deposit_without_ttl(self) -> None:
+        """credit_deposit without ttl_seconds creates non-expiring tranche."""
+        ledger = UserLedger()
+        ledger.credit_deposit(500, "inv-1")
+        assert ledger.tranches[0].expires_at is None
 
     def test_credit_deposit_unknown_invoice(self) -> None:
         ledger = UserLedger(pending_invoices=["inv-1"])
@@ -103,15 +250,28 @@ class TestUserLedger:
         assert "inv-1" in ledger.pending_invoices
 
     def test_rollback_debit(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 30)
         assert ledger.balance_api_sats == 70
         ledger.rollback_debit("search", 30)
         assert ledger.balance_api_sats == 100
         assert ledger.total_consumed_api_sats == 0
 
+    def test_rollback_creates_compensating_tranche(self) -> None:
+        """Rollback creates a new non-expiring tranche, doesn't modify old ones."""
+        ledger = _ledger_with_balance(100)
+        ledger.debit("search", 30)
+        initial_count = len(ledger.tranches)
+        ledger.rollback_debit("search", 30)
+        assert len(ledger.tranches) == initial_count + 1
+        comp = ledger.tranches[-1]
+        assert comp.original_sats == 30
+        assert comp.remaining_sats == 30
+        assert comp.expires_at is None
+        assert comp.invoice_id == "rollback:search"
+
     def test_rollback_clamps_to_zero(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 10)
         # Rollback more than was debited
         ledger.rollback_debit("search", 20)
@@ -130,10 +290,7 @@ class TestUserLedger:
         """Second credit_deposit with same sentinel is a no-op for credited_invoices."""
         ledger = UserLedger()
         ledger.credit_deposit(1000, "seed_balance_v1")
-        # Calling again adds balance but sentinel already present (idempotency
-        # is checked by the caller, not credit_deposit itself)
         assert "seed_balance_v1" in ledger.credited_invoices
-        # Caller should check `sentinel not in ledger.credited_invoices` before calling
         assert ledger.credited_invoices.count("seed_balance_v1") == 1
 
     def test_seed_balance_is_spendable(self) -> None:
@@ -144,7 +301,7 @@ class TestUserLedger:
         assert ledger.balance_api_sats == 900
 
     def test_rotate_daily_log(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         # Add an old entry
         ledger.daily_log["2020-01-01"] = {"search": ToolUsage(calls=5, api_sats=50)}
         # Add today's entry
@@ -156,30 +313,111 @@ class TestUserLedger:
 
 
 # ---------------------------------------------------------------------------
+# Expiration collection
+# ---------------------------------------------------------------------------
+
+
+class TestCollectExpired:
+    def test_collect_expired_sweeps_balance(self) -> None:
+        t = _tranche(100, expires_at=_EXPIRED)
+        ledger = UserLedger(tranches=[t])
+        collected = ledger._collect_expired()
+        assert collected == 100
+        assert t.remaining_sats == 0
+        assert ledger.total_expired_api_sats == 100
+
+    def test_collect_expired_skips_non_expired(self) -> None:
+        t = _tranche(100, expires_at=_FUTURE)
+        ledger = UserLedger(tranches=[t])
+        collected = ledger._collect_expired()
+        assert collected == 0
+        assert t.remaining_sats == 100
+        assert ledger.total_expired_api_sats == 0
+
+    def test_collect_expired_skips_never_expiring(self) -> None:
+        t = _tranche(100, expires_at=None)
+        ledger = UserLedger(tranches=[t])
+        collected = ledger._collect_expired()
+        assert collected == 0
+
+    def test_collect_expired_idempotent(self) -> None:
+        """Calling twice doesn't double-count."""
+        t = _tranche(100, expires_at=_EXPIRED)
+        ledger = UserLedger(tranches=[t])
+        ledger._collect_expired()
+        ledger._collect_expired()
+        assert ledger.total_expired_api_sats == 100
+
+
+# ---------------------------------------------------------------------------
+# Expiration analytics
+# ---------------------------------------------------------------------------
+
+
+class TestExpirationAnalytics:
+    def test_expiring_within_returns_sum(self) -> None:
+        soon = (datetime.now(timezone.utc) + timedelta(hours=12)).isoformat()
+        far = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        ledger = UserLedger(tranches=[
+            _tranche(100, expires_at=soon),
+            _tranche(200, expires_at=far),
+            _tranche(50, expires_at=None),
+        ])
+        assert ledger.expiring_within(86400) == 100  # only the 12h tranche
+
+    def test_expiring_within_empty(self) -> None:
+        ledger = UserLedger(tranches=[_tranche(100, expires_at=None)])
+        assert ledger.expiring_within(86400) == 0
+
+    def test_next_expiration_returns_earliest(self) -> None:
+        soon = (datetime.now(timezone.utc) + timedelta(hours=6)).isoformat()
+        later = (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+        ledger = UserLedger(tranches=[
+            _tranche(100, expires_at=later),
+            _tranche(50, expires_at=soon),
+        ])
+        result = ledger.next_expiration()
+        assert result is not None
+        assert result == soon
+
+    def test_next_expiration_none_when_no_expiring(self) -> None:
+        ledger = UserLedger(tranches=[_tranche(100, expires_at=None)])
+        assert ledger.next_expiration() is None
+
+
+# ---------------------------------------------------------------------------
 # Serialization
 # ---------------------------------------------------------------------------
 
 
 class TestLedgerSerialization:
     def test_roundtrip(self) -> None:
-        ledger = UserLedger(balance_api_sats=500, total_deposited_api_sats=1000)
+        ledger = UserLedger()
+        ledger.credit_deposit(500, "inv-1")
+        ledger.credit_deposit(500, "inv-2", ttl_seconds=3600)
         ledger.debit("search", 100)
         restored = UserLedger.from_json(ledger.to_json())
-        assert restored.balance_api_sats == 400
+        assert restored.balance_api_sats == ledger.balance_api_sats
         assert restored.total_deposited_api_sats == 1000
         assert restored.total_consumed_api_sats == 100
         assert "search" in restored.history
         assert restored.history["search"].calls == 1
+        assert len(restored.tranches) == 2
 
     def test_schema_version(self) -> None:
         ledger = UserLedger()
         obj = json.loads(ledger.to_json())
-        assert obj["v"] == 3
+        assert obj["v"] == 4
 
-    def test_from_json_missing_fields(self) -> None:
+    def test_from_json_v3_returns_fresh(self) -> None:
+        """v3 ledger data returns a fresh (empty) ledger."""
+        restored = UserLedger.from_json('{"v": 3, "balance_api_sats": 500}')
+        assert restored.balance_api_sats == 0
+        assert restored.tranches == []
+
+    def test_from_json_v1_returns_fresh(self) -> None:
         restored = UserLedger.from_json('{"v": 1}')
         assert restored.balance_api_sats == 0
-        assert restored.pending_invoices == []
 
     def test_from_json_corrupt_data(self) -> None:
         restored = UserLedger.from_json("not json at all")
@@ -194,7 +432,7 @@ class TestLedgerSerialization:
         assert restored.balance_api_sats == 0
 
     def test_daily_log_survives_roundtrip(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         ledger.debit("search", 10)
         ledger.debit("create", 20)
         restored = UserLedger.from_json(ledger.to_json())
@@ -208,8 +446,36 @@ class TestLedgerSerialization:
         assert restored.pending_invoices == ["inv-a", "inv-b"]
 
     def test_to_json_is_pretty_printed(self) -> None:
-        ledger = UserLedger(balance_api_sats=100)
+        ledger = _ledger_with_balance(100)
         output = ledger.to_json()
         assert "\n" in output
         parsed = json.loads(output)
-        assert parsed["balance_api_sats"] == 100
+        assert "tranches" in parsed
+
+    def test_to_json_prunes_empty_tranches(self) -> None:
+        """Fully consumed tranches are not serialized."""
+        ledger = _ledger_with_balance(100)
+        ledger.debit("search", 100)
+        obj = json.loads(ledger.to_json())
+        assert len(obj["tranches"]) == 0
+
+    def test_to_json_prunes_expired_tranches(self) -> None:
+        """Expired tranches are collected and pruned during serialization."""
+        ledger = UserLedger(tranches=[_tranche(100, expires_at=_EXPIRED)])
+        obj = json.loads(ledger.to_json())
+        assert len(obj["tranches"]) == 0
+        assert obj["total_expired_api_sats"] == 100
+
+    def test_tranches_survive_roundtrip(self) -> None:
+        """Tranche details (including expires_at) survive serialization."""
+        ledger = UserLedger()
+        ledger.credit_deposit(200, "inv-1", ttl_seconds=7200)
+        restored = UserLedger.from_json(ledger.to_json())
+        assert len(restored.tranches) == 1
+        assert restored.tranches[0].original_sats == 200
+        assert restored.tranches[0].expires_at is not None
+
+    def test_total_expired_survives_roundtrip(self) -> None:
+        ledger = UserLedger(total_expired_api_sats=42)
+        restored = UserLedger.from_json(ledger.to_json())
+        assert restored.total_expired_api_sats == 42


### PR DESCRIPTION
## Summary

- Credits are now stored as ordered tranches with optional TTL instead of a scalar balance
- Debits draw FIFO from the oldest non-expired tranche, spanning across tranches as needed
- Expired tranche remaining balances accumulate in `total_expired_api_sats` (lazy sweep)
- Rollbacks create compensating tranches that never expire (immutable append-only history)
- Per-tier TTL configurable via tier config JSON (`credit_ttl_seconds` key per tier)
- `TollboothConfig.credit_ttl_seconds` provides a global default (7 days)
- `check_balance` reports `total_expired_api_sats`, `expiring_within_24h_sats`, `next_expiration_iso`, and `active_tranches`
- Schema bumped to v4 — non-v4 ledgers return fresh (no backward compat, per design decision)
- Version bumped to 0.1.16

## Key design decisions

- Authority tax balances do NOT expire (Authorities set `credit_ttl_seconds: null` in tier config)
- No re-seeding — users who let credits expire must purchase new ones
- No tranche count limit per user
- `total_expired_api_sats` computed lazily during `debit()`, `to_json()`, and `_collect_expired()`

## Test plan

- [x] All 309 tests pass (`venv/bin/pytest tests/ -v`)
- [x] New tranche lifecycle tests: creation, expiration, FIFO debit, rollback
- [x] Serialization roundtrip tests for schema v4
- [x] Expiration analytics tests (`expiring_within`, `next_expiration`)
- [x] Credit tools tests for TTL propagation through tiers
- [x] Ledger cache tests updated for tranche-based API
- [ ] Downstream: thebrain-mcp seed logic, test_tool_gating, test_credit_tools
- [ ] Downstream: tollbooth-authority tier config (Authority = no TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)