### PR TITLE
Add account_statement_tool for customer statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.16"
+version = "0.1.17"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -6,7 +6,7 @@ import importlib.metadata
 import json
 import logging
 import platform
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from tollbooth.btcpay_client import BTCPayClient, BTCPayAuthError, BTCPayError
@@ -652,6 +652,116 @@ def compute_low_balance_warning(
             f"(warning threshold: {threshold}). "
             f"Consider topping up with purchase_credits."
         ),
+    }
+
+
+async def account_statement_tool(
+    cache: LedgerCache,
+    user_id: str,
+    days: int = 30,
+) -> dict[str, Any]:
+    """Generate a customer-facing account statement with purchase history and usage.
+
+    Returns a structured statement suitable for customer proof-of-purchase
+    and usage auditing. Includes: account summary, invoice line items, active
+    credit tranches, all-time tool usage, and recent daily usage.
+
+    Args:
+        cache: The LedgerCache instance.
+        user_id: The user's identity key.
+        days: Number of days of daily usage to include (default 30).
+    """
+    ledger = await cache.get(user_id)
+    now = datetime.now(timezone.utc)
+    today = date.today()
+
+    # -- Account summary ---------------------------------------------------
+    summary: dict[str, Any] = {
+        "balance_api_sats": ledger.balance_api_sats,
+        "total_deposited_api_sats": ledger.total_deposited_api_sats,
+        "total_consumed_api_sats": ledger.total_consumed_api_sats,
+        "total_expired_api_sats": ledger.total_expired_api_sats,
+    }
+
+    # -- Invoice line items (sorted by created_at, most recent first) ------
+    invoice_items: list[dict[str, Any]] = []
+    for rec in sorted(
+        ledger.invoices.values(),
+        key=lambda r: r.created_at or "",
+        reverse=True,
+    ):
+        item: dict[str, Any] = {
+            "invoice_id": rec.invoice_id,
+            "status": rec.status,
+            "amount_sats": rec.amount_sats,
+            "api_sats_credited": rec.api_sats_credited,
+            "multiplier": rec.multiplier,
+            "created_at": rec.created_at,
+        }
+        if rec.settled_at:
+            item["settled_at"] = rec.settled_at
+        invoice_items.append(item)
+
+    # -- Active tranches ---------------------------------------------------
+    tranche_items: list[dict[str, Any]] = []
+    for t in ledger.tranches:
+        if t.remaining_sats <= 0 or t.is_expired_at(now):
+            continue
+        entry: dict[str, Any] = {
+            "granted_at": t.granted_at,
+            "original_sats": t.original_sats,
+            "remaining_sats": t.remaining_sats,
+            "invoice_id": t.invoice_id,
+        }
+        if t.expires_at:
+            entry["expires_at"] = t.expires_at
+        tranche_items.append(entry)
+
+    # -- All-time tool usage (sorted by api_sats descending) ---------------
+    tool_usage_items: list[dict[str, Any]] = []
+    for tool_name, usage in sorted(
+        ledger.history.items(),
+        key=lambda kv: kv[1].api_sats,
+        reverse=True,
+    ):
+        tool_usage_items.append({
+            "tool": tool_name,
+            "calls": usage.calls,
+            "api_sats": usage.api_sats,
+        })
+
+    # -- Daily usage log (last N days, most recent first) ------------------
+    cutoff_date = (today - timedelta(days=days)).isoformat()
+    daily_items: list[dict[str, Any]] = []
+    for day_iso in sorted(ledger.daily_log.keys(), reverse=True):
+        if day_iso < cutoff_date:
+            break
+        day_tools = ledger.daily_log[day_iso]
+        day_total_calls = sum(u.calls for u in day_tools.values())
+        day_total_sats = sum(u.api_sats for u in day_tools.values())
+        daily_items.append({
+            "date": day_iso,
+            "total_calls": day_total_calls,
+            "total_api_sats": day_total_sats,
+            "tools": {
+                name: {"calls": u.calls, "api_sats": u.api_sats}
+                for name, u in sorted(
+                    day_tools.items(),
+                    key=lambda kv: kv[1].api_sats,
+                    reverse=True,
+                )
+            },
+        })
+
+    return {
+        "success": True,
+        "generated_at": now.isoformat(),
+        "statement_period_days": days,
+        "account_summary": summary,
+        "purchase_history": invoice_items,
+        "active_tranches": tranche_items,
+        "tool_usage_all_time": tool_usage_items,
+        "daily_usage": daily_items,
     }
 
 

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -19,13 +19,14 @@ from tollbooth.btcpay_client import (
 )
 from tollbooth.certificate import reset_jti_store
 from tollbooth.config import TollboothConfig
-from tollbooth.ledger import Tranche, UserLedger
+from tollbooth.ledger import ToolUsage, Tranche, UserLedger
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.tools.credits import (
     ROYALTY_PAYOUT_MAX_SATS,
     _attempt_royalty_payout,
     _get_multiplier,
     _get_tier_info,
+    account_statement_tool,
     btcpay_status_tool,
     check_balance_tool,
     check_payment_tool,
@@ -1382,3 +1383,129 @@ class TestReconcilePendingInvoices:
         # Balance should not increase
         assert ledger.balance_api_sats == 500
         cache.flush_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AccountStatement
+# ---------------------------------------------------------------------------
+
+
+class TestAccountStatement:
+    @pytest.mark.asyncio
+    async def test_empty_ledger(self) -> None:
+        """Fresh user gets a valid statement with zero values."""
+        cache = _mock_cache()
+        result = await account_statement_tool(cache, "user1")
+
+        assert result["success"] is True
+        assert "generated_at" in result
+        assert result["statement_period_days"] == 30
+        assert result["account_summary"]["balance_api_sats"] == 0
+        assert result["account_summary"]["total_deposited_api_sats"] == 0
+        assert result["purchase_history"] == []
+        assert result["active_tranches"] == []
+        assert result["tool_usage_all_time"] == []
+        assert result["daily_usage"] == []
+
+    @pytest.mark.asyncio
+    async def test_with_invoices(self) -> None:
+        """Statement includes invoice line items sorted by date descending."""
+        ledger = UserLedger()
+        ledger.record_invoice_created("inv-a", 500, 1, "2026-02-20T10:00:00+00:00")
+        ledger.record_invoice_settled("inv-a", 500, "2026-02-20T10:05:00+00:00", "Settled")
+        ledger.credit_deposit(500, "inv-a")
+
+        ledger.record_invoice_created("inv-b", 1000, 1, "2026-02-21T12:00:00+00:00")
+        ledger.record_invoice_settled("inv-b", 1000, "2026-02-21T12:05:00+00:00", "Settled")
+        ledger.credit_deposit(1000, "inv-b")
+
+        cache = _mock_cache(ledger)
+        result = await account_statement_tool(cache, "user1")
+
+        assert result["success"] is True
+        history = result["purchase_history"]
+        assert len(history) == 2
+        # Most recent first
+        assert history[0]["invoice_id"] == "inv-b"
+        assert history[1]["invoice_id"] == "inv-a"
+        assert history[0]["amount_sats"] == 1000
+        assert history[0]["settled_at"] == "2026-02-21T12:05:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_active_tranches(self) -> None:
+        """Statement lists non-expired, non-zero tranches."""
+        ledger = UserLedger()
+        # First tranche — will be fully consumed by FIFO debit
+        ledger.credit_deposit(100, "inv-a")
+        # Second tranche — survives
+        ledger.credit_deposit(300, "inv-b")
+        # FIFO debit consumes oldest (inv-a) fully
+        ledger.debit("test_tool", 100)
+
+        cache = _mock_cache(ledger)
+        result = await account_statement_tool(cache, "user1")
+
+        tranches = result["active_tranches"]
+        assert len(tranches) == 1
+        assert tranches[0]["remaining_sats"] == 300
+        assert tranches[0]["invoice_id"] == "inv-b"
+
+    @pytest.mark.asyncio
+    async def test_tool_usage(self) -> None:
+        """All-time usage sorted by api_sats descending."""
+        ledger = _ledger_with_balance(5000)
+        ledger.debit("search_thoughts", 10)
+        ledger.debit("search_thoughts", 10)
+        ledger.debit("brain_query", 100)
+
+        cache = _mock_cache(ledger)
+        result = await account_statement_tool(cache, "user1")
+
+        usage = result["tool_usage_all_time"]
+        assert len(usage) == 2
+        # brain_query has more api_sats, so comes first
+        assert usage[0]["tool"] == "brain_query"
+        assert usage[0]["api_sats"] == 100
+        assert usage[0]["calls"] == 1
+        assert usage[1]["tool"] == "search_thoughts"
+        assert usage[1]["api_sats"] == 20
+        assert usage[1]["calls"] == 2
+
+    @pytest.mark.asyncio
+    async def test_daily_usage_respects_days_param(self) -> None:
+        """Daily log only includes entries within the requested window."""
+        ledger = _ledger_with_balance(5000)
+        today = date.today()
+        # Add entries for 3 days
+        for offset in (0, 15, 45):
+            day = (today - timedelta(days=offset)).isoformat()
+            ledger.daily_log[day] = {
+                "get_thought": ToolUsage(calls=5, api_sats=5),
+            }
+
+        cache = _mock_cache(ledger)
+        result = await account_statement_tool(cache, "user1", days=30)
+
+        daily = result["daily_usage"]
+        # Only today (0 days ago) and 15 days ago are within 30 days
+        assert len(daily) == 2
+        assert daily[0]["date"] == today.isoformat()
+        assert daily[1]["date"] == (today - timedelta(days=15)).isoformat()
+
+    @pytest.mark.asyncio
+    async def test_summary_totals(self) -> None:
+        """Account summary reflects deposited, consumed, expired correctly."""
+        ledger = UserLedger()
+        ledger.credit_deposit(1000, "inv-1")
+        ledger.debit("tool_a", 300)
+        # Simulate some previously expired amount
+        ledger.total_expired_api_sats = 200
+
+        cache = _mock_cache(ledger)
+        result = await account_statement_tool(cache, "user1")
+
+        summary = result["account_summary"]
+        assert summary["balance_api_sats"] == 700
+        assert summary["total_deposited_api_sats"] == 1000
+        assert summary["total_consumed_api_sats"] == 300
+        assert summary["total_expired_api_sats"] == 200


### PR DESCRIPTION
## Summary
- New `account_statement_tool()` in `tollbooth.tools.credits` generates customer-facing purchase and usage reports
- Returns structured dict with: account summary, invoice line items (sorted by date), active credit tranches, all-time tool usage (sorted by consumption), and daily usage log (configurable window)
- Version bumped to 0.1.17

## Test plan
- [x] 6 new tests in `test_credit_tools.py` covering empty ledger, invoice history, active tranches, tool usage sorting, daily log window, and summary totals
- [x] Full suite: 315 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)