### PR TITLE
Fix vault daily-child duplication from stale graph cache

### DIFF
--- a/src/tollbooth/vaults/thebrain.py
+++ b/src/tollbooth/vaults/thebrain.py
@@ -138,11 +138,23 @@ class TheBrainVault:
         resp.raise_for_status()
         return data
 
-    async def _get_children(self, thought_id: str) -> list[dict[str, Any]]:
-        """Get a thought's children via the graph endpoint."""
+    async def _get_children(
+        self, thought_id: str, *, no_cache: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Get a thought's children via the graph endpoint.
+
+        When *no_cache* is True, cache-busting headers are sent to bypass
+        Azure App Service CDN caching — critical for write paths where a
+        recently created child must be visible.
+        """
+        headers: dict[str, str] = {}
+        if no_cache:
+            headers["Cache-Control"] = "no-cache"
+            headers["Pragma"] = "no-cache"
         try:
             resp = await self._client.get(
-                f"/thoughts/{self._brain_id}/{thought_id}/graph"
+                f"/thoughts/{self._brain_id}/{thought_id}/graph",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
@@ -150,6 +162,36 @@ class TheBrainVault:
         except httpx.HTTPError:
             logger.warning("Failed to read graph for thought %s", thought_id)
         return []
+
+    async def _search_children_by_name(
+        self, parent_id: str, name: str,
+    ) -> str | None:
+        """Search for a child thought by exact name under a parent.
+
+        Uses the ``/search`` endpoint as a fallback when the graph endpoint
+        returns stale data. Returns the thought ID if found, else None.
+        """
+        try:
+            resp = await self._client.get(
+                f"/search/{self._brain_id}",
+                params={"queryText": name, "maxResults": 10},
+            )
+            if resp.status_code == 200:
+                results = resp.json()
+                for r in results:
+                    if r.get("name") == name and r.get("sourceThoughtId") == parent_id:
+                        return r.get("id")
+                    # Fallback: check by verifying parentage via graph
+                    if r.get("name") == name:
+                        # Verify this is actually a child of parent_id
+                        graph = await self._get_graph(r["id"])
+                        parents = graph.get("parents", [])
+                        for p in parents:
+                            if p.get("id") == parent_id:
+                                return r["id"]
+        except httpx.HTTPError:
+            logger.warning("Search failed for '%s' under %s", name, parent_id)
+        return None
 
     async def _get_graph(self, thought_id: str) -> dict[str, Any]:
         """GET /thoughts/{brainId}/{thoughtId}/graph -> full graph dict.
@@ -456,13 +498,25 @@ class TheBrainVault:
             graph = await self._get_graph(self._home_thought_id)
             await self._register_member(ledger_parent_id, graph)
 
-        # Find or create today's daily child
-        children = await self._get_children(ledger_parent_id)
+        # Find or create today's daily child.
+        # Use no_cache=True to bypass Azure App Service CDN staleness.
+        children = await self._get_children(ledger_parent_id, no_cache=True)
         daily_child_id: str | None = None
         for child in children:
             if child.get("name") == today:
                 daily_child_id = child.get("id")
                 break
+
+        # Fallback: search endpoint (separate index from graph cache)
+        if not daily_child_id:
+            daily_child_id = await self._search_children_by_name(
+                ledger_parent_id, today,
+            )
+            if daily_child_id:
+                logger.info(
+                    "Found daily child via search fallback: %s/%s -> %s",
+                    user_id, today, daily_child_id,
+                )
 
         if daily_child_id:
             await self._set_note(daily_child_id, ledger_json)
@@ -489,16 +543,18 @@ class TheBrainVault:
         if not ledger_parent_id:
             return None
 
-        children = await self._get_children(ledger_parent_id)
+        children = await self._get_children(ledger_parent_id, no_cache=True)
         if children:
             # Sort by name descending -- ISO dates sort lexicographically
             children_sorted = sorted(
                 children, key=lambda t: t.get("name", ""), reverse=True
             )
-            most_recent = children_sorted[0]
-            note = await self._get_note(most_recent["id"])
-            if note:
-                return note
+            # Try children in order until we find one with a non-empty note.
+            # Duplicates from earlier bugs may have empty notes — skip them.
+            for child in children_sorted:
+                note = await self._get_note(child["id"])
+                if note:
+                    return note
 
         # Fallback: read parent note (pre-migration state)
         return await self._get_note(ledger_parent_id)

--- a/tests/test_thebrain_vault.py
+++ b/tests/test_thebrain_vault.py
@@ -810,6 +810,59 @@ class TestStoreLedger:
         # Cache should be updated
         assert vault._daily_child_cache[f"user1/{today}"] == "fresh-child"
 
+    @pytest.mark.asyncio
+    async def test_search_fallback_finds_daily_child(self) -> None:
+        """When graph returns stale data, search endpoint finds the child."""
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._discover_members = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        # Graph returns empty (stale) — child exists but not visible
+        vault._get_children = AsyncMock(return_value=[])
+        # Search finds the child
+        vault._search_children_by_name = AsyncMock(return_value="search-found-child")
+        vault._set_note = AsyncMock()
+
+        result = await vault.store_ledger("user1", '{"balance": 500}')
+        assert result == "search-found-child"
+        vault._set_note.assert_called_once_with("search-found-child", '{"balance": 500}')
+        # Should NOT have created a new thought
+        assert not hasattr(vault._create_thought, 'called') or not vault._create_thought.called
+
+    @pytest.mark.asyncio
+    async def test_creates_only_when_graph_and_search_both_miss(self) -> None:
+        """Creates daily child only when both graph and search find nothing."""
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._discover_members = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(return_value=[])
+        vault._search_children_by_name = AsyncMock(return_value=None)
+        vault._create_thought = AsyncMock(return_value={"id": "new-child"})
+        vault._set_note = AsyncMock()
+
+        result = await vault.store_ledger("user1", '{"balance": 600}')
+        assert result == "new-child"
+        vault._create_thought.assert_called_once_with(today, "ledger-parent")
+
+    @pytest.mark.asyncio
+    async def test_get_children_passes_no_cache_in_store_ledger(self) -> None:
+        """store_ledger calls _get_children with no_cache=True."""
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        vault = _vault()
+        vault._discover_members = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(
+            return_value=[{"id": "child-1", "name": today}]
+        )
+        vault._set_note = AsyncMock()
+
+        await vault.store_ledger("user1", '{"data": "test"}')
+        vault._get_children.assert_called_once_with("ledger-parent", no_cache=True)
+
 
 # ---------------------------------------------------------------------------
 # fetch_ledger
@@ -872,6 +925,39 @@ class TestFetchLedger:
 
         result = await vault.fetch_ledger("user1")
         assert result == '{"balance": 42}'
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_duplicates(self) -> None:
+        """fetch_ledger skips children with empty notes (duplicates from bug)."""
+        vault = _vault()
+        vault._discover_members = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(return_value=[
+            {"id": "dup1", "name": "2026-02-22"},
+            {"id": "dup2", "name": "2026-02-22"},
+            {"id": "dup3", "name": "2026-02-22"},
+            {"id": "good", "name": "2026-02-21"},
+        ])
+
+        async def _get_note_side_effect(thought_id: str) -> str | None:
+            if thought_id == "good":
+                return '{"balance": 777}'
+            return None  # Empty duplicates
+
+        vault._get_note = AsyncMock(side_effect=_get_note_side_effect)
+
+        result = await vault.fetch_ledger("user1")
+        assert result == '{"balance": 777}'
+
+    @pytest.mark.asyncio
+    async def test_fetch_uses_no_cache(self) -> None:
+        """fetch_ledger calls _get_children with no_cache=True."""
+        vault = _vault()
+        vault._discover_members = AsyncMock(return_value={"user1/ledger": "ledger-parent"})
+        vault._get_children = AsyncMock(return_value=[])
+        vault._get_note = AsyncMock(return_value=None)
+
+        await vault.fetch_ledger("user1")
+        vault._get_children.assert_called_once_with("ledger-parent", no_cache=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- TheBrain Cloud's Azure App Service caches `/graph` responses, so `store_ledger` missed recently-created daily children after process restarts — creating hundreds of duplicate empty-note thoughts with the same date
- Added `Cache-Control: no-cache` header to `_get_children` in write paths (`no_cache=True` parameter)
- Added `_search_children_by_name` fallback using the `/search` endpoint before creating a new daily child
- `fetch_ledger` now iterates through children to skip empty-note duplicates instead of only reading the first one
- 5 new tests covering search fallback, cache-busting headers, and dedup behavior

## Root Cause

On every process restart (deployment, cold start), `_daily_child_cache` is empty. `store_ledger` falls through to the "slow path" which uses `_get_children` (graph endpoint). Azure CDN returns stale data missing the recently-created child, so a duplicate is created. Repeated across many restarts = hundreds of duplicates.

## Test plan

- [x] 65 vault tests pass (5 new)
- [x] 320 total tests pass
- [ ] Deploy and verify no new duplicates are created on repeated `activate_session` calls
- [ ] Clean up existing duplicate thoughts in TheBrain (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)