### PR TITLE
Add OpenTimestamps Bitcoin anchoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.22"
+version = "0.1.23"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -33,6 +33,7 @@ nostr = [
     "pynostr>=0.6.0",
     "websocket-client>=1.6.0",
 ]
+ots = []  # Reserved — no extra deps needed (uses stdlib hashlib + existing httpx)
 dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
@@ -13,6 +13,7 @@ from tollbooth.vault_backend import VaultBackend
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
+from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
 
 try:
     from tollbooth.nostr_audit import NostrAuditPublisher, AuditedVault
@@ -44,4 +45,7 @@ __all__ = [
     "UNDERSTOOD_PROTOCOLS",
     "NostrAuditPublisher",
     "AuditedVault",
+    "MerkleTree",
+    "InclusionProof",
+    "OTSCalendarClient",
 ]

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -22,3 +22,6 @@ class TollboothConfig:
     credit_ttl_seconds: int | None = 604800  # 7 days default, None = never
     flush_batch_size: int = 10
     flush_staleness_secs: float = 120.0
+    # OpenTimestamps Bitcoin anchoring
+    ots_enabled: bool = False
+    ots_calendars: str | None = None  # Comma-separated URLs; None = defaults

--- a/src/tollbooth/ots.py
+++ b/src/tollbooth/ots.py
@@ -1,0 +1,323 @@
+"""OpenTimestamps Bitcoin anchoring — Merkle tree + OTS calendar client.
+
+Provides three components for anchoring ledger state to Bitcoin:
+
+- ``MerkleTree``: SHA-256 Merkle tree over sorted (npub, ledger_json) entries
+- ``InclusionProof``: Verifiable proof that a specific leaf is in the tree
+- ``OTSCalendarClient``: Async HTTP client for OTS calendar servers
+
+Zero new dependencies: stdlib ``hashlib`` for hashing, existing ``httpx``
+for HTTP calls to OTS calendar servers.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default OTS calendar servers (free, no API keys, no rate limits)
+DEFAULT_CALENDARS: list[str] = [
+    "https://a.pool.opentimestamps.org",
+    "https://b.pool.opentimestamps.org",
+    "https://a.pool.eternitywall.com",
+    "https://ots.btc.catallaxy.com",
+]
+
+
+def _sha256(data: bytes) -> bytes:
+    """Compute SHA-256 digest."""
+    return hashlib.sha256(data).digest()
+
+
+@dataclass(frozen=True)
+class InclusionProof:
+    """Merkle inclusion proof for a single leaf.
+
+    Proves that ``leaf_hash`` is included in a Merkle tree with
+    ``root_hash`` by providing the sibling hashes along the path
+    from leaf to root.
+    """
+
+    leaf_hash: str
+    leaf_index: int
+    tree_size: int
+    root_hash: str
+    siblings: list[dict[str, str]]  # [{"hash": hex, "position": "left"|"right"}, ...]
+
+    def verify(self) -> bool:
+        """Recompute leaf→root and check against stored root_hash."""
+        current = bytes.fromhex(self.leaf_hash)
+        for sib in self.siblings:
+            sib_hash = bytes.fromhex(sib["hash"])
+            if sib["position"] == "left":
+                current = _sha256(sib_hash + current)
+            else:
+                current = _sha256(current + sib_hash)
+        return current.hex() == self.root_hash
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "leaf_hash": self.leaf_hash,
+            "leaf_index": self.leaf_index,
+            "tree_size": self.tree_size,
+            "root_hash": self.root_hash,
+            "siblings": self.siblings,
+        }
+
+
+class MerkleTree:
+    """SHA-256 Merkle tree over sorted (npub, ledger_json) entries.
+
+    Leaf computation: ``SHA256(npub + ":" + SHA256(ledger_json))``
+    Entries are sorted by npub for deterministic construction.
+    Odd leaf count: duplicate last leaf.
+    """
+
+    def __init__(self, entries: list[tuple[str, str]]) -> None:
+        """Build a Merkle tree from (npub, ledger_json) pairs.
+
+        Args:
+            entries: List of (npub, ledger_json) tuples. Sorted by npub
+                internally for deterministic ordering.
+        """
+        sorted_entries = sorted(entries, key=lambda e: e[0])
+        self._leaf_hashes: list[bytes] = []
+        self._npub_to_index: dict[str, int] = {}
+
+        for i, (npub, ledger_json) in enumerate(sorted_entries):
+            inner = _sha256(ledger_json.encode("utf-8"))
+            leaf = _sha256(npub.encode("utf-8") + b":" + inner)
+            self._leaf_hashes.append(leaf)
+            self._npub_to_index[npub] = i
+
+        self._levels: list[list[bytes]] = []
+        self._build()
+
+    @classmethod
+    def from_leaf_hashes(cls, leaf_data: list[dict[str, str]]) -> MerkleTree:
+        """Rebuild a MerkleTree from stored leaf hashes.
+
+        Args:
+            leaf_data: List of ``{"npub": leaf_hash_hex}`` single-key dicts,
+                one per leaf, in original sorted order.
+
+        Returns:
+            A MerkleTree with the same root as the original.
+        """
+        tree = cls.__new__(cls)
+        tree._leaf_hashes = []
+        tree._npub_to_index = {}
+        tree._levels = []
+
+        for i, entry in enumerate(leaf_data):
+            for npub, hash_hex in entry.items():
+                tree._leaf_hashes.append(bytes.fromhex(hash_hex))
+                tree._npub_to_index[npub] = i
+
+        tree._build()
+        return tree
+
+    def _build(self) -> None:
+        """Build the Merkle tree levels from leaf hashes."""
+        if not self._leaf_hashes:
+            self._levels = []
+            return
+
+        level = list(self._leaf_hashes)
+        self._levels = [level]
+
+        while len(level) > 1:
+            # Duplicate last hash if odd count
+            if len(level) % 2 == 1:
+                level = level + [level[-1]]
+
+            next_level: list[bytes] = []
+            for j in range(0, len(level), 2):
+                combined = _sha256(level[j] + level[j + 1])
+                next_level.append(combined)
+
+            self._levels.append(next_level)
+            level = next_level
+
+    @property
+    def root(self) -> bytes:
+        """The Merkle root as raw bytes. Empty bytes if tree is empty."""
+        if not self._levels:
+            return b""
+        return self._levels[-1][0]
+
+    @property
+    def root_hex(self) -> str:
+        """The Merkle root as a hex string. Empty string if tree is empty."""
+        if not self._levels:
+            return ""
+        return self._levels[-1][0].hex()
+
+    @property
+    def leaf_count(self) -> int:
+        """Number of leaves in the tree."""
+        return len(self._leaf_hashes)
+
+    def get_leaf_hashes(self) -> list[dict[str, str]]:
+        """Export leaf hashes for storage.
+
+        Returns:
+            List of ``{"npub": leaf_hash_hex}`` dicts in tree order.
+        """
+        result: list[dict[str, str]] = []
+        # Invert the index to get npub by position
+        index_to_npub = {v: k for k, v in self._npub_to_index.items()}
+        for i, h in enumerate(self._leaf_hashes):
+            npub = index_to_npub.get(i, f"unknown_{i}")
+            result.append({npub: h.hex()})
+        return result
+
+    def get_proof(self, npub: str) -> InclusionProof | None:
+        """Generate an inclusion proof for a specific npub.
+
+        Returns None if the npub is not in the tree.
+        """
+        idx = self._npub_to_index.get(npub)
+        if idx is None:
+            return None
+
+        siblings: list[dict[str, str]] = []
+        current_idx = idx
+
+        for level_idx in range(len(self._levels) - 1):
+            level = self._levels[level_idx]
+            # Pad level for odd count (same as build)
+            padded = list(level)
+            if len(padded) % 2 == 1:
+                padded.append(padded[-1])
+
+            if current_idx % 2 == 0:
+                # Current is left child, sibling is right
+                sib_idx = current_idx + 1
+                siblings.append({
+                    "hash": padded[sib_idx].hex(),
+                    "position": "right",
+                })
+            else:
+                # Current is right child, sibling is left
+                sib_idx = current_idx - 1
+                siblings.append({
+                    "hash": padded[sib_idx].hex(),
+                    "position": "left",
+                })
+
+            current_idx = current_idx // 2
+
+        return InclusionProof(
+            leaf_hash=self._leaf_hashes[idx].hex(),
+            leaf_index=idx,
+            tree_size=self.leaf_count,
+            root_hash=self.root_hex,
+            siblings=siblings,
+        )
+
+
+class OTSCalendarClient:
+    """Async HTTP client for OpenTimestamps calendar servers.
+
+    Submits SHA-256 digests and retrieves timestamp proofs via the
+    OTS calendar HTTP protocol.
+    """
+
+    def __init__(
+        self,
+        calendars: list[str] | None = None,
+        timeout: float = 15.0,
+    ) -> None:
+        self._calendars = calendars or list(DEFAULT_CALENDARS)
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def submit_digest(self, digest: bytes) -> list[dict[str, str]]:
+        """Submit a SHA-256 digest to all configured OTS calendars.
+
+        Posts the raw 32-byte digest to each calendar's ``/digest``
+        endpoint. Returns a list of successful receipt records.
+
+        Never raises — logs failures and returns partial results.
+
+        Args:
+            digest: Raw 32-byte SHA-256 digest.
+
+        Returns:
+            List of ``{"calendar": url, "receipt_b64": base64_receipt}``
+            for each successful submission.
+        """
+        results: list[dict[str, str]] = []
+
+        for calendar in self._calendars:
+            url = f"{calendar.rstrip('/')}/digest"
+            try:
+                resp = await self._client.post(
+                    url,
+                    content=digest,
+                    headers={
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Accept": "application/vnd.opentimestamps.v1",
+                    },
+                )
+                if resp.status_code == 200:
+                    receipt_b64 = base64.b64encode(resp.content).decode("ascii")
+                    results.append({
+                        "calendar": calendar,
+                        "receipt_b64": receipt_b64,
+                    })
+                    logger.info("OTS digest submitted to %s (receipt: %d bytes)", calendar, len(resp.content))
+                else:
+                    logger.warning(
+                        "OTS calendar %s returned HTTP %d: %s",
+                        calendar, resp.status_code, resp.text[:200],
+                    )
+            except Exception as exc:
+                logger.warning("OTS calendar %s unreachable: %s", calendar, exc)
+
+        return results
+
+    async def upgrade_receipt(
+        self,
+        commitment_hex: str,
+        calendar_url: str,
+    ) -> bytes | None:
+        """Attempt to upgrade an OTS receipt to a Bitcoin-confirmed proof.
+
+        Args:
+            commitment_hex: The hex-encoded commitment (Merkle root).
+            calendar_url: The calendar server that issued the receipt.
+
+        Returns:
+            Upgraded proof bytes on success, None if not yet confirmed (404).
+        """
+        url = f"{calendar_url.rstrip('/')}/timestamp/{commitment_hex}"
+        try:
+            resp = await self._client.get(
+                url,
+                headers={"Accept": "application/vnd.opentimestamps.v1"},
+            )
+            if resp.status_code == 200:
+                return resp.content
+            if resp.status_code == 404:
+                return None
+            logger.warning(
+                "OTS upgrade from %s returned HTTP %d",
+                calendar_url, resp.status_code,
+            )
+            return None
+        except Exception as exc:
+            logger.warning("OTS upgrade from %s failed: %s", calendar_url, exc)
+            return None
+
+    async def close(self) -> None:
+        """Close the underlying httpx client."""
+        await self._client.aclose()

--- a/src/tollbooth/tools/__init__.py
+++ b/src/tollbooth/tools/__init__.py
@@ -1,5 +1,15 @@
-"""Tollbooth credit management tools."""
+"""Tollbooth credit management and anchoring tools."""
 
 from tollbooth.tools.credits import reconcile_pending_invoices
+from tollbooth.tools.anchors import (
+    anchor_ledger_tool,
+    get_anchor_proof_tool,
+    list_anchors_tool,
+)
 
-__all__ = ["reconcile_pending_invoices"]
+__all__ = [
+    "reconcile_pending_invoices",
+    "anchor_ledger_tool",
+    "get_anchor_proof_tool",
+    "list_anchors_tool",
+]

--- a/src/tollbooth/tools/anchors.py
+++ b/src/tollbooth/tools/anchors.py
@@ -1,0 +1,228 @@
+"""Bitcoin anchoring tools: anchor_ledger, get_anchor_proof, list_anchors.
+
+These tools periodically commit a Merkle root of all ledger balances to
+Bitcoin via OpenTimestamps. Patrons can independently verify their balance
+was included in a Bitcoin-committed hash.
+
+Zero hot-path impact — fully decoupled from credit tool calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from tollbooth.ots import MerkleTree, OTSCalendarClient
+
+logger = logging.getLogger(__name__)
+
+
+async def anchor_ledger_tool(
+    vault: Any,
+    ots_calendars: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a Merkle tree of all ledger balances and submit to OTS calendars.
+
+    Fetches all balances from the vault, builds a SHA-256 Merkle tree,
+    submits the root to OTS calendar servers, and stores the anchor
+    record in the vault.
+
+    Args:
+        vault: A NeonVault instance (must have fetch_all_balances, store_anchor).
+        ots_calendars: Optional list of OTS calendar URLs. Uses defaults if None.
+
+    Returns:
+        Anchor record with root_hash, leaf_count, receipts, and anchor_id.
+    """
+    # Fetch all balances from NeonVault
+    try:
+        entries = await vault.fetch_all_balances()
+    except Exception as e:
+        return {"success": False, "error": f"Failed to fetch balances: {e}"}
+
+    if not entries:
+        return {"success": False, "error": "No balances found — nothing to anchor."}
+
+    # Build Merkle tree
+    tree = MerkleTree(entries)
+    root_hex = tree.root_hex
+    leaf_count = tree.leaf_count
+
+    # Submit to OTS calendars
+    ots = OTSCalendarClient(calendars=ots_calendars)
+    try:
+        receipts = await ots.submit_digest(tree.root)
+    finally:
+        await ots.close()
+
+    # Build snapshot summary (npub → balance, no full ledger_json)
+    snapshot: dict[str, Any] = {
+        "entry_count": len(entries),
+        "npubs": [npub for npub, _ in sorted(entries, key=lambda e: e[0])],
+    }
+
+    # Store anchor record
+    now = datetime.now(timezone.utc)
+    try:
+        anchor_id = await vault.store_anchor(
+            root_hash=root_hex,
+            leaf_count=leaf_count,
+            status="submitted" if receipts else "no_receipts",
+            ots_receipts_json=json.dumps(receipts) if receipts else None,
+            snapshot_json=json.dumps(snapshot),
+            leaf_hashes_json=json.dumps(tree.get_leaf_hashes()),
+            created_at=now.isoformat(),
+        )
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Anchor computed but failed to store: {e}",
+            "root_hash": root_hex,
+            "leaf_count": leaf_count,
+            "receipts": len(receipts),
+        }
+
+    return {
+        "success": True,
+        "anchor_id": anchor_id,
+        "root_hash": root_hex,
+        "leaf_count": leaf_count,
+        "calendars_submitted": len(receipts),
+        "calendars_attempted": len(ots._calendars),
+        "status": "submitted" if receipts else "no_receipts",
+        "created_at": now.isoformat(),
+        "message": (
+            f"Anchored {leaf_count} ledger balances. "
+            f"Merkle root: {root_hex[:16]}... "
+            f"Submitted to {len(receipts)}/{len(ots._calendars)} OTS calendars. "
+            f"Bitcoin confirmation expected in 1-6 hours."
+        ),
+    }
+
+
+async def get_anchor_proof_tool(
+    vault: Any,
+    anchor_id: str,
+    npub: str,
+) -> dict[str, Any]:
+    """Generate a Merkle inclusion proof for a patron's balance in an anchor.
+
+    Reconstructs the Merkle tree from stored leaf hashes and generates
+    an inclusion proof for the specified npub.
+
+    Args:
+        vault: A NeonVault instance (must have fetch_anchor).
+        anchor_id: The anchor record ID.
+        npub: The patron's Nostr public key.
+
+    Returns:
+        Inclusion proof with verification guide, or error if not found.
+    """
+    try:
+        anchor = await vault.fetch_anchor(anchor_id)
+    except Exception as e:
+        return {"success": False, "error": f"Failed to fetch anchor: {e}"}
+
+    if not anchor:
+        return {"success": False, "error": f"Anchor {anchor_id} not found."}
+
+    # Reconstruct tree from stored leaf hashes
+    try:
+        leaf_hashes = json.loads(anchor["leaf_hashes_json"])
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        return {"success": False, "error": f"Failed to parse leaf hashes: {e}"}
+
+    tree = MerkleTree.from_leaf_hashes(leaf_hashes)
+
+    # Verify reconstructed root matches stored root
+    if tree.root_hex != anchor["root_hash"]:
+        return {
+            "success": False,
+            "error": "Integrity error: reconstructed root does not match stored root.",
+        }
+
+    # Generate inclusion proof
+    proof = tree.get_proof(npub)
+    if proof is None:
+        return {
+            "success": False,
+            "error": f"npub {npub} not found in anchor {anchor_id}.",
+        }
+
+    if not proof.verify():
+        return {
+            "success": False,
+            "error": "Internal error: generated proof fails verification.",
+        }
+
+    return {
+        "success": True,
+        "anchor_id": anchor_id,
+        "root_hash": anchor["root_hash"],
+        "anchor_status": anchor.get("status", "unknown"),
+        "anchor_created_at": anchor.get("created_at"),
+        "proof": proof.to_dict(),
+        "verified": True,
+        "verification_guide": (
+            "This proof demonstrates that your balance (identified by npub) "
+            "was included in a Merkle tree whose root was submitted to Bitcoin "
+            "via OpenTimestamps. To independently verify:\n\n"
+            "1. Recompute: leaf_hash = SHA256(your_npub + ':' + SHA256(your_ledger_json))\n"
+            "2. Walk the sibling path: for each sibling, concatenate in the specified "
+            "position (left/right) and SHA256 the result\n"
+            "3. The final hash should equal root_hash\n"
+            "4. The root_hash was submitted to OTS calendars and will be anchored "
+            "in a Bitcoin block header via OpenTimestamps"
+        ),
+    }
+
+
+async def list_anchors_tool(
+    vault: Any,
+    limit: int = 20,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """List recent anchor records.
+
+    Args:
+        vault: A NeonVault instance (must have list_anchors).
+        limit: Maximum number of anchors to return (default 20).
+        status: Optional filter by status (e.g., "submitted", "confirmed").
+
+    Returns:
+        List of anchor summaries.
+    """
+    try:
+        anchors = await vault.list_anchors(limit=limit, status=status)
+    except Exception as e:
+        return {"success": False, "error": f"Failed to list anchors: {e}"}
+
+    items: list[dict[str, Any]] = []
+    for a in anchors:
+        item: dict[str, Any] = {
+            "anchor_id": str(a["id"]),
+            "root_hash": a["root_hash"],
+            "leaf_count": a["leaf_count"],
+            "status": a["status"],
+            "created_at": a.get("created_at"),
+        }
+        if a.get("confirmed_at"):
+            item["confirmed_at"] = a["confirmed_at"]
+        # Include receipt count if available
+        if a.get("ots_receipts_json"):
+            try:
+                receipts = json.loads(a["ots_receipts_json"])
+                item["receipt_count"] = len(receipts)
+            except (json.JSONDecodeError, TypeError):
+                item["receipt_count"] = 0
+        else:
+            item["receipt_count"] = 0
+        items.append(item)
+
+    return {
+        "success": True,
+        "count": len(items),
+        "anchors": items,
+    }

--- a/src/tollbooth/vaults/neon.py
+++ b/src/tollbooth/vaults/neon.py
@@ -236,6 +236,131 @@ class NeonVault:
             "CREATE INDEX IF NOT EXISTS idx_transactions_created "
             "ON transactions(created_at)"
         )
+        # -- Anchors table (OTS Bitcoin anchoring) --
+        await self._execute(
+            "CREATE TABLE IF NOT EXISTS anchors ("
+            "    id BIGSERIAL PRIMARY KEY,"
+            "    root_hash TEXT NOT NULL UNIQUE,"
+            "    leaf_count INTEGER NOT NULL,"
+            "    status TEXT NOT NULL DEFAULT 'pending',"
+            "    ots_receipts_json TEXT,"
+            "    snapshot_json TEXT NOT NULL,"
+            "    leaf_hashes_json TEXT NOT NULL,"
+            "    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+            "    confirmed_at TIMESTAMPTZ"
+            ")"
+        )
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_anchors_created "
+            "ON anchors(created_at)"
+        )
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_anchors_status "
+            "ON anchors(status)"
+        )
+
+    # -- Anchor operations ---------------------------------------------------
+
+    async def fetch_all_balances(self) -> list[tuple[str, str]]:
+        """Fetch all (npub, ledger_json) pairs, sorted by npub.
+
+        Used by the OTS anchoring system to build a Merkle tree of all
+        ledger balances.
+        """
+        result = await self._execute(
+            "SELECT npub, ledger_json FROM balances ORDER BY npub"
+        )
+        rows = result.get("rows", [])
+        return [(row["npub"], row["ledger_json"]) for row in rows]
+
+    async def store_anchor(
+        self,
+        root_hash: str,
+        leaf_count: int,
+        status: str,
+        ots_receipts_json: str | None,
+        snapshot_json: str,
+        leaf_hashes_json: str,
+        created_at: str,
+    ) -> str:
+        """Store an anchor record. Returns the anchor ID as a string."""
+        result = await self._execute(
+            "INSERT INTO anchors "
+            "(root_hash, leaf_count, status, ots_receipts_json, "
+            " snapshot_json, leaf_hashes_json, created_at) "
+            "VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz) "
+            "RETURNING id",
+            [root_hash, leaf_count, status, ots_receipts_json,
+             snapshot_json, leaf_hashes_json, created_at],
+        )
+        rows = result.get("rows", [])
+        if rows:
+            return str(rows[0]["id"])
+        raise NeonQueryError("INSERT anchor returned no rows")
+
+    async def fetch_anchor(self, anchor_id: str) -> dict[str, Any] | None:
+        """Fetch a single anchor record by ID."""
+        result = await self._execute(
+            "SELECT id, root_hash, leaf_count, status, ots_receipts_json, "
+            "snapshot_json, leaf_hashes_json, created_at, confirmed_at "
+            "FROM anchors WHERE id = $1",
+            [int(anchor_id)],
+        )
+        rows = result.get("rows", [])
+        return rows[0] if rows else None
+
+    async def list_anchors(
+        self,
+        limit: int = 20,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List recent anchor records, optionally filtered by status."""
+        if status:
+            result = await self._execute(
+                "SELECT id, root_hash, leaf_count, status, ots_receipts_json, "
+                "created_at, confirmed_at "
+                "FROM anchors WHERE status = $1 "
+                "ORDER BY created_at DESC LIMIT $2",
+                [status, limit],
+            )
+        else:
+            result = await self._execute(
+                "SELECT id, root_hash, leaf_count, status, ots_receipts_json, "
+                "created_at, confirmed_at "
+                "FROM anchors ORDER BY created_at DESC LIMIT $1",
+                [limit],
+            )
+        return result.get("rows", [])
+
+    async def update_anchor_status(
+        self,
+        anchor_id: str,
+        status: str,
+        confirmed_at: str | None = None,
+    ) -> None:
+        """Update an anchor's status (e.g., 'submitted' → 'confirmed')."""
+        if confirmed_at:
+            await self._execute(
+                "UPDATE anchors SET status = $1, confirmed_at = $2::timestamptz "
+                "WHERE id = $3",
+                [status, confirmed_at, int(anchor_id)],
+            )
+        else:
+            await self._execute(
+                "UPDATE anchors SET status = $1 WHERE id = $2",
+                [status, int(anchor_id)],
+            )
+
+    async def update_anchor_receipts(
+        self,
+        anchor_id: str,
+        ots_receipts_json: str,
+    ) -> None:
+        """Update an anchor's OTS receipts (e.g., after upgrade)."""
+        await self._execute(
+            "UPDATE anchors SET ots_receipts_json = $1 WHERE id = $2",
+            [ots_receipts_json, int(anchor_id)],
+        )
 
     # -- Helpers -------------------------------------------------------------
 

--- a/tests/test_neon_vault.py
+++ b/tests/test_neon_vault.py
@@ -319,7 +319,7 @@ class TestEnsureSchema:
             return_value=_response(200, _sql_result(rows=[], command="CREATE"))
         )
         await vault.ensure_schema()
-        assert vault._client.post.call_count == 4  # 2 tables + 2 indexes
+        assert vault._client.post.call_count == 7  # 3 tables + 4 indexes
 
     @pytest.mark.asyncio
     async def test_schema_statements_use_if_not_exists(self) -> None:

--- a/tests/test_ots.py
+++ b/tests/test_ots.py
@@ -1,0 +1,533 @@
+"""Tests for OpenTimestamps Bitcoin anchoring: MerkleTree, InclusionProof, OTSCalendarClient, anchor tools."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from tollbooth.ots import (
+    DEFAULT_CALENDARS,
+    InclusionProof,
+    MerkleTree,
+    OTSCalendarClient,
+    _sha256,
+)
+from tollbooth.tools.anchors import (
+    anchor_ledger_tool,
+    get_anchor_proof_tool,
+    list_anchors_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# MerkleTree tests
+# ---------------------------------------------------------------------------
+
+class TestMerkleTree:
+    """Tests for MerkleTree construction, determinism, and proof generation."""
+
+    def _make_entries(self, n: int) -> list[tuple[str, str]]:
+        """Generate n deterministic (npub, ledger_json) pairs."""
+        return [(f"npub1{'a' * i}{chr(97 + i)}", f'{{"balance": {i * 100}}}') for i in range(n)]
+
+    def test_single_leaf(self):
+        entries = self._make_entries(1)
+        tree = MerkleTree(entries)
+        assert tree.leaf_count == 1
+        assert len(tree.root) == 32
+        assert len(tree.root_hex) == 64
+
+    def test_two_leaves(self):
+        entries = self._make_entries(2)
+        tree = MerkleTree(entries)
+        assert tree.leaf_count == 2
+        assert len(tree.root) == 32
+
+    def test_three_leaves_odd_duplication(self):
+        entries = self._make_entries(3)
+        tree = MerkleTree(entries)
+        assert tree.leaf_count == 3
+        assert len(tree.root) == 32
+
+    def test_four_leaves(self):
+        entries = self._make_entries(4)
+        tree = MerkleTree(entries)
+        assert tree.leaf_count == 4
+
+    def test_hundred_leaves(self):
+        entries = [(f"npub1user{i:04d}", f'{{"balance": {i}}}') for i in range(100)]
+        tree = MerkleTree(entries)
+        assert tree.leaf_count == 100
+        assert len(tree.root) == 32
+
+    def test_empty_tree(self):
+        tree = MerkleTree([])
+        assert tree.leaf_count == 0
+        assert tree.root == b""
+        assert tree.root_hex == ""
+
+    def test_deterministic_ordering(self):
+        """Tree should produce the same root regardless of input order."""
+        entries = self._make_entries(5)
+        tree1 = MerkleTree(entries)
+        tree2 = MerkleTree(list(reversed(entries)))
+        assert tree1.root_hex == tree2.root_hex
+
+    def test_leaf_hash_computation(self):
+        """Verify leaf = SHA256(npub + ":" + SHA256(ledger_json))."""
+        npub = "npub1test"
+        ledger = '{"balance": 500}'
+        tree = MerkleTree([(npub, ledger)])
+
+        inner = hashlib.sha256(ledger.encode()).digest()
+        expected = hashlib.sha256(npub.encode() + b":" + inner).digest()
+        assert tree._leaf_hashes[0] == expected
+
+    def test_get_leaf_hashes_roundtrip(self):
+        """Build tree → export leaf hashes → rebuild → same root."""
+        entries = self._make_entries(7)
+        original = MerkleTree(entries)
+        exported = original.get_leaf_hashes()
+
+        rebuilt = MerkleTree.from_leaf_hashes(exported)
+        assert rebuilt.root_hex == original.root_hex
+        assert rebuilt.leaf_count == original.leaf_count
+
+    def test_get_leaf_hashes_large_roundtrip(self):
+        """Roundtrip with 100 leaves."""
+        entries = [(f"npub1user{i:04d}", f'{{"balance": {i}}}') for i in range(100)]
+        original = MerkleTree(entries)
+        exported = original.get_leaf_hashes()
+        rebuilt = MerkleTree.from_leaf_hashes(exported)
+        assert rebuilt.root_hex == original.root_hex
+
+    def test_different_data_different_root(self):
+        """Different entries must produce different roots."""
+        tree1 = MerkleTree([("npub1a", '{"x": 1}')])
+        tree2 = MerkleTree([("npub1a", '{"x": 2}')])
+        assert tree1.root_hex != tree2.root_hex
+
+
+# ---------------------------------------------------------------------------
+# InclusionProof tests
+# ---------------------------------------------------------------------------
+
+class TestInclusionProof:
+    """Tests for InclusionProof verification."""
+
+    def _make_entries(self, n: int) -> list[tuple[str, str]]:
+        return [(f"npub1user{i:04d}", f'{{"balance": {i * 100}}}') for i in range(n)]
+
+    def test_verify_all_leaves_two(self):
+        entries = self._make_entries(2)
+        tree = MerkleTree(entries)
+        sorted_npubs = sorted(e[0] for e in entries)
+        for npub in sorted_npubs:
+            proof = tree.get_proof(npub)
+            assert proof is not None
+            assert proof.verify() is True
+
+    def test_verify_all_leaves_four(self):
+        entries = self._make_entries(4)
+        tree = MerkleTree(entries)
+        for npub, _ in entries:
+            proof = tree.get_proof(npub)
+            assert proof is not None
+            assert proof.verify() is True
+
+    def test_verify_all_leaves_odd(self):
+        """Verify proofs for a 5-leaf tree (odd count)."""
+        entries = self._make_entries(5)
+        tree = MerkleTree(entries)
+        for npub, _ in entries:
+            proof = tree.get_proof(npub)
+            assert proof is not None
+            assert proof.verify() is True
+
+    def test_verify_all_leaves_large(self):
+        """Verify proofs for a 50-leaf tree."""
+        entries = [(f"npub1user{i:04d}", f'{{"balance": {i}}}') for i in range(50)]
+        tree = MerkleTree(entries)
+        for npub, _ in entries:
+            proof = tree.get_proof(npub)
+            assert proof is not None, f"No proof for {npub}"
+            assert proof.verify() is True, f"Proof failed for {npub}"
+
+    def test_verify_single_leaf(self):
+        """Single-leaf tree: proof has no siblings."""
+        tree = MerkleTree([("npub1only", '{"x": 1}')])
+        proof = tree.get_proof("npub1only")
+        assert proof is not None
+        assert proof.siblings == []
+        assert proof.verify() is True
+
+    def test_tampered_root_fails(self):
+        entries = self._make_entries(4)
+        tree = MerkleTree(entries)
+        proof = tree.get_proof(entries[0][0])
+        assert proof is not None
+        # Tamper with root
+        bad_proof = InclusionProof(
+            leaf_hash=proof.leaf_hash,
+            leaf_index=proof.leaf_index,
+            tree_size=proof.tree_size,
+            root_hash="00" * 32,
+            siblings=proof.siblings,
+        )
+        assert bad_proof.verify() is False
+
+    def test_tampered_sibling_fails(self):
+        entries = self._make_entries(4)
+        tree = MerkleTree(entries)
+        proof = tree.get_proof(entries[0][0])
+        assert proof is not None
+        assert len(proof.siblings) > 0
+        # Tamper with first sibling
+        bad_siblings = list(proof.siblings)
+        bad_siblings[0] = {"hash": "ff" * 32, "position": bad_siblings[0]["position"]}
+        bad_proof = InclusionProof(
+            leaf_hash=proof.leaf_hash,
+            leaf_index=proof.leaf_index,
+            tree_size=proof.tree_size,
+            root_hash=proof.root_hash,
+            siblings=bad_siblings,
+        )
+        assert bad_proof.verify() is False
+
+    def test_proof_not_found(self):
+        tree = MerkleTree([("npub1a", '{"x": 1}')])
+        assert tree.get_proof("npub1nonexistent") is None
+
+    def test_to_dict(self):
+        tree = MerkleTree([("npub1a", '{"x": 1}'), ("npub1b", '{"x": 2}')])
+        proof = tree.get_proof("npub1a")
+        assert proof is not None
+        d = proof.to_dict()
+        assert "leaf_hash" in d
+        assert "leaf_index" in d
+        assert "tree_size" in d
+        assert "root_hash" in d
+        assert "siblings" in d
+        assert d["tree_size"] == 2
+
+
+# ---------------------------------------------------------------------------
+# OTSCalendarClient tests
+# ---------------------------------------------------------------------------
+
+class TestOTSCalendarClient:
+    """Tests for OTSCalendarClient HTTP interactions (mocked)."""
+
+    @pytest.mark.asyncio
+    async def test_submit_digest_success(self):
+        """All calendars return 200 — all receipts collected."""
+        fake_receipt = b"\x00\x01\x02\x03"
+        client = OTSCalendarClient(calendars=["https://cal1.test", "https://cal2.test"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = fake_receipt
+
+        with patch.object(client._client, "post", new_callable=AsyncMock, return_value=mock_response):
+            digest = _sha256(b"test data")
+            results = await client.submit_digest(digest)
+
+        assert len(results) == 2
+        for r in results:
+            assert "calendar" in r
+            assert "receipt_b64" in r
+            assert base64.b64decode(r["receipt_b64"]) == fake_receipt
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_submit_digest_partial_failure(self):
+        """One calendar fails, one succeeds — partial results returned."""
+        fake_receipt = b"\x00\x01"
+        client = OTSCalendarClient(calendars=["https://cal1.test", "https://cal2.test"])
+
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        success_resp.content = fake_receipt
+
+        fail_resp = MagicMock()
+        fail_resp.status_code = 500
+        fail_resp.text = "Internal Server Error"
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock,
+            side_effect=[fail_resp, success_resp],
+        ):
+            results = await client.submit_digest(_sha256(b"test"))
+
+        assert len(results) == 1
+        assert results[0]["calendar"] == "https://cal2.test"
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_submit_digest_all_fail(self):
+        """All calendars fail — empty list returned, no exception."""
+        client = OTSCalendarClient(calendars=["https://cal1.test"])
+
+        with patch.object(
+            client._client, "post", new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("unreachable"),
+        ):
+            results = await client.submit_digest(_sha256(b"test"))
+
+        assert results == []
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_upgrade_receipt_success(self):
+        """Calendar returns 200 — upgraded proof returned."""
+        upgraded = b"\x10\x20\x30"
+        client = OTSCalendarClient()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = upgraded
+
+        with patch.object(client._client, "get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.upgrade_receipt("abcdef", "https://cal1.test")
+
+        assert result == upgraded
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_upgrade_receipt_not_ready(self):
+        """Calendar returns 404 — None returned (not yet confirmed)."""
+        client = OTSCalendarClient()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch.object(client._client, "get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.upgrade_receipt("abcdef", "https://cal1.test")
+
+        assert result is None
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_upgrade_receipt_network_error(self):
+        """Network error during upgrade — None returned, no exception."""
+        client = OTSCalendarClient()
+
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("unreachable"),
+        ):
+            result = await client.upgrade_receipt("abcdef", "https://cal1.test")
+
+        assert result is None
+        await client.close()
+
+    def test_default_calendars(self):
+        client = OTSCalendarClient()
+        assert client._calendars == DEFAULT_CALENDARS
+
+    def test_custom_calendars(self):
+        custom = ["https://my.calendar.test"]
+        client = OTSCalendarClient(calendars=custom)
+        assert client._calendars == custom
+
+
+# ---------------------------------------------------------------------------
+# Anchor tool tests
+# ---------------------------------------------------------------------------
+
+class TestAnchorLedgerTool:
+    """Tests for anchor_ledger_tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Happy path: fetch balances, build tree, submit, store."""
+        entries = [("npub1alice", '{"balance": 100}'), ("npub1bob", '{"balance": 200}')]
+
+        vault = AsyncMock()
+        vault.fetch_all_balances = AsyncMock(return_value=entries)
+        vault.store_anchor = AsyncMock(return_value="42")
+
+        with patch("tollbooth.tools.anchors.OTSCalendarClient") as MockOTS:
+            mock_ots = AsyncMock()
+            mock_ots.submit_digest = AsyncMock(return_value=[
+                {"calendar": "https://cal1.test", "receipt_b64": "AAEC"},
+            ])
+            mock_ots.close = AsyncMock()
+            mock_ots._calendars = ["https://cal1.test"]
+            MockOTS.return_value = mock_ots
+
+            result = await anchor_ledger_tool(vault, ots_calendars=["https://cal1.test"])
+
+        assert result["success"] is True
+        assert result["anchor_id"] == "42"
+        assert result["leaf_count"] == 2
+        assert result["calendars_submitted"] == 1
+        assert result["status"] == "submitted"
+        assert len(result["root_hash"]) == 64
+
+        # Verify store_anchor was called with correct args
+        vault.store_anchor.assert_called_once()
+        call_kwargs = vault.store_anchor.call_args
+        assert call_kwargs.kwargs["leaf_count"] == 2
+        assert call_kwargs.kwargs["status"] == "submitted"
+
+    @pytest.mark.asyncio
+    async def test_no_balances(self):
+        vault = AsyncMock()
+        vault.fetch_all_balances = AsyncMock(return_value=[])
+        result = await anchor_ledger_tool(vault)
+        assert result["success"] is False
+        assert "nothing to anchor" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_fetch_error(self):
+        vault = AsyncMock()
+        vault.fetch_all_balances = AsyncMock(side_effect=Exception("DB down"))
+        result = await anchor_ledger_tool(vault)
+        assert result["success"] is False
+        assert "DB down" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_ots_receipts(self):
+        """OTS submission fails but anchor is still stored."""
+        entries = [("npub1x", '{"balance": 1}')]
+        vault = AsyncMock()
+        vault.fetch_all_balances = AsyncMock(return_value=entries)
+        vault.store_anchor = AsyncMock(return_value="99")
+
+        with patch("tollbooth.tools.anchors.OTSCalendarClient") as MockOTS:
+            mock_ots = AsyncMock()
+            mock_ots.submit_digest = AsyncMock(return_value=[])
+            mock_ots.close = AsyncMock()
+            mock_ots._calendars = ["https://cal1.test"]
+            MockOTS.return_value = mock_ots
+
+            result = await anchor_ledger_tool(vault)
+
+        assert result["success"] is True
+        assert result["status"] == "no_receipts"
+        assert result["calendars_submitted"] == 0
+
+
+class TestGetAnchorProofTool:
+    """Tests for get_anchor_proof_tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Happy path: fetch anchor, rebuild tree, generate proof."""
+        entries = [("npub1alice", '{"balance": 100}'), ("npub1bob", '{"balance": 200}')]
+        tree = MerkleTree(entries)
+
+        anchor = {
+            "id": 42,
+            "root_hash": tree.root_hex,
+            "leaf_count": 2,
+            "status": "submitted",
+            "leaf_hashes_json": json.dumps(tree.get_leaf_hashes()),
+            "created_at": "2026-02-23T00:00:00+00:00",
+        }
+
+        vault = AsyncMock()
+        vault.fetch_anchor = AsyncMock(return_value=anchor)
+
+        result = await get_anchor_proof_tool(vault, "42", "npub1alice")
+        assert result["success"] is True
+        assert result["verified"] is True
+        assert result["proof"]["root_hash"] == tree.root_hex
+        assert "verification_guide" in result
+
+    @pytest.mark.asyncio
+    async def test_anchor_not_found(self):
+        vault = AsyncMock()
+        vault.fetch_anchor = AsyncMock(return_value=None)
+        result = await get_anchor_proof_tool(vault, "999", "npub1x")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_npub_not_in_anchor(self):
+        tree = MerkleTree([("npub1a", '{"x": 1}')])
+        anchor = {
+            "id": 1,
+            "root_hash": tree.root_hex,
+            "leaf_count": 1,
+            "status": "submitted",
+            "leaf_hashes_json": json.dumps(tree.get_leaf_hashes()),
+        }
+        vault = AsyncMock()
+        vault.fetch_anchor = AsyncMock(return_value=anchor)
+
+        result = await get_anchor_proof_tool(vault, "1", "npub1nonexistent")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_corrupted_leaf_hashes(self):
+        anchor = {
+            "id": 1,
+            "root_hash": "aa" * 32,
+            "leaf_count": 1,
+            "status": "submitted",
+            "leaf_hashes_json": "not valid json",
+        }
+        vault = AsyncMock()
+        vault.fetch_anchor = AsyncMock(return_value=anchor)
+
+        result = await get_anchor_proof_tool(vault, "1", "npub1x")
+        assert result["success"] is False
+        assert "parse" in result["error"].lower() or "failed" in result["error"].lower()
+
+
+class TestListAnchorsTool:
+    """Tests for list_anchors_tool."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        anchors = [
+            {
+                "id": 2, "root_hash": "bb" * 32, "leaf_count": 5,
+                "status": "submitted", "ots_receipts_json": '[{"calendar": "x"}]',
+                "created_at": "2026-02-23T01:00:00+00:00", "confirmed_at": None,
+            },
+            {
+                "id": 1, "root_hash": "aa" * 32, "leaf_count": 3,
+                "status": "confirmed", "ots_receipts_json": None,
+                "created_at": "2026-02-22T00:00:00+00:00",
+                "confirmed_at": "2026-02-22T06:00:00+00:00",
+            },
+        ]
+        vault = AsyncMock()
+        vault.list_anchors = AsyncMock(return_value=anchors)
+
+        result = await list_anchors_tool(vault, limit=10)
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["anchors"][0]["anchor_id"] == "2"
+        assert result["anchors"][0]["receipt_count"] == 1
+        assert result["anchors"][1]["receipt_count"] == 0
+        assert result["anchors"][1]["confirmed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_with_status_filter(self):
+        vault = AsyncMock()
+        vault.list_anchors = AsyncMock(return_value=[])
+
+        result = await list_anchors_tool(vault, status="confirmed")
+        assert result["success"] is True
+        assert result["count"] == 0
+        vault.list_anchors.assert_called_once_with(limit=20, status="confirmed")
+
+    @pytest.mark.asyncio
+    async def test_vault_error(self):
+        vault = AsyncMock()
+        vault.list_anchors = AsyncMock(side_effect=Exception("connection lost"))
+        result = await list_anchors_tool(vault)
+        assert result["success"] is False
+        assert "connection lost" in result["error"]


### PR DESCRIPTION
## Summary

- **Fourth trust layer**: periodically anchors a Merkle root of all ledger balances to Bitcoin via OpenTimestamps
- **Zero new dependencies**: stdlib `hashlib` for Merkle tree, existing `httpx` for OTS calendar HTTP calls
- **New `ots.py`**: `MerkleTree`, `InclusionProof` (verifiable), `OTSCalendarClient` (async, multi-calendar)
- **New `tools/anchors.py`**: `anchor_ledger_tool`, `get_anchor_proof_tool`, `list_anchors_tool`
- **Extended NeonVault**: `anchors` table, `fetch_all_balances`, anchor CRUD methods
- **Extended `TollboothConfig`**: `ots_enabled`, `ots_calendars`
- **39 new tests** (423 total, all passing)
- Version bump: 0.1.22 → 0.1.23

## Test plan

- [x] `MerkleTree`: 1/2/3/4/100-leaf trees, deterministic ordering, odd leaf duplication, empty tree
- [x] `InclusionProof`: verify() succeeds for all leaves, fails on tampered root/siblings
- [x] `MerkleTree.from_leaf_hashes()`: roundtrip — build tree, export, rebuild, same root
- [x] `OTSCalendarClient.submit_digest()`: mock httpx, success + partial failure + all-fail
- [x] `OTSCalendarClient.upgrade_receipt()`: mock 200 and 404 responses
- [x] `anchor_ledger_tool`: mock vault, verify result structure
- [x] `get_anchor_proof_tool`: mock vault, verify proof verifies
- [x] `list_anchors_tool`: mock vault, verify list output
- [x] Existing test suite: 423 tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)