### PR TITLE
Add ToolPricing for dynamic tool cost computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.23"
+version = "0.1.24"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.23"
+__version__ = "0.1.24"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
@@ -12,6 +12,7 @@ from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
+from tollbooth.pricing import ToolPricing
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
 
@@ -36,6 +37,7 @@ __all__ = [
     "TheBrainVault",
     "NeonVault",
     "NeonQueryError",
+    "ToolPricing",
     "ToolTier",
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",

--- a/src/tollbooth/pricing.py
+++ b/src/tollbooth/pricing.py
@@ -1,0 +1,47 @@
+"""Dynamic tool pricing for Tollbooth micropayment gating."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import ceil
+
+
+@dataclass(frozen=True)
+class ToolPricing:
+    """Computes the api_sat cost for a tool call.
+
+    Supports fixed costs, percentage-based costs keyed off a tool parameter,
+    or both combined.
+    """
+
+    fixed: int = 0
+    rate_percent: float = 0.0
+    rate_param: str = ""
+    min_cost: int = 0
+    max_cost: int | None = None
+
+    def compute(self, **params: object) -> int:
+        """Return the api_sat cost given tool call parameters."""
+        cost = self.fixed
+
+        if self.rate_percent > 0 and self.rate_param:
+            if self.rate_param not in params:
+                raise ValueError(
+                    f"Missing required parameter '{self.rate_param}' for rate pricing"
+                )
+            raw = params[self.rate_param]
+            if not isinstance(raw, (int, float)):
+                raise ValueError(
+                    f"Parameter '{self.rate_param}' must be numeric, got {type(raw).__name__}"
+                )
+            amount = float(raw)
+            rate_cost = ceil(amount * self.rate_percent / 100) if amount > 0 else 0
+            rate_cost = max(rate_cost, self.min_cost)
+            cost += rate_cost
+        else:
+            cost = max(cost, self.min_cost)
+
+        if self.max_cost is not None:
+            cost = min(cost, self.max_cost)
+
+        return cost

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,94 @@
+"""Tests for ToolPricing."""
+
+import pytest
+
+from tollbooth.pricing import ToolPricing
+from tollbooth.constants import ToolTier
+
+
+class TestFixedPricing:
+    def test_fixed_only(self):
+        assert ToolPricing(fixed=5).compute() == 5
+
+    def test_fixed_zero(self):
+        assert ToolPricing(fixed=0).compute() == 0
+
+    def test_fixed_with_min_cost(self):
+        assert ToolPricing(fixed=1, min_cost=5).compute() == 5
+
+    def test_fixed_above_min_cost(self):
+        assert ToolPricing(fixed=10, min_cost=5).compute() == 10
+
+    def test_composable_with_tool_tier(self):
+        p = ToolPricing(fixed=ToolTier.WRITE)
+        assert p.compute() == 5
+
+
+class TestRatePricing:
+    def test_rate_only(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount_sats", min_cost=10)
+        assert p.compute(amount_sats=50_000) == 1000
+
+    def test_rate_with_min_cost_enforcement(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount_sats", min_cost=10)
+        # 2% of 100 = 2, below min_cost of 10
+        assert p.compute(amount_sats=100) == 10
+
+    def test_rate_with_max_cost_cap(self):
+        p = ToolPricing(rate_percent=10.0, rate_param="size", max_cost=50)
+        # 10% of 1000 = 100, capped at 50
+        assert p.compute(size=1000) == 50
+
+    def test_rate_rounds_up(self):
+        p = ToolPricing(rate_percent=3.0, rate_param="amount")
+        # 3% of 10 = 0.3, ceil → 1
+        assert p.compute(amount=10) == 1
+
+    def test_zero_amount_returns_min(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount", min_cost=10)
+        assert p.compute(amount=0) == 10
+
+    def test_negative_amount_returns_min(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount", min_cost=5)
+        assert p.compute(amount=-100) == 5
+
+
+class TestHybridPricing:
+    def test_fixed_plus_rate(self):
+        p = ToolPricing(fixed=5, rate_percent=1.0, rate_param="size")
+        # fixed 5 + 1% of 1000 = 5 + 10 = 15
+        assert p.compute(size=1000) == 15
+
+    def test_fixed_plus_rate_with_max(self):
+        p = ToolPricing(fixed=5, rate_percent=10.0, rate_param="size", max_cost=20)
+        # fixed 5 + 10% of 1000 = 105, capped at 20
+        assert p.compute(size=1000) == 20
+
+    def test_fixed_plus_rate_with_min(self):
+        p = ToolPricing(fixed=5, rate_percent=1.0, rate_param="size", min_cost=15)
+        # 1% of 100 = 1, below min 15, so rate_cost = 15, total = 5 + 15 = 20
+        assert p.compute(size=100) == 20
+
+
+class TestValidation:
+    def test_missing_param_raises(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount_sats")
+        with pytest.raises(ValueError, match="Missing required parameter"):
+            p.compute()
+
+    def test_non_numeric_param_raises(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount_sats")
+        with pytest.raises(ValueError, match="must be numeric"):
+            p.compute(amount_sats="not_a_number")
+
+    def test_none_param_raises(self):
+        p = ToolPricing(rate_percent=2.0, rate_param="amount_sats")
+        with pytest.raises(ValueError, match="must be numeric"):
+            p.compute(amount_sats=None)
+
+
+class TestImmutability:
+    def test_frozen(self):
+        p = ToolPricing(fixed=5)
+        with pytest.raises(AttributeError):
+            p.fixed = 10  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Adds `ToolPricing` frozen dataclass in `src/tollbooth/pricing.py` supporting fixed, percentage-based, and hybrid (fixed + rate) tool pricing
- Min/max cost enforcement, input validation, composable with existing `ToolTier` enum
- Exported from `tollbooth.__init__` — `from tollbooth import ToolPricing` works
- Version bump to 0.1.24

## Motivation
The Authority refactor (TheBrain task `cff1a573`) needs `certify_credits` to charge a dynamic fee proportional to `amount_sats`. This PR provides the general-purpose pricing primitive.

## What's NOT changed
- `ledger.py` — debit API unchanged; servers call `ToolPricing.compute()` then pass the result to `debit()`
- `config.py`, `constants.py`, `tools/credits.py`, vault code — untouched

## Test plan
- [x] 18 new tests in `tests/test_pricing.py` covering fixed, rate, hybrid, min/max, validation, immutability
- [x] Full suite passes: 441 tests in 7.84s
- [x] `from tollbooth import ToolPricing` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)