### PR TITLE
Fix SSL cert verification bypass in Nostr relay connections

### DIFF
--- a/demos/demo_nostr_audit.py
+++ b/demos/demo_nostr_audit.py
@@ -18,8 +18,8 @@ After running, verify events on a relay:
 import asyncio
 import json
 import os
-import ssl
 import sys
+from typing import Any
 import time
 
 from tollbooth import UserLedger
@@ -139,7 +139,7 @@ async def main() -> None:
             ["REQ", "demo-verify", {"kinds": [30078], "#t": ["tollbooth-audit"], "limit": 5}]
         )
         print(f"  Connecting to {relay}...")
-        sslopt = {"cert_reqs": ssl.CERT_NONE}
+        sslopt: dict[str, Any] = {}
         ws = create_connection(relay, timeout=10, sslopt=sslopt)
         try:
             ws.send(sub_filter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.24"
+version = "0.1.25"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.24"
+__version__ = "0.1.25"
 
 from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/nostr_audit.py
+++ b/src/tollbooth/nostr_audit.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import logging
-import ssl
 import threading
 import time
 from typing import Any
@@ -212,7 +211,7 @@ class NostrAuditPublisher:
 
     def _publish_to_relays(self, message: str) -> None:
         """Send event to all configured relays. Catches all exceptions."""
-        sslopt = {"cert_reqs": ssl.CERT_NONE}
+        sslopt: dict[str, Any] = {}
         for relay_url in self._relays:
             try:
                 ws = create_connection(relay_url, timeout=10, sslopt=sslopt)

--- a/tests/test_nostr_audit.py
+++ b/tests/test_nostr_audit.py
@@ -369,3 +369,35 @@ class TestEventContent:
 
             content = json.loads(MockEvent.call_args.kwargs["content"])
             assert content["event_type"] == "snapshot"
+
+
+# ---------------------------------------------------------------------------
+# SSL certificate verification
+# ---------------------------------------------------------------------------
+
+
+class TestSSLCertVerification:
+    @patch("tollbooth.nostr_audit._HAS_PYNOSTR", True)
+    @patch("tollbooth.nostr_audit._HAS_WEBSOCKET", True)
+    def test_sslopt_does_not_disable_cert_verification(self) -> None:
+        """Ensure _publish_to_relays does NOT set cert_reqs to CERT_NONE."""
+        mock_pk = _mock_private_key()
+
+        with (
+            patch("tollbooth.nostr_audit.PrivateKey", create=True) as MockPK,
+            patch("tollbooth.nostr_audit.create_connection", create=True) as mock_ws,
+        ):
+            MockPK.from_nsec.return_value = mock_pk
+            mock_conn = MagicMock()
+            mock_conn.recv.return_value = '["OK"]'
+            mock_ws.return_value = mock_conn
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+            pub._publish_to_relays('["EVENT", {}]')
+
+            # Verify sslopt does NOT contain cert_reqs disabling verification
+            for call in mock_ws.call_args_list:
+                sslopt = call.kwargs.get("sslopt", {})
+                assert "cert_reqs" not in sslopt, (
+                    "sslopt must not disable SSL certificate verification"
+                )


### PR DESCRIPTION
## Summary
- Remove `ssl.CERT_NONE` from websocket `sslopt` in `nostr_audit.py` and `demo_nostr_audit.py`, restoring default SSL certificate verification
- Add test asserting `sslopt` does not contain `cert_reqs` 
- Bump version to 0.1.25

**Security**: C-1 (Critical) — SSL/TLS certificate verification was disabled via `ssl.CERT_NONE`, allowing potential MITM attacks on Nostr relay WebSocket connections. Public relays (damus.io, nos.lol) use valid Let's Encrypt certs. The existing exception handler in `_publish_to_relays` already gracefully skips relays with cert issues.

## Test plan
- [x] New test: `test_sslopt_does_not_disable_cert_verification` asserts no `cert_reqs` in sslopt
- [x] All existing nostr_audit tests pass
- [ ] After merge: tag v0.1.25, wait for PyPI publish before downstream PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)