### PR TITLE
Add Nostr certificate verification (Phase 1 dual-mode)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.25"
+version = "0.1.26"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,11 +26,11 @@ classifiers = [
 dependencies = [
     "httpx==0.28.1",
     "PyJWT[crypto]==2.11.0",
+    "pynostr>=0.6.0",
 ]
 
 [project.optional-dependencies]
 nostr = [
-    "pynostr>=0.6.0",
     "websocket-client>=1.6.0",
 ]
 ots = []  # Reserved — no extra deps needed (uses stdlib hashlib + existing httpx)

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,9 +3,9 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 
-from tollbooth.certificate import CertificateError, verify_certificate, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
+from tollbooth.certificate import CertificateError, verify_certificate, verify_certificate_auto, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -21,6 +21,12 @@ try:
 except ImportError:
     NostrAuditPublisher = None  # type: ignore[assignment,misc]
     AuditedVault = None  # type: ignore[assignment,misc]
+
+try:
+    from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
+except ImportError:
+    verify_nostr_certificate = None  # type: ignore[assignment,misc]
+    NOSTR_CERT_KIND = 30079
 
 __all__ = [
     "CertificateError",
@@ -42,6 +48,9 @@ __all__ = [
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",
     "verify_certificate",
+    "verify_certificate_auto",
+    "verify_nostr_certificate",
+    "NOSTR_CERT_KIND",
     "normalize_public_key",
     "key_fingerprint",
     "UNDERSTOOD_PROTOCOLS",

--- a/src/tollbooth/certificate.py
+++ b/src/tollbooth/certificate.py
@@ -157,6 +157,55 @@ def verify_certificate(
     }
 
 
+def verify_certificate_auto(
+    token: str,
+    authority_public_key: str = "",
+    authority_npub: str = "",
+    *,
+    understood_protocols: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Auto-detect certificate format and verify.
+
+    If *token* looks like JSON (starts with ``{``), it is treated as a Nostr
+    event and verified via Schnorr signature against *authority_npub*.
+    Otherwise it is treated as a JWT and verified via Ed25519 against
+    *authority_public_key*.
+
+    Args:
+        token: JWT string **or** Nostr event JSON string.
+        authority_public_key: Ed25519 public key (PEM or bare base64) for JWT mode.
+        authority_npub: Authority's bech32 npub for Nostr mode.
+        understood_protocols: Protocol identifiers this Operator accepts.
+
+    Returns:
+        Same claims dict as ``verify_certificate()`` and ``verify_nostr_certificate()``.
+
+    Raises:
+        CertificateError: On verification failure or missing key for the detected format.
+    """
+    stripped = token.strip()
+    if stripped.startswith("{"):
+        # Nostr event JSON
+        if not authority_npub:
+            raise CertificateError(
+                "Certificate appears to be a Nostr event but no authority_npub configured."
+            )
+        from tollbooth.nostr_certificate import verify_nostr_certificate
+
+        return verify_nostr_certificate(
+            stripped, authority_npub, understood_protocols=understood_protocols,
+        )
+    else:
+        # JWT
+        if not authority_public_key:
+            raise CertificateError(
+                "Certificate appears to be a JWT but no authority_public_key configured."
+            )
+        return verify_certificate(
+            stripped, authority_public_key, understood_protocols=understood_protocols,
+        )
+
+
 def reset_jti_store() -> None:
     """Reset the JTI store — for testing only."""
     global _jti_store

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -18,7 +18,8 @@ class TollboothConfig:
     tollbooth_royalty_address: str | None = None
     tollbooth_royalty_percent: float = 0.02
     tollbooth_royalty_min_sats: int = 10
-    authority_public_key: str | None = None
+    authority_public_key: str | None = None  # Ed25519 PEM (JWT verification)
+    authority_npub: str | None = None  # Nostr npub (Schnorr verification)
     credit_ttl_seconds: int | None = 604800  # 7 days default, None = never
     flush_batch_size: int = 10
     flush_staleness_secs: float = 120.0

--- a/src/tollbooth/nostr_certificate.py
+++ b/src/tollbooth/nostr_certificate.py
@@ -1,0 +1,163 @@
+"""Authority certificate verification — Nostr event (Schnorr/BIP-340) validation with anti-replay.
+
+Verifies kind 30079 parameterized replaceable events signed by the Authority's
+Nostr key. The Schnorr-native replacement for the Ed25519 JWT path in
+``certificate.py``.
+
+Dependencies: ``pynostr`` (for event parsing and Schnorr verification).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import tollbooth.certificate as _cert_mod
+from tollbooth.certificate import CertificateError, UNDERSTOOD_PROTOCOLS
+
+logger = logging.getLogger(__name__)
+
+NOSTR_CERT_KIND = 30079
+"""NIP-33 parameterized replaceable event kind for tollbooth certificates."""
+
+NOSTR_CERT_TAG = "tollbooth-cert"
+NOSTR_CERT_LABEL = "dpyc.tollbooth"
+
+
+def _get_tag_value(tags: list[list[str]], key: str) -> str | None:
+    """Extract the first value for a given tag key from a Nostr event's tags."""
+    for tag in tags:
+        if len(tag) >= 2 and tag[0] == key:
+            return tag[1]
+    return None
+
+
+def _npub_to_hex(npub: str) -> str:
+    """Convert a bech32 npub to hex pubkey string."""
+    from pynostr.key import PublicKey  # type: ignore[import-untyped]
+
+    return PublicKey.from_npub(npub).hex()
+
+
+def verify_nostr_certificate(
+    event_json: str,
+    authority_npub: str,
+    *,
+    understood_protocols: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Verify a Nostr event certificate signed by the Authority.
+
+    Args:
+        event_json: JSON string of the signed Nostr event.
+        authority_npub: The Authority's npub (bech32) for signature verification.
+        understood_protocols: Protocol identifiers this Operator accepts.
+            Defaults to ``UNDERSTOOD_PROTOCOLS``.
+
+    Returns:
+        Dict with extracted claims: operator_id, amount_sats, tax_paid_sats,
+        net_sats, jti, dpyc_protocol. Same shape as ``verify_certificate()``.
+
+    Raises:
+        CertificateError: On invalid, expired, tampered, or replayed certificates.
+    """
+    try:
+        from pynostr.event import Event  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise CertificateError(
+            f"Missing dependency for Nostr certificate verification: {e}. "
+            "Install with: pip install 'tollbooth-dpyc[nostr]'"
+        ) from e
+
+    # Parse event JSON
+    try:
+        event_dict = json.loads(event_json)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise CertificateError(f"Certificate event is not valid JSON: {e}") from e
+
+    # Construct Event object
+    try:
+        event = Event.from_dict(event_dict)
+    except Exception as e:
+        raise CertificateError(f"Invalid Nostr event structure: {e}") from e
+
+    # 1. Verify Schnorr signature
+    try:
+        if not event.verify():
+            raise CertificateError(
+                "Certificate signature is invalid — possible tampering."
+            )
+    except CertificateError:
+        raise
+    except Exception as e:
+        raise CertificateError(f"Signature verification failed: {e}") from e
+
+    # 2. Verify signer is the expected Authority
+    try:
+        authority_hex = _npub_to_hex(authority_npub)
+    except Exception as e:
+        raise CertificateError(f"Invalid authority npub: {e}") from e
+
+    if event.pubkey != authority_hex:
+        raise CertificateError(
+            "Certificate not signed by registered Authority."
+        )
+
+    # 3. Verify event kind
+    if event.kind != NOSTR_CERT_KIND:
+        raise CertificateError(
+            f"Not a tollbooth certificate event (kind {event.kind}, expected {NOSTR_CERT_KIND})."
+        )
+
+    # 4. Check expiration (NIP-40)
+    expiration_str = _get_tag_value(event.tags, "expiration")
+    if not expiration_str:
+        raise CertificateError("Certificate missing expiration tag.")
+    try:
+        expiration = int(expiration_str)
+    except (ValueError, TypeError) as e:
+        raise CertificateError(f"Invalid expiration tag: {e}") from e
+    if expiration < time.time():
+        raise CertificateError("Certificate has expired.")
+
+    # 5. Extract JTI from d-tag
+    jti = _get_tag_value(event.tags, "d")
+    if not jti:
+        raise CertificateError("Certificate missing d-tag (JTI).")
+
+    # 6. Anti-replay check (shared store with JWT path — access via module
+    #    so reset_jti_store() is visible across both verification paths)
+    if not _cert_mod._jti_store.check_and_record(jti, float(expiration)):
+        raise CertificateError(
+            f"Certificate replay detected — jti {jti} already used."
+        )
+
+    # 7. Extract claims from content
+    try:
+        claims = json.loads(event.content)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise CertificateError(f"Certificate content is not valid JSON: {e}") from e
+
+    # 8. Protocol version check
+    protos = understood_protocols or UNDERSTOOD_PROTOCOLS
+    proto = claims.get("dpyc_protocol")
+    if not proto:
+        raise CertificateError(
+            "Certificate missing dpyc_protocol claim — "
+            "Authority may be running incompatible version"
+        )
+    if proto not in protos:
+        raise CertificateError(
+            f"Unsupported protocol '{proto}'. "
+            f"This Operator supports: {', '.join(sorted(protos))}"
+        )
+
+    return {
+        "operator_id": claims.get("sub", ""),
+        "amount_sats": claims.get("amount_sats", 0),
+        "tax_paid_sats": claims.get("tax_paid_sats", 0),
+        "net_sats": claims.get("net_sats", 0),
+        "jti": jti,
+        "dpyc_protocol": proto,
+    }

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -10,7 +10,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from tollbooth.btcpay_client import BTCPayClient, BTCPayAuthError, BTCPayError
-from tollbooth.certificate import CertificateError, verify_certificate
+from tollbooth.certificate import CertificateError, verify_certificate_auto
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger
 from tollbooth.ledger_cache import LedgerCache
@@ -213,22 +213,28 @@ async def purchase_credits_tool(
     user_id: str,
     amount_sats: int,
     certificate: str,
-    authority_public_key: str,
+    authority_public_key: str = "",
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
     default_credit_ttl_seconds: int | None = None,
+    authority_npub: str = "",
 ) -> dict[str, Any]:
     """Create a BTCPay invoice after verifying an Authority certificate.
 
     For OPERATOR use: the certified purchase flow. Every credit purchase
-    requires a valid Authority-signed Ed25519 JWT certificate. The
-    certificate's net_sats (amount after tax) determines the invoice amount.
+    requires a valid Authority-signed certificate (JWT or Nostr event).
+    The certificate's net_sats (amount after tax) determines the invoice amount.
+
+    Accepts either an Ed25519 JWT (verified via *authority_public_key*) or a
+    Schnorr-signed Nostr event (verified via *authority_npub*). At least one
+    authority key must be configured. Format is auto-detected.
     """
-    # Trust gate — no Authority key means the operator is misconfigured
-    if not authority_public_key:
+    # Trust gate — at least one Authority key must be configured
+    if not authority_public_key and not authority_npub:
         return {
             "success": False,
-            "error": "Operator misconfigured: authority_public_key is required. "
+            "error": "Operator misconfigured: neither authority_public_key nor "
+            "authority_npub is set. "
             "A Tollbooth Operator cannot operate without a trusted Authority.",
         }
 
@@ -236,11 +242,13 @@ async def purchase_credits_tool(
         return {
             "success": False,
             "error": "A valid Authority certificate is required for every credit purchase. "
-            "Call the Authority's certify_purchase tool first.",
+            "Call the Authority's certify_credits tool first.",
         }
 
     try:
-        cert_claims = verify_certificate(certificate, authority_public_key)
+        cert_claims = verify_certificate_auto(
+            certificate, authority_public_key, authority_npub,
+        )
     except CertificateError as e:
         return {"success": False, "error": f"Certificate rejected: {e}"}
 
@@ -812,6 +820,7 @@ async def btcpay_status_tool(
     from tollbooth.certificate import normalize_public_key, key_fingerprint
     authority_config: dict[str, Any] = {
         "public_key_configured": bool(config.authority_public_key),
+        "npub_configured": bool(config.authority_npub),
         "certificate_verification_enabled": False,
     }
     if config.authority_public_key:
@@ -825,6 +834,9 @@ async def btcpay_status_tool(
         except Exception as e:
             authority_config["public_key_valid"] = False
             authority_config["public_key_error"] = str(e)
+    if config.authority_npub:
+        authority_config["authority_npub"] = config.authority_npub
+        authority_config["certificate_verification_enabled"] = True
     result["authority_config"] = authority_config
 
     # Connectivity checks — only if all 3 connection vars present and client available

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -374,7 +374,7 @@ class TestPurchaseWithCertificate:
 
 class TestMandatoryTrust:
     @pytest.mark.asyncio
-    async def test_no_public_key_rejects_purchase(self):
+    async def test_no_authority_key_rejects_purchase(self):
         """Operators cannot operate without a trusted Authority."""
         result = await purchase_credits_tool(
             btcpay=_mock_btcpay(),
@@ -383,12 +383,14 @@ class TestMandatoryTrust:
             amount_sats=1000,
             certificate="some.jwt.token",
             authority_public_key="",
+            authority_npub="",
         )
         assert result["success"] is False
-        assert "authority_public_key is required" in result["error"]
+        assert "authority_public_key" in result["error"]
+        assert "authority_npub" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_empty_certificate_and_empty_key(self):
+    async def test_empty_certificate_and_empty_keys(self):
         """Both missing — operator misconfigured."""
         result = await purchase_credits_tool(
             btcpay=_mock_btcpay(),
@@ -397,6 +399,7 @@ class TestMandatoryTrust:
             amount_sats=1000,
             certificate="",
             authority_public_key="",
+            authority_npub="",
         )
         assert result["success"] is False
-        assert "authority_public_key is required" in result["error"]
+        assert "authority_public_key" in result["error"]

--- a/tests/test_nostr_certificate.py
+++ b/tests/test_nostr_certificate.py
@@ -1,0 +1,415 @@
+"""Tests for Nostr event certificate verification: Schnorr/BIP-340 validation and anti-replay."""
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pynostr.event import Event  # type: ignore[import-untyped]
+from pynostr.key import PrivateKey  # type: ignore[import-untyped]
+
+from tollbooth.certificate import CertificateError, reset_jti_store, verify_certificate_auto
+from tollbooth.nostr_certificate import (
+    NOSTR_CERT_KIND,
+    NOSTR_CERT_LABEL,
+    NOSTR_CERT_TAG,
+    verify_nostr_certificate,
+)
+from tollbooth.ledger import UserLedger
+from tollbooth.ledger_cache import LedgerCache
+from tollbooth.btcpay_client import BTCPayClient
+from tollbooth.tools.credits import purchase_credits_tool
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_jti_store():
+    """Reset the JTI store before each test."""
+    reset_jti_store()
+    yield
+    reset_jti_store()
+
+
+@pytest.fixture()
+def nostr_keypair():
+    """Generate a Nostr keypair for testing."""
+    private_key = PrivateKey()
+    npub = private_key.public_key.bech32()
+    return private_key, npub
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_jti_counter = 0
+
+
+def _sign_nostr_certificate(
+    private_key: PrivateKey,
+    *,
+    operator_id: str = "npub1operator",
+    amount_sats: int = 1000,
+    tax_paid_sats: int = 20,
+    net_sats: int = 980,
+    jti: str | None = None,
+    exp_offset: int = 600,
+    kind: int = NOSTR_CERT_KIND,
+    extra_tags: list[list[str]] | None = None,
+    content_override: str | None = None,
+    include_expiration: bool = True,
+    include_d_tag: bool = True,
+) -> str:
+    """Sign a test Nostr certificate event. Returns JSON string."""
+    global _jti_counter
+    if jti is None:
+        _jti_counter += 1
+        jti = f"nostr-jti-{_jti_counter}-{time.time_ns()}"
+
+    claims = {
+        "sub": operator_id,
+        "amount_sats": amount_sats,
+        "tax_paid_sats": tax_paid_sats,
+        "net_sats": net_sats,
+        "dpyc_protocol": "dpyp-01-base-certificate",
+    }
+
+    content = content_override if content_override is not None else json.dumps(claims)
+    expiration = int(time.time()) + exp_offset
+
+    tags: list[list[str]] = []
+    if include_d_tag:
+        tags.append(["d", jti])
+    tags.append(["p", "deadbeef" * 8])
+    tags.append(["t", NOSTR_CERT_TAG])
+    tags.append(["L", NOSTR_CERT_LABEL])
+    if include_expiration:
+        tags.append(["expiration", str(expiration)])
+    if extra_tags:
+        tags.extend(extra_tags)
+
+    event = Event(
+        kind=kind,
+        content=content,
+        tags=tags,
+        pubkey=private_key.public_key.hex(),
+        created_at=int(time.time()),
+    )
+    event.sign(private_key.hex())
+
+    return json.dumps(event.to_dict())
+
+
+def _mock_btcpay(invoice_response: dict | None = None):
+    client = AsyncMock(spec=BTCPayClient)
+    resp = invoice_response or {"id": "inv-1", "checkoutLink": "https://pay.example.com/inv-1"}
+    client.create_invoice = AsyncMock(return_value=resp)
+    return client
+
+
+def _mock_cache(ledger: UserLedger | None = None):
+    cache = AsyncMock(spec=LedgerCache)
+    cache.get = AsyncMock(return_value=ledger or UserLedger())
+    cache.mark_dirty = MagicMock()
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# verify_nostr_certificate — valid
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyNostrCertificateValid:
+    def test_valid_certificate(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="jti-valid-1")
+        result = verify_nostr_certificate(event_json, npub)
+        assert result["operator_id"] == "npub1operator"
+        assert result["amount_sats"] == 1000
+        assert result["tax_paid_sats"] == 20
+        assert result["net_sats"] == 980
+        assert result["jti"] == "jti-valid-1"
+        assert result["dpyc_protocol"] == "dpyp-01-base-certificate"
+
+    def test_extracts_all_claims(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(
+            private_key,
+            operator_id="npub1custom",
+            amount_sats=5000,
+            tax_paid_sats=100,
+            net_sats=4900,
+            jti="jti-custom-1",
+        )
+        result = verify_nostr_certificate(event_json, npub)
+        assert result["operator_id"] == "npub1custom"
+        assert result["amount_sats"] == 5000
+        assert result["net_sats"] == 4900
+
+
+# ---------------------------------------------------------------------------
+# verify_nostr_certificate — invalid
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyNostrCertificateInvalid:
+    def test_expired_certificate(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, exp_offset=-10, jti="jti-expired")
+        with pytest.raises(CertificateError, match="expired"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_wrong_signer(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        other_key = PrivateKey()
+        event_json = _sign_nostr_certificate(other_key, jti="jti-wrong-signer")
+        with pytest.raises(CertificateError, match="not signed by registered Authority"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_tampered_content(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="jti-tampered")
+        # Tamper with content after signing
+        event_dict = json.loads(event_json)
+        event_dict["content"] = '{"sub":"hacker","amount_sats":999999}'
+        tampered_json = json.dumps(event_dict)
+        with pytest.raises(CertificateError, match="invalid|failed"):
+            verify_nostr_certificate(tampered_json, npub)
+
+    def test_wrong_kind(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, kind=1, jti="jti-wrong-kind")
+        with pytest.raises(CertificateError, match="Not a tollbooth certificate"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_missing_expiration_tag(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(
+            private_key, include_expiration=False, jti="jti-no-exp",
+        )
+        with pytest.raises(CertificateError, match="missing expiration"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_missing_d_tag(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(
+            private_key, include_d_tag=False, jti="jti-no-d-tag",
+        )
+        with pytest.raises(CertificateError, match="missing d-tag"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_invalid_json(self, nostr_keypair):
+        _, npub = nostr_keypair
+        with pytest.raises(CertificateError, match="not valid JSON"):
+            verify_nostr_certificate("not json at all", npub)
+
+    def test_invalid_content_json(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(
+            private_key, content_override="not json", jti="jti-bad-content",
+        )
+        with pytest.raises(CertificateError, match="content is not valid JSON"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_invalid_authority_npub(self, nostr_keypair):
+        private_key, _ = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="jti-bad-npub")
+        with pytest.raises(CertificateError, match="Invalid authority npub"):
+            verify_nostr_certificate(event_json, "not-an-npub")
+
+
+# ---------------------------------------------------------------------------
+# Anti-replay (JTI via d-tag)
+# ---------------------------------------------------------------------------
+
+
+class TestNostrAntiReplay:
+    def test_duplicate_jti_rejected(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="jti-nostr-dup")
+        verify_nostr_certificate(event_json, npub)
+        # Same JTI again — replay
+        event_json2 = _sign_nostr_certificate(private_key, jti="jti-nostr-dup")
+        with pytest.raises(CertificateError, match="replay"):
+            verify_nostr_certificate(event_json2, npub)
+
+    def test_different_jti_accepted(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json1 = _sign_nostr_certificate(private_key, jti="jti-nostr-a")
+        event_json2 = _sign_nostr_certificate(private_key, jti="jti-nostr-b")
+        verify_nostr_certificate(event_json1, npub)
+        verify_nostr_certificate(event_json2, npub)  # should not raise
+
+    def test_jwt_and_nostr_share_jti_store(self, nostr_keypair):
+        """JTI store is shared — a JTI used by JWT blocks the same JTI in Nostr."""
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives import serialization
+        from tollbooth.certificate import verify_certificate
+
+        # First: verify a JWT with jti "shared-jti"
+        ed_key = Ed25519PrivateKey.generate()
+        ed_pub = ed_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        jwt_claims = {
+            "sub": "op-1",
+            "amount_sats": 1000,
+            "tax_paid_sats": 20,
+            "net_sats": 980,
+            "jti": "shared-jti",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 600,
+            "dpyc_protocol": "dpyp-01-base-certificate",
+        }
+        jwt_token = pyjwt.encode(jwt_claims, ed_key, algorithm="EdDSA")
+        verify_certificate(jwt_token, ed_pub)
+
+        # Now: try to verify a Nostr event with the same JTI
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="shared-jti")
+        with pytest.raises(CertificateError, match="replay"):
+            verify_nostr_certificate(event_json, npub)
+
+
+# ---------------------------------------------------------------------------
+# Protocol versioning
+# ---------------------------------------------------------------------------
+
+
+class TestNostrProtocolVersioning:
+    def test_missing_protocol_rejected(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        content = json.dumps({"sub": "op-1", "amount_sats": 1000, "net_sats": 980})
+        event_json = _sign_nostr_certificate(
+            private_key, content_override=content, jti="jti-no-proto",
+        )
+        with pytest.raises(CertificateError, match="missing dpyc_protocol"):
+            verify_nostr_certificate(event_json, npub)
+
+    def test_unknown_protocol_rejected(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        content = json.dumps({
+            "sub": "op-1",
+            "amount_sats": 1000,
+            "net_sats": 980,
+            "dpyc_protocol": "dpyp-99-future",
+        })
+        event_json = _sign_nostr_certificate(
+            private_key, content_override=content, jti="jti-future-proto",
+        )
+        with pytest.raises(CertificateError, match="Unsupported protocol"):
+            verify_nostr_certificate(event_json, npub)
+
+
+# ---------------------------------------------------------------------------
+# verify_certificate_auto — format auto-detection
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDetect:
+    def test_jwt_routed_to_jwt_verifier(self):
+        """JWT-like string (no leading {) routes to JWT path."""
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives import serialization
+
+        ed_key = Ed25519PrivateKey.generate()
+        ed_pub = ed_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        claims = {
+            "sub": "op-1",
+            "amount_sats": 1000,
+            "tax_paid_sats": 20,
+            "net_sats": 980,
+            "jti": "auto-jwt-1",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 600,
+            "dpyc_protocol": "dpyp-01-base-certificate",
+        }
+        token = pyjwt.encode(claims, ed_key, algorithm="EdDSA")
+        result = verify_certificate_auto(token, authority_public_key=ed_pub)
+        assert result["operator_id"] == "op-1"
+        assert result["jti"] == "auto-jwt-1"
+
+    def test_nostr_event_routed_to_nostr_verifier(self, nostr_keypair):
+        """JSON string (starts with {) routes to Nostr path."""
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-nostr-1")
+        result = verify_certificate_auto(event_json, authority_npub=npub)
+        assert result["jti"] == "auto-nostr-1"
+
+    def test_nostr_without_npub_fails(self, nostr_keypair):
+        """Nostr event detected but no npub configured."""
+        private_key, _ = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-no-npub")
+        with pytest.raises(CertificateError, match="no authority_npub"):
+            verify_certificate_auto(event_json)
+
+    def test_jwt_without_public_key_fails(self):
+        """JWT detected but no public key configured."""
+        with pytest.raises(CertificateError, match="no authority_public_key"):
+            verify_certificate_auto("eyJhbGciOi.fake.jwt")
+
+
+# ---------------------------------------------------------------------------
+# purchase_credits_tool with Nostr certificate
+# ---------------------------------------------------------------------------
+
+
+class TestPurchaseWithNostrCertificate:
+    @pytest.mark.asyncio
+    async def test_valid_nostr_certificate_creates_invoice(self, nostr_keypair):
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, net_sats=980)
+        result = await purchase_credits_tool(
+            btcpay=_mock_btcpay(),
+            cache=_mock_cache(),
+            user_id="user-1",
+            amount_sats=1000,
+            certificate=event_json,
+            authority_npub=npub,
+        )
+        assert result["success"] is True
+        assert result["amount_sats"] == 980  # from certificate net_sats
+
+    @pytest.mark.asyncio
+    async def test_npub_only_config_works(self, nostr_keypair):
+        """Operator configured with only authority_npub (no public_key) accepts Nostr certs."""
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, net_sats=500, jti="npub-only")
+        result = await purchase_credits_tool(
+            btcpay=_mock_btcpay(),
+            cache=_mock_cache(),
+            user_id="user-1",
+            amount_sats=1000,
+            certificate=event_json,
+            authority_public_key="",  # no JWT key
+            authority_npub=npub,
+        )
+        assert result["success"] is True
+        assert result["amount_sats"] == 500
+
+    @pytest.mark.asyncio
+    async def test_invalid_nostr_certificate_rejected(self, nostr_keypair):
+        _, npub = nostr_keypair
+        other_key = PrivateKey()
+        event_json = _sign_nostr_certificate(other_key, jti="wrong-signer-purchase")
+        result = await purchase_credits_tool(
+            btcpay=_mock_btcpay(),
+            cache=_mock_cache(),
+            user_id="user-1",
+            amount_sats=1000,
+            certificate=event_json,
+            authority_npub=npub,
+        )
+        assert result["success"] is False
+        assert "Certificate rejected" in result["error"]


### PR DESCRIPTION
## Summary
- Adds Schnorr/BIP-340 Nostr event certificates (kind 30079) as an alternative to Ed25519 JWT for Authority-Operator trust
- Phase 1: both JWT and Nostr formats supported simultaneously via auto-detection
- `verify_certificate_auto()` dispatches based on leading character (`{` = Nostr JSON, else JWT)
- `purchase_credits_tool()` now accepts `authority_npub` alongside existing `authority_public_key`
- Trust gate requires at least one authority key; Nostr-only operators need only `AUTHORITY_NPUB`
- Shared JTI anti-replay store across both verification paths
- `pynostr` promoted from optional to core dependency (Schnorr signing/verification needed for certificates)
- Version bump: 0.1.25 → 0.1.26

## New files
- `src/tollbooth/nostr_certificate.py` — Nostr event certificate verification module
- `tests/test_nostr_certificate.py` — 23 new tests

## Modified files
- `certificate.py` — `verify_certificate_auto()` dispatcher
- `config.py` — `authority_npub` field on `TollboothConfig`
- `tools/credits.py` — dual-mode `purchase_credits_tool()`, updated `btcpay_status_tool()`
- `__init__.py` — new exports (`verify_certificate_auto`, `verify_nostr_certificate`, `NOSTR_CERT_KIND`)
- `pyproject.toml` — `pynostr` in core deps, version bump
- `tests/test_certificate.py` — updated trust gate tests for new error messages

## Test plan
- [x] 23 new Nostr certificate tests: valid/invalid events, anti-replay, protocol versioning, auto-detection, purchase flow
- [x] All 465 existing tests pass (no regressions)
- [ ] tollbooth-authority Phase 1 signing (next PR, depends on this release)
- [ ] thebrain-mcp wiring (next PR, depends on this release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)