### PR TITLE
Remove JWT/Ed25519 — Nostr-only certificates (Phase 2+3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.26"
+version = "0.1.27"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
     "httpx==0.28.1",
-    "PyJWT[crypto]==2.11.0",
     "pynostr>=0.6.0",
 ]
 

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,9 +3,9 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.26"
+__version__ = "0.1.27"
 
-from tollbooth.certificate import CertificateError, verify_certificate, verify_certificate_auto, normalize_public_key, key_fingerprint, UNDERSTOOD_PROTOCOLS
+from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -15,18 +15,13 @@ from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_AP
 from tollbooth.pricing import ToolPricing
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
+from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
 
 try:
     from tollbooth.nostr_audit import NostrAuditPublisher, AuditedVault
 except ImportError:
     NostrAuditPublisher = None  # type: ignore[assignment,misc]
     AuditedVault = None  # type: ignore[assignment,misc]
-
-try:
-    from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
-except ImportError:
-    verify_nostr_certificate = None  # type: ignore[assignment,misc]
-    NOSTR_CERT_KIND = 30079
 
 __all__ = [
     "CertificateError",
@@ -47,12 +42,9 @@ __all__ = [
     "ToolTier",
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",
-    "verify_certificate",
     "verify_certificate_auto",
     "verify_nostr_certificate",
     "NOSTR_CERT_KIND",
-    "normalize_public_key",
-    "key_fingerprint",
     "UNDERSTOOD_PROTOCOLS",
     "NostrAuditPublisher",
     "AuditedVault",

--- a/src/tollbooth/certificate.py
+++ b/src/tollbooth/certificate.py
@@ -1,4 +1,4 @@
-"""Authority certificate verification — Ed25519 JWT validation with anti-replay."""
+"""Authority certificate verification — shared infrastructure."""
 
 from __future__ import annotations
 
@@ -13,36 +13,12 @@ logger = logging.getLogger(__name__)
 UNDERSTOOD_PROTOCOLS: frozenset[str] = frozenset({"dpyp-01-base-certificate"})
 
 
-def normalize_public_key(raw: str) -> str:
-    """Accept a bare base64 key string or full PEM and return valid PEM.
-
-    Operators can set AUTHORITY_PUBLIC_KEY to just the base64 body
-    (e.g. ``MCowBQYDK2VwAyEA...``) — no PEM headers needed. The
-    variable name tells you it's a public key.
-    """
-    stripped = raw.strip()
-    if stripped.startswith("-----"):
-        return stripped
-    return f"-----BEGIN PUBLIC KEY-----\n{stripped}\n-----END PUBLIC KEY-----"
-
-
-def key_fingerprint(raw: str) -> str:
-    """Return last 8 chars of the base64 key body for display."""
-    stripped = raw.strip()
-    if stripped.startswith("-----"):
-        lines = [ln for ln in stripped.splitlines() if not ln.startswith("-----")]
-        b64 = "".join(lines).strip()
-    else:
-        b64 = stripped
-    return b64[-8:] if len(b64) >= 8 else b64
-
-
 class CertificateError(Exception):
     """Raised when a certificate fails validation."""
 
 
 class _JTIStore:
-    """Thread-safe in-memory JTI (JWT ID) store for anti-replay protection."""
+    """Thread-safe in-memory certificate ID store for anti-replay protection."""
 
     def __init__(self) -> None:
         self._seen: dict[str, float] = {}  # jti -> expiry timestamp
@@ -68,142 +44,35 @@ class _JTIStore:
 _jti_store = _JTIStore()
 
 
-def verify_certificate(
+def verify_certificate_auto(
     token: str,
-    public_key_pem: str,
     *,
+    authority_npub: str = "",
     understood_protocols: frozenset[str] | None = None,
 ) -> dict[str, Any]:
-    """Verify an Authority-signed Ed25519 JWT certificate.
+    """Verify a Nostr event certificate signed by the Authority.
 
     Args:
-        token: The JWT string from certify_purchase.
-        public_key_pem: The Authority's Ed25519 public key — either bare base64
-            or full PEM format. The variable name indicates it's a public key.
+        token: Nostr event JSON string.
+        authority_npub: Authority's bech32 npub for Schnorr verification.
         understood_protocols: Protocol identifiers this Operator accepts.
-            Defaults to ``UNDERSTOOD_PROTOCOLS``.
 
     Returns:
-        Dict with extracted claims: operator_id, amount_sats, tax_paid_sats,
+        Claims dict: operator_id, amount_sats, tax_paid_sats,
         net_sats, jti, dpyc_protocol.
 
     Raises:
-        CertificateError: On invalid, expired, tampered, or replayed certificates.
+        CertificateError: On verification failure or missing authority_npub.
     """
-    try:
-        import jwt
-        from cryptography.hazmat.primitives.serialization import load_pem_public_key
-    except ImportError as e:
+    if not authority_npub:
         raise CertificateError(
-            f"Missing dependency for certificate verification: {e}. "
-            "Install with: pip install 'PyJWT[crypto]'"
-        ) from e
-
-    # Normalize bare base64 to PEM
-    pem = normalize_public_key(public_key_pem)
-
-    # Load the public key
-    try:
-        public_key = load_pem_public_key(pem.encode())
-    except (ValueError, TypeError) as e:
-        raise CertificateError(f"Invalid authority public key: {e}") from e
-
-    # Decode and verify the JWT
-    try:
-        claims = jwt.decode(token, public_key, algorithms=["EdDSA"])
-    except jwt.ExpiredSignatureError as e:
-        raise CertificateError("Certificate has expired.") from e
-    except jwt.InvalidSignatureError as e:
-        raise CertificateError("Certificate signature is invalid — possible tampering.") from e
-    except jwt.DecodeError as e:
-        raise CertificateError(f"Certificate could not be decoded: {e}") from e
-    except jwt.InvalidTokenError as e:
-        raise CertificateError(f"Invalid certificate: {e}") from e
-
-    # Extract required fields
-    jti = claims.get("jti")
-    if not jti:
-        raise CertificateError("Certificate missing jti claim.")
-
-    exp = claims.get("exp")
-    if not exp:
-        raise CertificateError("Certificate missing exp claim.")
-
-    # Anti-replay check
-    if not _jti_store.check_and_record(jti, float(exp)):
-        raise CertificateError(f"Certificate replay detected — jti {jti} already used.")
-
-    # Protocol version check
-    protos = understood_protocols or UNDERSTOOD_PROTOCOLS
-    proto = claims.get("dpyc_protocol")
-    if not proto:
-        raise CertificateError(
-            "Certificate missing dpyc_protocol claim — "
-            "Authority may be running incompatible version"
+            "No authority_npub configured — cannot verify certificate."
         )
-    if proto not in protos:
-        raise CertificateError(
-            f"Unsupported protocol '{proto}'. "
-            f"This Operator supports: {', '.join(sorted(protos))}"
-        )
+    from tollbooth.nostr_certificate import verify_nostr_certificate
 
-    return {
-        "operator_id": claims.get("sub", ""),
-        "amount_sats": claims.get("amount_sats", 0),
-        "tax_paid_sats": claims.get("tax_paid_sats", 0),
-        "net_sats": claims.get("net_sats", 0),
-        "jti": jti,
-        "dpyc_protocol": proto,
-    }
-
-
-def verify_certificate_auto(
-    token: str,
-    authority_public_key: str = "",
-    authority_npub: str = "",
-    *,
-    understood_protocols: frozenset[str] | None = None,
-) -> dict[str, Any]:
-    """Auto-detect certificate format and verify.
-
-    If *token* looks like JSON (starts with ``{``), it is treated as a Nostr
-    event and verified via Schnorr signature against *authority_npub*.
-    Otherwise it is treated as a JWT and verified via Ed25519 against
-    *authority_public_key*.
-
-    Args:
-        token: JWT string **or** Nostr event JSON string.
-        authority_public_key: Ed25519 public key (PEM or bare base64) for JWT mode.
-        authority_npub: Authority's bech32 npub for Nostr mode.
-        understood_protocols: Protocol identifiers this Operator accepts.
-
-    Returns:
-        Same claims dict as ``verify_certificate()`` and ``verify_nostr_certificate()``.
-
-    Raises:
-        CertificateError: On verification failure or missing key for the detected format.
-    """
-    stripped = token.strip()
-    if stripped.startswith("{"):
-        # Nostr event JSON
-        if not authority_npub:
-            raise CertificateError(
-                "Certificate appears to be a Nostr event but no authority_npub configured."
-            )
-        from tollbooth.nostr_certificate import verify_nostr_certificate
-
-        return verify_nostr_certificate(
-            stripped, authority_npub, understood_protocols=understood_protocols,
-        )
-    else:
-        # JWT
-        if not authority_public_key:
-            raise CertificateError(
-                "Certificate appears to be a JWT but no authority_public_key configured."
-            )
-        return verify_certificate(
-            stripped, authority_public_key, understood_protocols=understood_protocols,
-        )
+    return verify_nostr_certificate(
+        token.strip(), authority_npub, understood_protocols=understood_protocols,
+    )
 
 
 def reset_jti_store() -> None:

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -18,7 +18,6 @@ class TollboothConfig:
     tollbooth_royalty_address: str | None = None
     tollbooth_royalty_percent: float = 0.02
     tollbooth_royalty_min_sats: int = 10
-    authority_public_key: str | None = None  # Ed25519 PEM (JWT verification)
     authority_npub: str | None = None  # Nostr npub (Schnorr verification)
     credit_ttl_seconds: int | None = 604800  # 7 days default, None = never
     flush_batch_size: int = 10

--- a/src/tollbooth/nostr_certificate.py
+++ b/src/tollbooth/nostr_certificate.py
@@ -1,8 +1,7 @@
 """Authority certificate verification — Nostr event (Schnorr/BIP-340) validation with anti-replay.
 
 Verifies kind 30079 parameterized replaceable events signed by the Authority's
-Nostr key. The Schnorr-native replacement for the Ed25519 JWT path in
-``certificate.py``.
+Nostr key.
 
 Dependencies: ``pynostr`` (for event parsing and Schnorr verification).
 """
@@ -57,7 +56,7 @@ def verify_nostr_certificate(
 
     Returns:
         Dict with extracted claims: operator_id, amount_sats, tax_paid_sats,
-        net_sats, jti, dpyc_protocol. Same shape as ``verify_certificate()``.
+        net_sats, jti, dpyc_protocol.
 
     Raises:
         CertificateError: On invalid, expired, tampered, or replayed certificates.
@@ -126,8 +125,8 @@ def verify_nostr_certificate(
     if not jti:
         raise CertificateError("Certificate missing d-tag (JTI).")
 
-    # 6. Anti-replay check (shared store with JWT path — access via module
-    #    so reset_jti_store() is visible across both verification paths)
+    # 6. Anti-replay check (shared anti-replay store — access via module
+    #    so reset_jti_store() is visible)
     if not _cert_mod._jti_store.check_and_record(jti, float(expiration)):
         raise CertificateError(
             f"Certificate replay detected — jti {jti} already used."

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -213,28 +213,22 @@ async def purchase_credits_tool(
     user_id: str,
     amount_sats: int,
     certificate: str,
-    authority_public_key: str = "",
+    authority_npub: str,
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
     default_credit_ttl_seconds: int | None = None,
-    authority_npub: str = "",
 ) -> dict[str, Any]:
     """Create a BTCPay invoice after verifying an Authority certificate.
 
     For OPERATOR use: the certified purchase flow. Every credit purchase
-    requires a valid Authority-signed certificate (JWT or Nostr event).
+    requires a valid Authority-signed Nostr event certificate.
     The certificate's net_sats (amount after tax) determines the invoice amount.
-
-    Accepts either an Ed25519 JWT (verified via *authority_public_key*) or a
-    Schnorr-signed Nostr event (verified via *authority_npub*). At least one
-    authority key must be configured. Format is auto-detected.
     """
-    # Trust gate — at least one Authority key must be configured
-    if not authority_public_key and not authority_npub:
+    # Trust gate — authority_npub must be configured
+    if not authority_npub:
         return {
             "success": False,
-            "error": "Operator misconfigured: neither authority_public_key nor "
-            "authority_npub is set. "
+            "error": "Operator misconfigured: authority_npub is not set. "
             "A Tollbooth Operator cannot operate without a trusted Authority.",
         }
 
@@ -247,7 +241,7 @@ async def purchase_credits_tool(
 
     try:
         cert_claims = verify_certificate_auto(
-            certificate, authority_public_key, authority_npub,
+            certificate, authority_npub=authority_npub,
         )
     except CertificateError as e:
         return {"success": False, "error": f"Certificate rejected: {e}"}
@@ -817,26 +811,12 @@ async def btcpay_status_tool(
     result["credit_ttl_seconds"] = config.credit_ttl_seconds
 
     # Authority trust chain config
-    from tollbooth.certificate import normalize_public_key, key_fingerprint
     authority_config: dict[str, Any] = {
-        "public_key_configured": bool(config.authority_public_key),
         "npub_configured": bool(config.authority_npub),
-        "certificate_verification_enabled": False,
+        "certificate_verification_enabled": bool(config.authority_npub),
     }
-    if config.authority_public_key:
-        try:
-            from cryptography.hazmat.primitives.serialization import load_pem_public_key
-            pem = normalize_public_key(config.authority_public_key)
-            load_pem_public_key(pem.encode())
-            authority_config["public_key_fingerprint"] = key_fingerprint(config.authority_public_key)
-            authority_config["public_key_valid"] = True
-            authority_config["certificate_verification_enabled"] = True
-        except Exception as e:
-            authority_config["public_key_valid"] = False
-            authority_config["public_key_error"] = str(e)
     if config.authority_npub:
         authority_config["authority_npub"] = config.authority_npub
-        authority_config["certificate_verification_enabled"] = True
     result["authority_config"] = authority_config
 
     # Connectivity checks — only if all 3 connection vars present and client available

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -1,18 +1,21 @@
-"""Tests for Authority certificate verification: Ed25519 JWT validation and anti-replay."""
+"""Tests for shared certificate infrastructure: JTI store, error class, and auto-verify routing."""
 
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock
 
-import jwt
 import pytest
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives import serialization
+from pynostr.event import Event  # type: ignore[import-untyped]
+from pynostr.key import PrivateKey  # type: ignore[import-untyped]
 
-from tollbooth.certificate import CertificateError, verify_certificate, reset_jti_store, UNDERSTOOD_PROTOCOLS
-from tollbooth.ledger import UserLedger
-from tollbooth.ledger_cache import LedgerCache
-from tollbooth.btcpay_client import BTCPayClient
-from tollbooth.tools.credits import purchase_credits_tool
+from tollbooth.certificate import (
+    CertificateError,
+    _JTIStore,
+    reset_jti_store,
+    verify_certificate_auto,
+    UNDERSTOOD_PROTOCOLS,
+)
+from tollbooth.nostr_certificate import NOSTR_CERT_KIND, NOSTR_CERT_TAG, NOSTR_CERT_LABEL
 
 
 # ---------------------------------------------------------------------------
@@ -29,377 +32,172 @@ def _clean_jti_store():
 
 
 @pytest.fixture()
-def keypair():
-    """Generate an Ed25519 keypair for testing."""
-    private_key = Ed25519PrivateKey.generate()
-    public_pem = private_key.public_key().public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
-    return private_key, public_pem
+def nostr_keypair():
+    """Generate a Nostr keypair for testing."""
+    private_key = PrivateKey()
+    npub = private_key.public_key.bech32()
+    return private_key, npub
 
 
-def _sign_certificate(
-    private_key: Ed25519PrivateKey,
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_jti_counter = 0
+
+
+def _sign_nostr_certificate(
+    private_key: PrivateKey,
     *,
-    operator_id: str = "op-1",
+    operator_id: str = "npub1operator",
     amount_sats: int = 1000,
     tax_paid_sats: int = 20,
     net_sats: int = 980,
-    jti: str = "jti-unique-1",
+    jti: str | None = None,
     exp_offset: int = 600,
-    extra_claims: dict | None = None,
 ) -> str:
-    """Sign a test certificate JWT."""
+    """Sign a test Nostr certificate event. Returns JSON string."""
+    global _jti_counter
+    if jti is None:
+        _jti_counter += 1
+        jti = f"cert-jti-{_jti_counter}-{time.time_ns()}"
+
     claims = {
         "sub": operator_id,
         "amount_sats": amount_sats,
         "tax_paid_sats": tax_paid_sats,
         "net_sats": net_sats,
-        "jti": jti,
-        "iat": int(time.time()),
-        "exp": int(time.time()) + exp_offset,
         "dpyc_protocol": "dpyp-01-base-certificate",
     }
-    if extra_claims:
-        claims.update(extra_claims)
-    return jwt.encode(claims, private_key, algorithm="EdDSA")
 
+    expiration = int(time.time()) + exp_offset
+    tags: list[list[str]] = [
+        ["d", jti],
+        ["p", "deadbeef" * 8],
+        ["t", NOSTR_CERT_TAG],
+        ["L", NOSTR_CERT_LABEL],
+        ["expiration", str(expiration)],
+    ]
 
-def _mock_btcpay(invoice_response: dict | None = None):
-    client = AsyncMock(spec=BTCPayClient)
-    resp = invoice_response or {"id": "inv-1", "checkoutLink": "https://pay.example.com/inv-1"}
-    client.create_invoice = AsyncMock(return_value=resp)
-    return client
-
-
-def _mock_cache(ledger: UserLedger | None = None):
-    cache = AsyncMock(spec=LedgerCache)
-    cache.get = AsyncMock(return_value=ledger or UserLedger())
-    cache.mark_dirty = MagicMock()
-    return cache
+    event = Event(
+        kind=NOSTR_CERT_KIND,
+        content=json.dumps(claims),
+        tags=tags,
+        pubkey=private_key.public_key.hex(),
+        created_at=int(time.time()),
+    )
+    event.sign(private_key.hex())
+    return json.dumps(event.to_dict())
 
 
 # ---------------------------------------------------------------------------
-# verify_certificate — valid
+# _JTIStore
 # ---------------------------------------------------------------------------
 
 
-class TestVerifyCertificateValid:
-    def test_valid_certificate(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key)
-        result = verify_certificate(token, public_pem)
-        assert result["operator_id"] == "op-1"
-        assert result["amount_sats"] == 1000
-        assert result["tax_paid_sats"] == 20
+class TestJTIStore:
+    def test_check_and_record_new(self):
+        """New JTI is accepted."""
+        store = _JTIStore()
+        assert store.check_and_record("jti-1", time.time() + 600) is True
+
+    def test_check_and_record_replay(self):
+        """Same JTI is rejected (replay)."""
+        store = _JTIStore()
+        store.check_and_record("jti-1", time.time() + 600)
+        assert store.check_and_record("jti-1", time.time() + 600) is False
+
+    def test_cleanup_expired(self):
+        """Expired JTIs are cleaned up and can be re-used."""
+        store = _JTIStore()
+        # Record with expiry in the past
+        store.check_and_record("jti-old", time.time() - 10)
+        # After cleanup, the JTI should be accepted again
+        assert store.check_and_record("jti-old", time.time() + 600) is True
+
+    def test_different_jtis_accepted(self):
+        """Different JTIs are all accepted."""
+        store = _JTIStore()
+        assert store.check_and_record("jti-a", time.time() + 600) is True
+        assert store.check_and_record("jti-b", time.time() + 600) is True
+        assert store.check_and_record("jti-c", time.time() + 600) is True
+
+
+# ---------------------------------------------------------------------------
+# reset_jti_store
+# ---------------------------------------------------------------------------
+
+
+class TestResetJTIStore:
+    def test_reset_clears_store(self, nostr_keypair):
+        """After reset, previously seen JTIs are forgotten."""
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="jti-reset-test")
+        verify_certificate_auto(event_json, authority_npub=npub)
+
+        # Reset and re-verify the same JTI — should succeed after reset
+        reset_jti_store()
+        event_json2 = _sign_nostr_certificate(private_key, jti="jti-reset-test")
+        result = verify_certificate_auto(event_json2, authority_npub=npub)
+        assert result["jti"] == "jti-reset-test"
+
+
+# ---------------------------------------------------------------------------
+# CertificateError
+# ---------------------------------------------------------------------------
+
+
+class TestCertificateError:
+    def test_can_be_raised(self):
+        with pytest.raises(CertificateError, match="test error"):
+            raise CertificateError("test error")
+
+    def test_is_exception(self):
+        assert issubclass(CertificateError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# verify_certificate_auto — Nostr routing
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCertificateAuto:
+    def test_nostr_event_verified(self, nostr_keypair):
+        """Nostr event JSON is verified successfully."""
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-nostr-1")
+        result = verify_certificate_auto(event_json, authority_npub=npub)
+        assert result["jti"] == "auto-nostr-1"
+        assert result["operator_id"] == "npub1operator"
         assert result["net_sats"] == 980
-        assert result["jti"] == "jti-unique-1"
 
-    def test_bare_base64_key_accepted(self, keypair):
-        """Bare base64 key (no PEM headers) works for verification."""
-        private_key, public_pem = keypair
-        # Strip PEM headers to get bare base64
-        lines = [ln for ln in public_pem.strip().splitlines() if not ln.startswith("-----")]
-        bare_b64 = "".join(lines).strip()
-        token = _sign_certificate(private_key, jti="jti-bare-b64")
-        result = verify_certificate(token, bare_b64)
-        assert result["operator_id"] == "op-1"
-        assert result["jti"] == "jti-bare-b64"
+    def test_no_authority_npub_fails(self, nostr_keypair):
+        """Missing authority_npub raises CertificateError."""
+        private_key, _ = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-no-npub")
+        with pytest.raises(CertificateError, match="No authority_npub configured"):
+            verify_certificate_auto(event_json, authority_npub="")
 
-    def test_extracts_all_claims(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(
-            private_key,
-            operator_id="op-42",
-            amount_sats=5000,
-            tax_paid_sats=100,
-            net_sats=4900,
-            jti="jti-42",
-        )
-        result = verify_certificate(token, public_pem)
-        assert result["operator_id"] == "op-42"
-        assert result["amount_sats"] == 5000
-        assert result["net_sats"] == 4900
+    def test_empty_string_npub_fails(self, nostr_keypair):
+        """Empty string authority_npub raises CertificateError."""
+        private_key, _ = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-empty-npub")
+        with pytest.raises(CertificateError, match="No authority_npub configured"):
+            verify_certificate_auto(event_json)
 
+    def test_wrong_signer_fails(self, nostr_keypair):
+        """Certificate signed by wrong key is rejected."""
+        _, npub = nostr_keypair
+        other_key = PrivateKey()
+        event_json = _sign_nostr_certificate(other_key, jti="auto-wrong-signer")
+        with pytest.raises(CertificateError, match="not signed by registered Authority"):
+            verify_certificate_auto(event_json, authority_npub=npub)
 
-# ---------------------------------------------------------------------------
-# verify_certificate — invalid
-# ---------------------------------------------------------------------------
-
-
-class TestVerifyCertificateInvalid:
-    def test_expired_certificate(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, exp_offset=-10)
-        with pytest.raises(CertificateError, match="expired"):
-            verify_certificate(token, public_pem)
-
-    def test_tampered_certificate(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key)
-        # Flip a character in the signature portion
-        parts = token.split(".")
-        sig = list(parts[2])
-        sig[0] = "A" if sig[0] != "A" else "B"
-        parts[2] = "".join(sig)
-        tampered = ".".join(parts)
-        with pytest.raises(CertificateError, match="invalid|decoded"):
-            verify_certificate(tampered, public_pem)
-
-    def test_wrong_key(self, keypair):
-        private_key, public_pem = keypair
-        # Sign with a different key
-        other_key = Ed25519PrivateKey.generate()
-        token = _sign_certificate(other_key)
-        with pytest.raises(CertificateError, match="invalid|signature"):
-            verify_certificate(token, public_pem)
-
-    def test_garbage_token(self, keypair):
-        _, public_pem = keypair
-        with pytest.raises(CertificateError, match="decoded|Invalid"):
-            verify_certificate("not.a.jwt", public_pem)
-
-    def test_invalid_public_key(self):
-        with pytest.raises(CertificateError, match="Invalid authority public key"):
-            verify_certificate("some.jwt.token", "not a valid pem")
-
-    def test_missing_jti(self, keypair):
-        private_key, public_pem = keypair
-        claims = {
-            "operator_id": "op-1",
-            "amount_sats": 1000,
-            "net_sats": 980,
-            "iat": int(time.time()),
-            "exp": int(time.time()) + 600,
-        }
-        token = jwt.encode(claims, private_key, algorithm="EdDSA")
-        with pytest.raises(CertificateError, match="missing jti"):
-            verify_certificate(token, public_pem)
-
-
-# ---------------------------------------------------------------------------
-# Anti-replay (JTI)
-# ---------------------------------------------------------------------------
-
-
-class TestAntiReplay:
-    def test_duplicate_jti_rejected(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, jti="jti-dup")
-        # First call succeeds
-        verify_certificate(token, public_pem)
-        # Second call with same JTI — replay
-        token2 = _sign_certificate(private_key, jti="jti-dup")
+    def test_replay_detected(self, nostr_keypair):
+        """Same JTI is rejected on second use."""
+        private_key, npub = nostr_keypair
+        event_json = _sign_nostr_certificate(private_key, jti="auto-replay")
+        verify_certificate_auto(event_json, authority_npub=npub)
+        event_json2 = _sign_nostr_certificate(private_key, jti="auto-replay")
         with pytest.raises(CertificateError, match="replay"):
-            verify_certificate(token2, public_pem)
-
-    def test_different_jti_accepted(self, keypair):
-        private_key, public_pem = keypair
-        token1 = _sign_certificate(private_key, jti="jti-a")
-        token2 = _sign_certificate(private_key, jti="jti-b")
-        verify_certificate(token1, public_pem)
-        verify_certificate(token2, public_pem)  # should not raise
-
-
-# ---------------------------------------------------------------------------
-# Protocol versioning (dpyc_protocol claim)
-# ---------------------------------------------------------------------------
-
-
-class TestProtocolVersioning:
-    def test_missing_protocol_rejected(self, keypair):
-        """Certificate without dpyc_protocol claim is rejected."""
-        private_key, public_pem = keypair
-        claims = {
-            "sub": "op-1",
-            "amount_sats": 1000,
-            "tax_paid_sats": 20,
-            "net_sats": 980,
-            "jti": "jti-no-proto",
-            "iat": int(time.time()),
-            "exp": int(time.time()) + 600,
-        }
-        token = jwt.encode(claims, private_key, algorithm="EdDSA")
-        with pytest.raises(CertificateError, match="missing dpyc_protocol"):
-            verify_certificate(token, public_pem)
-
-    def test_unknown_protocol_rejected(self, keypair):
-        """Certificate with unrecognized protocol is rejected."""
-        private_key, public_pem = keypair
-        token = _sign_certificate(
-            private_key,
-            jti="jti-future-proto",
-            extra_claims={"dpyc_protocol": "dpyp-99-future"},
-        )
-        with pytest.raises(CertificateError, match="Unsupported protocol"):
-            verify_certificate(token, public_pem)
-
-    def test_valid_protocol_accepted(self, keypair):
-        """Certificate with correct dpyc_protocol passes verification."""
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, jti="jti-valid-proto")
-        result = verify_certificate(token, public_pem)
-        assert result["dpyc_protocol"] == "dpyp-01-base-certificate"
-
-    def test_custom_understood_protocols(self, keypair):
-        """Operator can supply a custom set of understood protocols."""
-        private_key, public_pem = keypair
-        custom = frozenset({"dpyp-02-extended"})
-        token = _sign_certificate(
-            private_key,
-            jti="jti-custom-proto",
-            extra_claims={"dpyc_protocol": "dpyp-02-extended"},
-        )
-        result = verify_certificate(token, public_pem, understood_protocols=custom)
-        assert result["dpyc_protocol"] == "dpyp-02-extended"
-
-
-# ---------------------------------------------------------------------------
-# purchase_credits_tool with certificate
-# ---------------------------------------------------------------------------
-
-
-class TestPurchaseWithCertificate:
-    @pytest.mark.asyncio
-    async def test_missing_certificate_rejected(self, keypair):
-        _, public_pem = keypair
-        result = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate="",
-            authority_public_key=public_pem,
-        )
-        assert result["success"] is False
-        assert "certificate is required" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_invalid_certificate_rejected(self, keypair):
-        _, public_pem = keypair
-        result = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate="bad.jwt.token",
-            authority_public_key=public_pem,
-        )
-        assert result["success"] is False
-        assert "Certificate rejected" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_valid_certificate_creates_invoice(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, net_sats=980)
-        result = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate=token,
-            authority_public_key=public_pem,
-        )
-        assert result["success"] is True
-        assert result["amount_sats"] == 980  # from certificate net_sats
-        assert result["certificate_jti"] == "jti-unique-1"
-
-    @pytest.mark.asyncio
-    async def test_certificate_net_sats_overrides_amount(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, net_sats=500, jti="jti-override")
-        btcpay = _mock_btcpay()
-        result = await purchase_credits_tool(
-            btcpay=btcpay,
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=9999,  # should be overridden by cert's net_sats
-            certificate=token,
-            authority_public_key=public_pem,
-        )
-        assert result["success"] is True
-        assert result["amount_sats"] == 500
-        btcpay.create_invoice.assert_called_once()
-        call_args = btcpay.create_invoice.call_args
-        assert call_args[0][0] == 500
-
-    @pytest.mark.asyncio
-    async def test_certificate_jti_in_invoice_metadata(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, jti="jti-meta-test")
-        btcpay = _mock_btcpay()
-        await purchase_credits_tool(
-            btcpay=btcpay,
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate=token,
-            authority_public_key=public_pem,
-        )
-        call_kwargs = btcpay.create_invoice.call_args[1]
-        assert call_kwargs["metadata"]["certificate_jti"] == "jti-meta-test"
-
-    @pytest.mark.asyncio
-    async def test_replay_rejected_in_purchase(self, keypair):
-        private_key, public_pem = keypair
-        token = _sign_certificate(private_key, jti="jti-replay-purchase")
-        result1 = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate=token,
-            authority_public_key=public_pem,
-        )
-        assert result1["success"] is True
-        # Replayed certificate fails
-        token2 = _sign_certificate(private_key, jti="jti-replay-purchase")
-        result2 = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate=token2,
-            authority_public_key=public_pem,
-        )
-        assert result2["success"] is False
-        assert "replay" in result2["error"].lower()
-
-
-# ---------------------------------------------------------------------------
-# Mandatory trust — no untrusted operation
-# ---------------------------------------------------------------------------
-
-
-class TestMandatoryTrust:
-    @pytest.mark.asyncio
-    async def test_no_authority_key_rejects_purchase(self):
-        """Operators cannot operate without a trusted Authority."""
-        result = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate="some.jwt.token",
-            authority_public_key="",
-            authority_npub="",
-        )
-        assert result["success"] is False
-        assert "authority_public_key" in result["error"]
-        assert "authority_npub" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_empty_certificate_and_empty_keys(self):
-        """Both missing — operator misconfigured."""
-        result = await purchase_credits_tool(
-            btcpay=_mock_btcpay(),
-            cache=_mock_cache(),
-            user_id="user-1",
-            amount_sats=1000,
-            certificate="",
-            authority_public_key="",
-            authority_npub="",
-        )
-        assert result["success"] is False
-        assert "authority_public_key" in result["error"]
+            verify_certificate_auto(event_json2, authority_npub=npub)

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -5,10 +5,9 @@ import time
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
-import jwt as pyjwt
 import pytest
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives import serialization
+from pynostr.event import Event  # type: ignore[import-untyped]
+from pynostr.key import PrivateKey  # type: ignore[import-untyped]
 
 from tollbooth.btcpay_client import (
     BTCPayAuthError,
@@ -21,6 +20,7 @@ from tollbooth.certificate import reset_jti_store
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import ToolUsage, Tranche, UserLedger
 from tollbooth.ledger_cache import LedgerCache
+from tollbooth.nostr_certificate import NOSTR_CERT_KIND, NOSTR_CERT_TAG, NOSTR_CERT_LABEL
 from tollbooth.tools.credits import (
     ROYALTY_PAYOUT_MAX_SATS,
     _attempt_royalty_payout,
@@ -38,33 +38,44 @@ from tollbooth.constants import MAX_INVOICE_SATS
 
 
 # ---------------------------------------------------------------------------
-# Module-level test keypair for certificate signing
+# Module-level Nostr test keypair for certificate signing
 # ---------------------------------------------------------------------------
 
-_TEST_PRIVATE_KEY = Ed25519PrivateKey.generate()
-_TEST_PUBLIC_PEM = _TEST_PRIVATE_KEY.public_key().public_bytes(
-    serialization.Encoding.PEM,
-    serialization.PublicFormat.SubjectPublicKeyInfo,
-).decode()
+_TEST_NOSTR_PRIVKEY = PrivateKey()
+_TEST_AUTHORITY_NPUB = _TEST_NOSTR_PRIVKEY.public_key.bech32()
 
 _jti_counter = 0
 
 
 def _test_certificate(net_sats: int = 980, amount_sats: int = 1000) -> str:
-    """Sign a test certificate with a unique JTI for each call."""
+    """Sign a test Nostr certificate event with a unique JTI for each call."""
     global _jti_counter
     _jti_counter += 1
+    jti = f"test-jti-{_jti_counter}-{time.time_ns()}"
     claims = {
         "sub": "test-op",
         "amount_sats": amount_sats,
         "tax_paid_sats": amount_sats - net_sats,
         "net_sats": net_sats,
-        "jti": f"test-jti-{_jti_counter}-{time.time_ns()}",
-        "iat": int(time.time()),
-        "exp": int(time.time()) + 600,
         "dpyc_protocol": "dpyp-01-base-certificate",
     }
-    return pyjwt.encode(claims, _TEST_PRIVATE_KEY, algorithm="EdDSA")
+    expiration = int(time.time()) + 600
+    tags: list[list[str]] = [
+        ["d", jti],
+        ["p", "deadbeef" * 8],
+        ["t", NOSTR_CERT_TAG],
+        ["L", NOSTR_CERT_LABEL],
+        ["expiration", str(expiration)],
+    ]
+    event = Event(
+        kind=NOSTR_CERT_KIND,
+        content=json.dumps(claims),
+        tags=tags,
+        pubkey=_TEST_NOSTR_PRIVKEY.public_key.hex(),
+        created_at=int(time.time()),
+    )
+    event.sign(_TEST_NOSTR_PRIVKEY.hex())
+    return json.dumps(event.to_dict())
 
 
 @pytest.fixture(autouse=True)
@@ -256,7 +267,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", 1000,
             certificate=_test_certificate(net_sats=1000),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is True
         assert result["invoice_id"] == "inv-42"
@@ -273,7 +284,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", 0,
             certificate=_test_certificate(net_sats=0),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
         assert "positive" in result["error"]
@@ -285,7 +296,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", -100,
             certificate=_test_certificate(net_sats=-100),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
 
@@ -296,7 +307,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", 1000,
             certificate=_test_certificate(net_sats=1000),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
         assert "BTCPay error" in result["error"]
@@ -309,7 +320,7 @@ class TestPurchaseCredits:
         await purchase_credits_tool(
             btcpay, cache, "user1", 500,
             certificate=_test_certificate(net_sats=500),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert "inv-99" in ledger.pending_invoices
 
@@ -320,7 +331,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", 1000,
             certificate=_test_certificate(net_sats=1000),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
             tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
         )
         assert result["tier"] == "default"
@@ -334,7 +345,7 @@ class TestPurchaseCredits:
         result = await purchase_credits_tool(
             btcpay, cache, "user-vip", 500,
             certificate=_test_certificate(net_sats=500),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
             tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
         )
         assert result["tier"] == "vip"
@@ -706,7 +717,7 @@ class TestPurchaseCap:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", MAX_INVOICE_SATS,
             certificate=_test_certificate(net_sats=MAX_INVOICE_SATS),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is True
 
@@ -718,7 +729,7 @@ class TestPurchaseCap:
         result = await purchase_credits_tool(
             btcpay, cache, "user1", MAX_INVOICE_SATS + 1,
             certificate=_test_certificate(net_sats=MAX_INVOICE_SATS + 1),
-            authority_public_key=_TEST_PUBLIC_PEM,
+            authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
         assert "maximum" in result["error"]
@@ -1230,74 +1241,26 @@ class TestBTCPayStatus:
 
 class TestBTCPayStatusAuthorityConfig:
     @pytest.mark.asyncio
-    async def test_authority_key_configured_and_valid(self) -> None:
-        """Valid Ed25519 PEM key shows configured, valid, fingerprint, verification enabled."""
-        config = _make_config(authority_public_key=_TEST_PUBLIC_PEM)
+    async def test_authority_npub_configured(self) -> None:
+        """Valid npub shows configured, verification enabled."""
+        config = _make_config(authority_npub=_TEST_AUTHORITY_NPUB)
         result = await btcpay_status_tool(config, None)
 
         auth = result["authority_config"]
-        assert auth["public_key_configured"] is True
-        assert auth["public_key_valid"] is True
+        assert auth["npub_configured"] is True
         assert auth["certificate_verification_enabled"] is True
-        assert len(auth["public_key_fingerprint"]) == 8
-        assert "public_key_error" not in auth
+        assert auth["authority_npub"] == _TEST_AUTHORITY_NPUB
 
     @pytest.mark.asyncio
-    async def test_authority_key_not_configured(self) -> None:
-        """No key set — configured false, verification disabled."""
-        config = _make_config(authority_public_key=None)
+    async def test_authority_npub_not_configured(self) -> None:
+        """No npub set — configured false, verification disabled."""
+        config = _make_config(authority_npub=None)
         result = await btcpay_status_tool(config, None)
 
         auth = result["authority_config"]
-        assert auth["public_key_configured"] is False
+        assert auth["npub_configured"] is False
         assert auth["certificate_verification_enabled"] is False
-        assert "public_key_fingerprint" not in auth
-        assert "public_key_valid" not in auth
-
-    @pytest.mark.asyncio
-    async def test_authority_key_invalid_pem(self) -> None:
-        """Malformed PEM key — configured true, valid false, error reported."""
-        config = _make_config(authority_public_key="not a valid PEM key")
-        result = await btcpay_status_tool(config, None)
-
-        auth = result["authority_config"]
-        assert auth["public_key_configured"] is True
-        assert auth["public_key_valid"] is False
-        assert auth["certificate_verification_enabled"] is False
-        assert "public_key_error" in auth
-
-    @pytest.mark.asyncio
-    async def test_bare_base64_key_accepted(self) -> None:
-        """Bare base64 key (no PEM headers) works for diagnostics."""
-        # Extract just the base64 body from the PEM
-        lines = [ln for ln in _TEST_PUBLIC_PEM.strip().splitlines() if not ln.startswith("-----")]
-        bare_b64 = "".join(lines).strip()
-        config = _make_config(authority_public_key=bare_b64)
-        result = await btcpay_status_tool(config, None)
-
-        auth = result["authority_config"]
-        assert auth["public_key_configured"] is True
-        assert auth["public_key_valid"] is True
-        assert auth["certificate_verification_enabled"] is True
-        assert len(auth["public_key_fingerprint"]) == 8
-        assert "authority_url" not in auth
-
-    @pytest.mark.asyncio
-    async def test_fingerprint_matches_key_tail(self) -> None:
-        """Fingerprint is last 8 chars of the base64 key body."""
-        lines = [ln for ln in _TEST_PUBLIC_PEM.strip().splitlines() if not ln.startswith("-----")]
-        bare_b64 = "".join(lines).strip()
-        expected = bare_b64[-8:]
-
-        # Test with full PEM
-        config_pem = _make_config(authority_public_key=_TEST_PUBLIC_PEM)
-        result_pem = await btcpay_status_tool(config_pem, None)
-        assert result_pem["authority_config"]["public_key_fingerprint"] == expected
-
-        # Test with bare base64
-        config_bare = _make_config(authority_public_key=bare_b64)
-        result_bare = await btcpay_status_tool(config_bare, None)
-        assert result_bare["authority_config"]["public_key_fingerprint"] == expected
+        assert "authority_npub" not in auth
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nostr_certificate.py
+++ b/tests/test_nostr_certificate.py
@@ -245,38 +245,6 @@ class TestNostrAntiReplay:
         verify_nostr_certificate(event_json1, npub)
         verify_nostr_certificate(event_json2, npub)  # should not raise
 
-    def test_jwt_and_nostr_share_jti_store(self, nostr_keypair):
-        """JTI store is shared — a JTI used by JWT blocks the same JTI in Nostr."""
-        import jwt as pyjwt
-        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-        from cryptography.hazmat.primitives import serialization
-        from tollbooth.certificate import verify_certificate
-
-        # First: verify a JWT with jti "shared-jti"
-        ed_key = Ed25519PrivateKey.generate()
-        ed_pub = ed_key.public_key().public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
-        jwt_claims = {
-            "sub": "op-1",
-            "amount_sats": 1000,
-            "tax_paid_sats": 20,
-            "net_sats": 980,
-            "jti": "shared-jti",
-            "iat": int(time.time()),
-            "exp": int(time.time()) + 600,
-            "dpyc_protocol": "dpyp-01-base-certificate",
-        }
-        jwt_token = pyjwt.encode(jwt_claims, ed_key, algorithm="EdDSA")
-        verify_certificate(jwt_token, ed_pub)
-
-        # Now: try to verify a Nostr event with the same JTI
-        private_key, npub = nostr_keypair
-        event_json = _sign_nostr_certificate(private_key, jti="shared-jti")
-        with pytest.raises(CertificateError, match="replay"):
-            verify_nostr_certificate(event_json, npub)
-
 
 # ---------------------------------------------------------------------------
 # Protocol versioning
@@ -314,50 +282,19 @@ class TestNostrProtocolVersioning:
 
 
 class TestAutoDetect:
-    def test_jwt_routed_to_jwt_verifier(self):
-        """JWT-like string (no leading {) routes to JWT path."""
-        import jwt as pyjwt
-        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-        from cryptography.hazmat.primitives import serialization
-
-        ed_key = Ed25519PrivateKey.generate()
-        ed_pub = ed_key.public_key().public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
-        claims = {
-            "sub": "op-1",
-            "amount_sats": 1000,
-            "tax_paid_sats": 20,
-            "net_sats": 980,
-            "jti": "auto-jwt-1",
-            "iat": int(time.time()),
-            "exp": int(time.time()) + 600,
-            "dpyc_protocol": "dpyp-01-base-certificate",
-        }
-        token = pyjwt.encode(claims, ed_key, algorithm="EdDSA")
-        result = verify_certificate_auto(token, authority_public_key=ed_pub)
-        assert result["operator_id"] == "op-1"
-        assert result["jti"] == "auto-jwt-1"
-
     def test_nostr_event_routed_to_nostr_verifier(self, nostr_keypair):
-        """JSON string (starts with {) routes to Nostr path."""
+        """Nostr event JSON is verified via verify_certificate_auto."""
         private_key, npub = nostr_keypair
         event_json = _sign_nostr_certificate(private_key, jti="auto-nostr-1")
         result = verify_certificate_auto(event_json, authority_npub=npub)
         assert result["jti"] == "auto-nostr-1"
 
     def test_nostr_without_npub_fails(self, nostr_keypair):
-        """Nostr event detected but no npub configured."""
+        """No npub configured raises CertificateError."""
         private_key, _ = nostr_keypair
         event_json = _sign_nostr_certificate(private_key, jti="auto-no-npub")
-        with pytest.raises(CertificateError, match="no authority_npub"):
+        with pytest.raises(CertificateError, match="No authority_npub"):
             verify_certificate_auto(event_json)
-
-    def test_jwt_without_public_key_fails(self):
-        """JWT detected but no public key configured."""
-        with pytest.raises(CertificateError, match="no authority_public_key"):
-            verify_certificate_auto("eyJhbGciOi.fake.jwt")
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +329,6 @@ class TestPurchaseWithNostrCertificate:
             user_id="user-1",
             amount_sats=1000,
             certificate=event_json,
-            authority_public_key="",  # no JWT key
             authority_npub=npub,
         )
         assert result["success"] is True


### PR DESCRIPTION
## Summary
- Remove `PyJWT[crypto]` dependency entirely
- Delete `verify_certificate()` (JWT verifier), `normalize_public_key()`, `key_fingerprint()`
- Remove `authority_public_key` from `TollboothConfig`
- Simplify `verify_certificate_auto()` to Nostr-only (remove JWT branch)
- Remove `authority_public_key` parameter from `purchase_credits_tool()` — `authority_npub` is now required
- Simplify `btcpay_status_tool()` authority config to npub-only
- Rewrite all tests: Ed25519 fixtures → pynostr Nostr event fixtures
- Version bump to 0.1.27

## Breaking changes
- `verify_certificate()` removed — use `verify_nostr_certificate()` or `verify_certificate_auto()`
- `authority_public_key` parameter removed from `purchase_credits_tool()`
- `TollboothConfig.authority_public_key` field removed
- `PyJWT` no longer a dependency

## Test plan
- [x] 448 tests pass locally
- [x] All JWT test fixtures replaced with Nostr event fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)