### PR TITLE
NIP-44 encrypted audit events — patron privacy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.27"
+version = "0.1.28"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.27"
+__version__ = "0.1.28"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/nip44.py
+++ b/src/tollbooth/nip44.py
@@ -1,0 +1,202 @@
+"""NIP-44v2 encryption — ECDH + HKDF + ChaCha20-Poly1305 with padding.
+
+Implements the NIP-44 version 2 payload encryption scheme for Nostr events.
+Used by the audit publisher to encrypt patron balance data so only the
+patron's nsec can decrypt it.
+
+Dependencies: ``coincurve`` (secp256k1 ECDH) and ``cryptography``
+(HKDF-SHA256, ChaCha20-Poly1305) — both already transitive deps of pynostr.
+
+Reference: https://github.com/nostr-protocol/nips/blob/master/44.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import struct
+
+from coincurve import PrivateKey as _CoinPrivateKey  # type: ignore[import-untyped]
+from coincurve import PublicKey as _CoinPublicKey  # type: ignore[import-untyped]
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
+
+# NIP-44v2 constants
+_VERSION = 2
+_MIN_PLAINTEXT_SIZE = 1
+_MAX_PLAINTEXT_SIZE = 65535
+
+
+def _calc_padded_len(unpadded_len: int) -> int:
+    """Calculate NIP-44v2 padded length.
+
+    Padding ensures ciphertext length reveals minimal information about
+    plaintext length. Uses a power-of-two bucket scheme.
+    """
+    if unpadded_len <= 32:
+        return 32
+    next_power = 1
+    while next_power < unpadded_len:
+        next_power *= 2
+    if next_power <= 256:
+        return next_power
+    chunk = next_power // 8
+    return chunk * ((unpadded_len + chunk - 1) // chunk)
+
+
+def _pad(plaintext: bytes) -> bytes:
+    """Pad plaintext per NIP-44v2: 2-byte BE length prefix + zero-padding."""
+    unpadded_len = len(plaintext)
+    if unpadded_len < _MIN_PLAINTEXT_SIZE or unpadded_len > _MAX_PLAINTEXT_SIZE:
+        raise ValueError(
+            f"Plaintext length {unpadded_len} outside valid range "
+            f"[{_MIN_PLAINTEXT_SIZE}, {_MAX_PLAINTEXT_SIZE}]"
+        )
+    padded_len = _calc_padded_len(unpadded_len)
+    prefix = struct.pack(">H", unpadded_len)
+    padding = b"\x00" * (padded_len - unpadded_len)
+    return prefix + plaintext + padding
+
+
+def _unpad(padded: bytes) -> bytes:
+    """Remove NIP-44v2 padding: read 2-byte BE length, extract plaintext."""
+    if len(padded) < 2:
+        raise ValueError("Padded data too short")
+    (unpadded_len,) = struct.unpack(">H", padded[:2])
+    if unpadded_len < _MIN_PLAINTEXT_SIZE or unpadded_len > _MAX_PLAINTEXT_SIZE:
+        raise ValueError(f"Invalid unpadded length: {unpadded_len}")
+    if 2 + unpadded_len > len(padded):
+        raise ValueError("Padded data shorter than declared length")
+    # Verify padding is all zeros
+    tail = padded[2 + unpadded_len :]
+    if tail != b"\x00" * len(tail):
+        raise ValueError("Non-zero padding bytes detected")
+    return padded[2 : 2 + unpadded_len]
+
+
+def _get_conversation_key(
+    private_key_hex: str, public_key_hex: str,
+) -> bytes:
+    """Derive NIP-44v2 conversation key via secp256k1 ECDH + HKDF-extract.
+
+    1. Scalar-multiply recipient pubkey by sender privkey → shared point.
+    2. Take x-coordinate (32 bytes) of the shared point.
+    3. HKDF-extract(salt="nip44-v2", IKM=shared_x) → 32-byte conversation key.
+
+    Args:
+        private_key_hex: 32-byte private key as hex string.
+        public_key_hex: 32-byte x-only public key as hex string.
+
+    Returns:
+        32-byte conversation key.
+    """
+    sk = _CoinPrivateKey(bytes.fromhex(private_key_hex))
+    # x-only pubkey needs 02 prefix for coincurve (assume even Y)
+    pk = _CoinPublicKey(b"\x02" + bytes.fromhex(public_key_hex))
+
+    # Scalar multiplication → shared point, then extract x-coordinate
+    shared_point = pk.multiply(sk.secret)
+    shared_x = shared_point.format(compressed=False)[1:33]
+
+    # HKDF-extract is HMAC-SHA256(salt, IKM)
+    return hmac.new(b"nip44-v2", shared_x, hashlib.sha256).digest()
+
+
+def _get_message_keys(
+    conversation_key: bytes, nonce: bytes,
+) -> tuple[bytes, bytes]:
+    """Derive per-message chacha_key and chacha_nonce via HKDF-expand.
+
+    HKDF-expand(PRK=conversation_key, info=nonce, L=76)
+    → chacha_key(32) + chacha_nonce(12) + hmac_key(32)
+
+    Returns:
+        (chacha_key: 32 bytes, chacha_nonce: 12 bytes)
+    """
+    expanded = HKDFExpand(
+        algorithm=SHA256(),
+        length=76,
+        info=nonce,
+    ).derive(conversation_key)
+
+    chacha_key = expanded[:32]
+    chacha_nonce = expanded[32:44]
+    return chacha_key, chacha_nonce
+
+
+def encrypt(
+    plaintext: str,
+    private_key_hex: str,
+    public_key_hex: str,
+) -> str:
+    """Encrypt a plaintext string per NIP-44v2.
+
+    Args:
+        plaintext: UTF-8 string to encrypt.
+        private_key_hex: Sender's 32-byte private key as hex.
+        public_key_hex: Recipient's 32-byte x-only public key as hex.
+
+    Returns:
+        Base64-encoded NIP-44v2 payload: version(1) + nonce(32) + ciphertext.
+    """
+    import base64
+
+    plaintext_bytes = plaintext.encode("utf-8")
+    padded = _pad(plaintext_bytes)
+
+    conversation_key = _get_conversation_key(private_key_hex, public_key_hex)
+    nonce = os.urandom(32)
+    chacha_key, chacha_nonce = _get_message_keys(conversation_key, nonce)
+
+    cipher = ChaCha20Poly1305(chacha_key)
+    ciphertext = cipher.encrypt(chacha_nonce, padded, None)
+
+    # NIP-44v2 payload: version byte + nonce + ciphertext (includes Poly1305 tag)
+    payload = bytes([_VERSION]) + nonce + ciphertext
+    return base64.b64encode(payload).decode("ascii")
+
+
+def decrypt(
+    payload_b64: str,
+    private_key_hex: str,
+    public_key_hex: str,
+) -> str:
+    """Decrypt a NIP-44v2 base64 payload.
+
+    Args:
+        payload_b64: Base64-encoded NIP-44v2 payload.
+        private_key_hex: Recipient's 32-byte private key as hex.
+        public_key_hex: Sender's 32-byte x-only public key as hex.
+
+    Returns:
+        Decrypted UTF-8 plaintext string.
+
+    Raises:
+        ValueError: On invalid version, decryption failure, or padding error.
+    """
+    import base64
+
+    payload = base64.b64decode(payload_b64)
+    if len(payload) < 35:  # 1 version + 32 nonce + 2 min ciphertext
+        raise ValueError("NIP-44 payload too short")
+
+    version = payload[0]
+    if version != _VERSION:
+        raise ValueError(f"Unsupported NIP-44 version: {version}")
+
+    nonce = payload[1:33]
+    ciphertext = payload[33:]
+
+    conversation_key = _get_conversation_key(private_key_hex, public_key_hex)
+    chacha_key, chacha_nonce = _get_message_keys(conversation_key, nonce)
+
+    cipher = ChaCha20Poly1305(chacha_key)
+    try:
+        padded = cipher.decrypt(chacha_nonce, ciphertext, None)
+    except Exception as e:
+        raise ValueError(f"NIP-44 decryption failed: {e}") from e
+
+    plaintext_bytes = _unpad(padded)
+    return plaintext_bytes.decode("utf-8")

--- a/src/tollbooth/nostr_audit.py
+++ b/src/tollbooth/nostr_audit.py
@@ -4,6 +4,11 @@ Publishes kind 30078 (NIP-78 parameterized replaceable) events to Nostr
 relays on every vault write, providing an independent, cryptographically
 signed audit trail for NeonVault cutover diagnostics.
 
+**Privacy**: When the patron's identity is an npub, the ``content`` field
+is encrypted via NIP-44v2 (ECDH + ChaCha20-Poly1305).  Only the patron's
+nsec can decrypt it.  Observers see the event metadata (kind, tags, pubkey)
+but not the balance data.
+
 Architecture:
 
     LedgerCache → AuditedVault → NeonVault (or TheBrainVault)
@@ -40,6 +45,13 @@ try:
     _HAS_WEBSOCKET = True
 except ImportError:
     _HAS_WEBSOCKET = False
+
+try:
+    from tollbooth.nip44 import encrypt as _nip44_encrypt
+
+    _HAS_NIP44 = True
+except ImportError:
+    _HAS_NIP44 = False
 
 
 def _extract_audit_fields(ledger_json: str) -> dict[str, Any]:
@@ -154,6 +166,11 @@ class NostrAuditPublisher:
     ) -> None:
         """Construct and publish a kind 30078 event with balance state.
 
+        When *user_id* is an npub and NIP-44 is available, the ``content``
+        field is encrypted to the patron's public key so only the patron's
+        nsec can read the balance data.  An ``["encrypted", "nip44"]`` tag
+        is added so clients know to decrypt.
+
         Fire-and-forget: relay publishing runs in a daemon thread so it
         never blocks the vault write path. All exceptions are caught.
         """
@@ -166,7 +183,7 @@ class NostrAuditPublisher:
             # Short npub prefix for d-tag (first 12 chars of hex pubkey)
             user_short = user_hex[:12] if len(user_hex) >= 12 else user_hex
 
-            content = json.dumps(
+            plaintext = json.dumps(
                 {
                     "user_id": user_id,
                     "balance": fields["balance"],
@@ -182,15 +199,39 @@ class NostrAuditPublisher:
                 separators=(",", ":"),
             )
 
+            tags = [
+                ["d", f"tollbooth-audit-{user_short}"],
+                ["p", user_hex],
+                ["t", "tollbooth-audit"],
+                ["L", "dpyc.tollbooth"],
+            ]
+
+            # Encrypt content to patron's npub via NIP-44v2
+            can_encrypt = (
+                _HAS_NIP44
+                and user_id.startswith("npub1")
+                and self._private_key is not None
+            )
+            if can_encrypt:
+                content = _nip44_encrypt(
+                    plaintext, self._private_key.hex(), user_hex,
+                )
+                tags.append(["encrypted", "nip44"])
+            else:
+                # Fallback: skip publishing entirely if encryption unavailable
+                # for npub patrons (never publish plaintext for npub users)
+                if user_id.startswith("npub1"):
+                    logger.warning(
+                        "NIP-44 encryption unavailable — skipping audit "
+                        "event for npub patron (refusing plaintext fallback)."
+                    )
+                    return
+                content = plaintext
+
             event = Event(
                 kind=30078,
                 content=content,
-                tags=[
-                    ["d", f"tollbooth-audit-{user_short}"],
-                    ["p", user_hex],
-                    ["t", "tollbooth-audit"],
-                    ["L", "dpyc.tollbooth"],
-                ],
+                tags=tags,
                 pubkey=self._pubkey_hex,
                 created_at=int(time.time()),
             )

--- a/tests/test_nip44.py
+++ b/tests/test_nip44.py
@@ -1,0 +1,229 @@
+"""Tests for NIP-44v2 encryption module."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from pynostr.key import PrivateKey  # type: ignore[import-untyped]
+
+from tollbooth.nip44 import (
+    _calc_padded_len,
+    _get_conversation_key,
+    _pad,
+    _unpad,
+    decrypt,
+    encrypt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Padding
+# ---------------------------------------------------------------------------
+
+
+class TestCalcPaddedLen:
+    def test_short_texts_pad_to_32(self) -> None:
+        for n in (1, 15, 31, 32):
+            assert _calc_padded_len(n) == 32
+
+    def test_power_of_two_buckets(self) -> None:
+        assert _calc_padded_len(33) == 64
+        assert _calc_padded_len(64) == 64
+        assert _calc_padded_len(65) == 128
+        assert _calc_padded_len(128) == 128
+        assert _calc_padded_len(129) == 256
+        assert _calc_padded_len(256) == 256
+
+    def test_chunk_based_above_256(self) -> None:
+        # 257 → next_power=512, chunk=64, ceil(257/64)*64 = 5*64 = 320
+        assert _calc_padded_len(257) == 320
+        # 512 → next_power=512, chunk=64, 512/64 * 64 = 512
+        assert _calc_padded_len(512) == 512
+
+    def test_always_at_least_input_size(self) -> None:
+        for n in range(1, 1000):
+            assert _calc_padded_len(n) >= n
+
+
+class TestPadUnpad:
+    def test_round_trip(self) -> None:
+        for text in (b"x", b"hello", b"a" * 100, b"z" * 1000):
+            padded = _pad(text)
+            assert _unpad(padded) == text
+
+    def test_pad_adds_length_prefix(self) -> None:
+        padded = _pad(b"hello")
+        # First 2 bytes: big-endian length (5)
+        assert padded[0] == 0
+        assert padded[1] == 5
+        # Followed by the plaintext
+        assert padded[2:7] == b"hello"
+        # Total padded length = 2 + padded_len(5) = 2 + 32 = 34
+        assert len(padded) == 34
+
+    def test_padding_is_zero_filled(self) -> None:
+        padded = _pad(b"hi")
+        # After prefix (2 bytes) + plaintext (2 bytes) = zeros to fill to 32
+        tail = padded[4:]
+        assert tail == b"\x00" * len(tail)
+
+    def test_empty_plaintext_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside valid range"):
+            _pad(b"")
+
+    def test_oversized_plaintext_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside valid range"):
+            _pad(b"x" * 65536)
+
+    def test_unpad_short_data_rejected(self) -> None:
+        with pytest.raises(ValueError, match="too short"):
+            _unpad(b"\x00")
+
+    def test_unpad_bad_length_rejected(self) -> None:
+        # Declare length 100 but only provide 10 bytes
+        bad = b"\x00\x64" + b"x" * 10
+        with pytest.raises(ValueError, match="shorter than declared"):
+            _unpad(bad)
+
+    def test_unpad_nonzero_padding_rejected(self) -> None:
+        padded = _pad(b"hi")
+        # Corrupt a padding byte
+        corrupted = padded[:-1] + b"\xff"
+        with pytest.raises(ValueError, match="Non-zero padding"):
+            _unpad(corrupted)
+
+
+# ---------------------------------------------------------------------------
+# Conversation key
+# ---------------------------------------------------------------------------
+
+
+class TestConversationKey:
+    def test_symmetric(self) -> None:
+        """Both parties derive the same conversation key."""
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ck1 = _get_conversation_key(sk1.hex(), sk2.public_key.hex())
+        ck2 = _get_conversation_key(sk2.hex(), sk1.public_key.hex())
+        assert ck1 == ck2
+
+    def test_different_pairs_differ(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+        sk3 = PrivateKey()
+
+        ck12 = _get_conversation_key(sk1.hex(), sk2.public_key.hex())
+        ck13 = _get_conversation_key(sk1.hex(), sk3.public_key.hex())
+        assert ck12 != ck13
+
+    def test_deterministic(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ck_a = _get_conversation_key(sk1.hex(), sk2.public_key.hex())
+        ck_b = _get_conversation_key(sk1.hex(), sk2.public_key.hex())
+        assert ck_a == ck_b
+
+
+# ---------------------------------------------------------------------------
+# Encrypt / Decrypt
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptDecrypt:
+    def test_round_trip_short(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        msg = "hello"
+        ct = encrypt(msg, sk1.hex(), sk2.public_key.hex())
+        pt = decrypt(ct, sk2.hex(), sk1.public_key.hex())
+        assert pt == msg
+
+    def test_round_trip_json(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        msg = '{"user_id":"npub1abc","balance":5220,"deposited":8000}'
+        ct = encrypt(msg, sk1.hex(), sk2.public_key.hex())
+        pt = decrypt(ct, sk2.hex(), sk1.public_key.hex())
+        assert pt == msg
+
+    def test_round_trip_long(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        msg = "x" * 10000
+        ct = encrypt(msg, sk1.hex(), sk2.public_key.hex())
+        pt = decrypt(ct, sk2.hex(), sk1.public_key.hex())
+        assert pt == msg
+
+    def test_ciphertext_is_base64(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ct = encrypt("test", sk1.hex(), sk2.public_key.hex())
+        # Should not raise
+        payload = base64.b64decode(ct)
+        # Version byte should be 2
+        assert payload[0] == 2
+
+    def test_plaintext_not_in_ciphertext(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        msg = "sensitive_balance_data_12345"
+        ct = encrypt(msg, sk1.hex(), sk2.public_key.hex())
+        payload = base64.b64decode(ct)
+        assert msg.encode() not in payload
+
+    def test_wrong_key_fails(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+        sk3 = PrivateKey()
+
+        ct = encrypt("secret", sk1.hex(), sk2.public_key.hex())
+        with pytest.raises(ValueError, match="decryption failed"):
+            decrypt(ct, sk3.hex(), sk1.public_key.hex())
+
+    def test_tampered_ciphertext_fails(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ct = encrypt("secret", sk1.hex(), sk2.public_key.hex())
+        payload = bytearray(base64.b64decode(ct))
+        # Flip a byte in the ciphertext portion
+        payload[-5] ^= 0xFF
+        tampered = base64.b64encode(bytes(payload)).decode()
+        with pytest.raises(ValueError, match="decryption failed"):
+            decrypt(tampered, sk2.hex(), sk1.public_key.hex())
+
+    def test_wrong_version_rejected(self) -> None:
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ct = encrypt("test", sk1.hex(), sk2.public_key.hex())
+        payload = bytearray(base64.b64decode(ct))
+        payload[0] = 99  # wrong version
+        bad = base64.b64encode(bytes(payload)).decode()
+        with pytest.raises(ValueError, match="Unsupported NIP-44 version"):
+            decrypt(bad, sk2.hex(), sk1.public_key.hex())
+
+    def test_payload_too_short(self) -> None:
+        with pytest.raises(ValueError, match="too short"):
+            decrypt(base64.b64encode(b"\x02" + b"\x00" * 10).decode(), "aa" * 32, "bb" * 32)
+
+    def test_each_encryption_differs(self) -> None:
+        """Random nonce means same plaintext encrypts differently each time."""
+        sk1 = PrivateKey()
+        sk2 = PrivateKey()
+
+        ct1 = encrypt("same", sk1.hex(), sk2.public_key.hex())
+        ct2 = encrypt("same", sk1.hex(), sk2.public_key.hex())
+        assert ct1 != ct2
+
+        # But both decrypt to the same plaintext
+        assert decrypt(ct1, sk2.hex(), sk1.public_key.hex()) == "same"
+        assert decrypt(ct2, sk2.hex(), sk1.public_key.hex()) == "same"

--- a/tests/test_nostr_audit.py
+++ b/tests/test_nostr_audit.py
@@ -153,8 +153,8 @@ class TestPublishLedgerUpdate:
 
     @patch("tollbooth.nostr_audit._HAS_PYNOSTR", True)
     @patch("tollbooth.nostr_audit._HAS_WEBSOCKET", True)
-    def test_constructs_event_and_publishes(self) -> None:
-        """Test that a valid publisher constructs an event and fires a thread."""
+    def test_constructs_plaintext_event_for_non_npub(self) -> None:
+        """Non-npub user IDs produce plaintext content (legacy path)."""
         mock_pk = _mock_private_key()
 
         mock_event = MagicMock()
@@ -172,7 +172,7 @@ class TestPublishLedgerUpdate:
             assert pub.enabled
 
             pub.publish_ledger_update(
-                "npub1testuser", SAMPLE_LEDGER_JSON, "flush",
+                "user_01KGZY", SAMPLE_LEDGER_JSON, "flush",
             )
 
             # Event was constructed with kind 30078
@@ -180,22 +180,23 @@ class TestPublishLedgerUpdate:
             call_kwargs = MockEvent.call_args
             assert call_kwargs.kwargs["kind"] == 30078
 
-            # Content is valid JSON with expected fields
+            # Content is valid JSON with expected fields (plaintext)
             content = json.loads(call_kwargs.kwargs["content"])
-            assert content["user_id"] == "npub1testuser"
+            assert content["user_id"] == "user_01KGZY"
             assert content["balance"] == 5220
             assert content["deposited"] == 8000
             assert content["consumed"] == 2780
             assert content["event_type"] == "flush"
             assert "timestamp" in content
 
-            # Tags include d-tag, p-tag, t-tag, L-tag
+            # Tags include d-tag, p-tag, t-tag, L-tag — NO encrypted tag
             tags = call_kwargs.kwargs["tags"]
             tag_names = [t[0] for t in tags]
             assert "d" in tag_names
             assert "p" in tag_names
             assert "t" in tag_names
             assert "L" in tag_names
+            assert "encrypted" not in tag_names
 
             # d-tag starts with tollbooth-audit-
             d_tag = [t for t in tags if t[0] == "d"][0]
@@ -211,6 +212,77 @@ class TestPublishLedgerUpdate:
             # Thread was started for relay publishing
             mock_threading.Thread.assert_called_once()
             mock_threading.Thread.return_value.start.assert_called_once()
+
+    @patch("tollbooth.nostr_audit._HAS_PYNOSTR", True)
+    @patch("tollbooth.nostr_audit._HAS_WEBSOCKET", True)
+    def test_encrypts_content_for_npub_patron(self) -> None:
+        """npub user IDs get NIP-44 encrypted content + encrypted tag."""
+        mock_pk = _mock_private_key()
+
+        mock_event = MagicMock()
+        mock_event.to_message.return_value = '["EVENT", {}]'
+
+        with (
+            patch("tollbooth.nostr_audit.PrivateKey", create=True) as MockPK,
+            patch("tollbooth.nostr_audit.Event", create=True) as MockEvent,
+            patch("tollbooth.nostr_audit.threading") as mock_threading,
+            patch("tollbooth.nostr_audit._HAS_NIP44", True),
+            patch(
+                "tollbooth.nostr_audit._nip44_encrypt",
+                return_value="ENCRYPTED_BASE64_PAYLOAD",
+                create=True,
+            ) as mock_encrypt,
+        ):
+            MockPK.from_nsec.return_value = mock_pk
+            MockEvent.return_value = mock_event
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+
+            pub.publish_ledger_update(
+                "npub1testuser", SAMPLE_LEDGER_JSON, "flush",
+            )
+
+            # NIP-44 encrypt was called with the plaintext JSON
+            mock_encrypt.assert_called_once()
+            encrypt_args = mock_encrypt.call_args
+            plaintext_arg = encrypt_args.args[0]
+            assert '"balance":5220' in plaintext_arg
+            assert '"user_id":"npub1testuser"' in plaintext_arg
+
+            # Event content is the encrypted payload, not plaintext
+            MockEvent.assert_called_once()
+            call_kwargs = MockEvent.call_args
+            assert call_kwargs.kwargs["content"] == "ENCRYPTED_BASE64_PAYLOAD"
+
+            # Tags include the encrypted marker
+            tags = call_kwargs.kwargs["tags"]
+            tag_names = [t[0] for t in tags]
+            assert "encrypted" in tag_names
+            enc_tag = [t for t in tags if t[0] == "encrypted"][0]
+            assert enc_tag[1] == "nip44"
+
+    @patch("tollbooth.nostr_audit._HAS_PYNOSTR", True)
+    @patch("tollbooth.nostr_audit._HAS_WEBSOCKET", True)
+    @patch("tollbooth.nostr_audit._HAS_NIP44", False)
+    def test_skips_publish_when_nip44_unavailable_for_npub(self) -> None:
+        """Refuse plaintext fallback — skip event entirely for npub patrons."""
+        mock_pk = _mock_private_key()
+
+        with (
+            patch("tollbooth.nostr_audit.PrivateKey", create=True) as MockPK,
+            patch("tollbooth.nostr_audit.Event", create=True) as MockEvent,
+            patch("tollbooth.nostr_audit.threading") as mock_threading,
+        ):
+            MockPK.from_nsec.return_value = mock_pk
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+            pub.publish_ledger_update(
+                "npub1testuser", SAMPLE_LEDGER_JSON, "flush",
+            )
+
+            # Event should NOT be constructed — refused plaintext fallback
+            MockEvent.assert_not_called()
+            mock_threading.Thread.assert_not_called()
 
     @patch("tollbooth.nostr_audit._HAS_PYNOSTR", True)
     @patch("tollbooth.nostr_audit._HAS_WEBSOCKET", True)
@@ -369,6 +441,131 @@ class TestEventContent:
 
             content = json.loads(MockEvent.call_args.kwargs["content"])
             assert content["event_type"] == "snapshot"
+
+
+# ---------------------------------------------------------------------------
+# SSL certificate verification
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# NIP-44 encryption integration — real crypto, no mocks
+# ---------------------------------------------------------------------------
+
+
+class TestNIP44EncryptionIntegration:
+    """End-to-end tests: real NostrAuditPublisher with real NIP-44 encryption."""
+
+    def test_real_encrypted_event_decryptable_by_patron(self) -> None:
+        """Publish an encrypted event, verify patron can decrypt the content."""
+        from pynostr.key import PrivateKey as RealPrivateKey
+        from tollbooth.nip44 import decrypt as nip44_decrypt
+
+        operator_sk = RealPrivateKey.from_nsec(FAKE_NSEC)
+        patron_sk = RealPrivateKey()
+        patron_npub = patron_sk.public_key.bech32()
+
+        captured_events: list[dict] = []
+
+        # Patch Event to capture rather than sign
+        with (
+            patch("tollbooth.nostr_audit.Event") as MockEvent,
+            patch("tollbooth.nostr_audit.threading"),
+        ):
+            mock_event = MagicMock()
+            mock_event.to_message.return_value = '["EVENT", {}]'
+            MockEvent.return_value = mock_event
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+            assert pub.enabled
+
+            pub.publish_ledger_update(
+                patron_npub, SAMPLE_LEDGER_JSON, "flush",
+            )
+
+            MockEvent.assert_called_once()
+            call_kwargs = MockEvent.call_args.kwargs
+            captured_events.append(call_kwargs)
+
+        event_kwargs = captured_events[0]
+
+        # Content should be NIP-44 encrypted (base64, not JSON)
+        content = event_kwargs["content"]
+        try:
+            json.loads(content)
+            pytest.fail("Content should be encrypted, not valid JSON")
+        except json.JSONDecodeError:
+            pass  # Expected — it's base64 ciphertext
+
+        # Patron decrypts with their nsec + operator's pubkey
+        decrypted = nip44_decrypt(
+            content, patron_sk.hex(), operator_sk.public_key.hex(),
+        )
+        payload = json.loads(decrypted)
+        assert payload["user_id"] == patron_npub
+        assert payload["balance"] == 5220
+        assert payload["deposited"] == 8000
+        assert payload["event_type"] == "flush"
+
+        # Encrypted tag present
+        tags = event_kwargs["tags"]
+        enc_tags = [t for t in tags if t[0] == "encrypted"]
+        assert len(enc_tags) == 1
+        assert enc_tags[0][1] == "nip44"
+
+    def test_observer_cannot_read_encrypted_content(self) -> None:
+        """A third party without the patron's nsec cannot decrypt."""
+        from pynostr.key import PrivateKey as RealPrivateKey
+        from tollbooth.nip44 import decrypt as nip44_decrypt
+
+        operator_sk = RealPrivateKey.from_nsec(FAKE_NSEC)
+        patron_sk = RealPrivateKey()
+        observer_sk = RealPrivateKey()
+
+        with (
+            patch("tollbooth.nostr_audit.Event") as MockEvent,
+            patch("tollbooth.nostr_audit.threading"),
+        ):
+            mock_event = MagicMock()
+            mock_event.to_message.return_value = '["EVENT", {}]'
+            MockEvent.return_value = mock_event
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+            pub.publish_ledger_update(
+                patron_sk.public_key.bech32(), SAMPLE_LEDGER_JSON,
+            )
+
+            content = MockEvent.call_args.kwargs["content"]
+
+        # Observer tries to decrypt — should fail
+        with pytest.raises(ValueError, match="decryption failed"):
+            nip44_decrypt(
+                content, observer_sk.hex(), operator_sk.public_key.hex(),
+            )
+
+    def test_p_tag_contains_patron_hex_pubkey(self) -> None:
+        """The p-tag enables patron discovery on relays."""
+        from pynostr.key import PrivateKey as RealPrivateKey
+
+        patron_sk = RealPrivateKey()
+        patron_npub = patron_sk.public_key.bech32()
+        patron_hex = patron_sk.public_key.hex()
+
+        with (
+            patch("tollbooth.nostr_audit.Event") as MockEvent,
+            patch("tollbooth.nostr_audit.threading"),
+        ):
+            mock_event = MagicMock()
+            mock_event.to_message.return_value = '["EVENT", {}]'
+            MockEvent.return_value = mock_event
+
+            pub = NostrAuditPublisher(FAKE_NSEC, FAKE_RELAYS, enabled=True)
+            pub.publish_ledger_update(patron_npub, SAMPLE_LEDGER_JSON)
+
+            tags = MockEvent.call_args.kwargs["tags"]
+            p_tags = [t for t in tags if t[0] == "p"]
+            assert len(p_tags) == 1
+            assert p_tags[0][1] == patron_hex
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Audit event `content` is now NIP-44v2 encrypted to the patron's npub when the patron is identified by npub
- Only the patron's nsec can decrypt their balance data; observers see event metadata but not content
- **Plaintext fallback refused**: if NIP-44 deps unavailable for npub patrons, events are skipped entirely (never published in cleartext)
- Non-npub patrons (legacy Horizon IDs) still get plaintext events
- New `nip44.py` module: standalone NIP-44v2 using coincurve + cryptography (zero new deps)
- Events include `["encrypted", "nip44"]` tag for client detection

## What observers see
```json
{
  "kind": 30078,
  "content": "<NIP-44 ciphertext — opaque to everyone except patron>",
  "tags": [["d", "tollbooth-audit-..."], ["p", "<patron_hex>"], ["encrypted", "nip44"], ...]
}
```

## Test plan
- [x] 25 NIP-44 unit tests (padding, conversation key, encrypt/decrypt, wrong key, tamper)
- [x] 3 integration tests (real crypto: patron decryption, observer rejection, p-tag verification)
- [x] 2 new audit publisher tests (encryption path, plaintext-refusal path)
- [x] 478 total tests pass (was 448)

🤖 Generated with [Claude Code](https://claude.com/claude-code)