### PR TITLE
Secure Courier Service — Nostr DM credential exchange

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.28"
+version = "0.1.29"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.28"
+__version__ = "0.1.29"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
@@ -22,6 +22,29 @@ try:
 except ImportError:
     NostrAuditPublisher = None  # type: ignore[assignment,misc]
     AuditedVault = None  # type: ignore[assignment,misc]
+
+try:
+    from tollbooth.nostr_credentials import (
+        NostrCredentialExchange,
+        CourierError,
+        CourierNotReady,
+        CourierTimeout,
+        CourierValidationError,
+    )
+    from tollbooth.credential_templates import (
+        CredentialTemplate,
+        FieldSpec,
+        TemplateValidationError,
+    )
+except ImportError:
+    NostrCredentialExchange = None  # type: ignore[assignment,misc]
+    CourierError = None  # type: ignore[assignment,misc]
+    CourierNotReady = None  # type: ignore[assignment,misc]
+    CourierTimeout = None  # type: ignore[assignment,misc]
+    CourierValidationError = None  # type: ignore[assignment,misc]
+    CredentialTemplate = None  # type: ignore[assignment,misc]
+    FieldSpec = None  # type: ignore[assignment,misc]
+    TemplateValidationError = None  # type: ignore[assignment,misc]
 
 __all__ = [
     "CertificateError",
@@ -51,4 +74,12 @@ __all__ = [
     "MerkleTree",
     "InclusionProof",
     "OTSCalendarClient",
+    "NostrCredentialExchange",
+    "CourierError",
+    "CourierNotReady",
+    "CourierTimeout",
+    "CourierValidationError",
+    "CredentialTemplate",
+    "FieldSpec",
+    "TemplateValidationError",
 ]

--- a/src/tollbooth/credential_templates.py
+++ b/src/tollbooth/credential_templates.py
@@ -1,0 +1,123 @@
+"""Credential template schema definition and validation.
+
+Operators define strict credential templates — no freeform JSON accepted.
+Each template declares the expected fields (required/optional, sensitive/not)
+and a service name for matching incoming payloads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Specification for a single credential field."""
+
+    required: bool = True
+    sensitive: bool = True
+
+
+@dataclass(frozen=True)
+class CredentialTemplate:
+    """Schema for a service's credential payload.
+
+    Operators declare expected fields; incoming payloads are validated
+    against this schema.  Unknown fields are rejected, required fields
+    enforced, and the ``description`` is rendered for the end user.
+    """
+
+    service: str
+    version: int
+    fields: dict[str, FieldSpec]
+    description: str = ""
+
+
+class TemplateValidationError(ValueError):
+    """Raised when a credential payload fails template validation."""
+
+
+def validate_payload(
+    payload: dict,
+    template: CredentialTemplate,
+) -> dict[str, str]:
+    """Validate a credential payload against a template.
+
+    Args:
+        payload: Decoded JSON dict from the Nostr DM.
+        template: The operator-defined credential template.
+
+    Returns:
+        Validated payload dict (only the declared fields, stripped of any
+        ``service`` or ``version`` metadata keys).
+
+    Raises:
+        TemplateValidationError: On missing required fields, unknown fields,
+            or type mismatches.
+    """
+    # Allow optional service/version metadata in the payload
+    metadata_keys = {"service", "version"}
+    payload_fields = {k: v for k, v in payload.items() if k not in metadata_keys}
+
+    # Check for unknown fields
+    known = set(template.fields.keys())
+    unknown = set(payload_fields.keys()) - known
+    if unknown:
+        raise TemplateValidationError(
+            f"Unknown fields: {', '.join(sorted(unknown))}. "
+            f"Expected: {', '.join(sorted(known))}"
+        )
+
+    # Check required fields
+    missing = []
+    for name, spec in template.fields.items():
+        if spec.required and name not in payload_fields:
+            missing.append(name)
+    if missing:
+        raise TemplateValidationError(
+            f"Missing required fields: {', '.join(sorted(missing))}"
+        )
+
+    # Validate types (all values must be strings)
+    for name, value in payload_fields.items():
+        if not isinstance(value, str):
+            raise TemplateValidationError(
+                f"Field '{name}' must be a string, got {type(value).__name__}"
+            )
+        if template.fields[name].required and not value.strip():
+            raise TemplateValidationError(
+                f"Required field '{name}' must not be empty"
+            )
+
+    return payload_fields
+
+
+def render_template_instructions(template: CredentialTemplate) -> str:
+    """Render a credential template as human-readable DM instructions.
+
+    Produces a text block the user can reference when composing their
+    Nostr DM payload.
+    """
+    lines = [
+        f"Service: {template.service} (v{template.version})",
+    ]
+    if template.description:
+        lines.append(f"Description: {template.description}")
+    lines.append("")
+    lines.append("Send a JSON object as a Nostr DM with these fields:")
+    lines.append("")
+
+    for name, spec in template.fields.items():
+        req = "REQUIRED" if spec.required else "optional"
+        lines.append(f'  "{name}": "<your value>"  ({req})')
+
+    lines.append("")
+    lines.append("Example:")
+    example = {}
+    for name, spec in template.fields.items():
+        example[name] = f"your_{name}_here"
+    import json
+
+    lines.append(f"  {json.dumps(example, indent=2)}")
+
+    return "\n".join(lines)

--- a/src/tollbooth/nip04.py
+++ b/src/tollbooth/nip04.py
@@ -1,0 +1,84 @@
+"""NIP-04 decryption — legacy AES-256-CBC encrypted direct messages.
+
+Implements the NIP-04 decryption scheme used by older Nostr clients for
+kind 4 encrypted DMs.  The content format is ``<base64_ciphertext>?iv=<base64_iv>``.
+
+The shared secret is derived via secp256k1 ECDH (same curve as NIP-44), but
+the symmetric cipher is AES-256-CBC instead of ChaCha20-Poly1305.
+
+Dependencies: ``coincurve`` (secp256k1 ECDH) and ``cryptography``
+(AES-256-CBC) — both already transitive deps of pynostr.
+
+Reference: https://github.com/nostr-protocol/nips/blob/master/04.md
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from coincurve import PrivateKey as _CoinPrivateKey  # type: ignore[import-untyped]
+from coincurve import PublicKey as _CoinPublicKey  # type: ignore[import-untyped]
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.padding import PKCS7
+
+
+def _get_shared_secret(private_key_hex: str, public_key_hex: str) -> bytes:
+    """Derive NIP-04 shared secret via secp256k1 ECDH.
+
+    Returns the SHA-256 hash of the x-coordinate of the ECDH shared point,
+    used as the AES-256-CBC key.
+    """
+    sk = _CoinPrivateKey(bytes.fromhex(private_key_hex))
+    pk = _CoinPublicKey(b"\x02" + bytes.fromhex(public_key_hex))
+    shared_point = pk.multiply(sk.secret)
+    shared_x = shared_point.format(compressed=False)[1:33]
+    return shared_x
+
+
+def decrypt(
+    ciphertext_with_iv: str,
+    private_key_hex: str,
+    public_key_hex: str,
+) -> str:
+    """Decrypt a NIP-04 message.
+
+    Args:
+        ciphertext_with_iv: NIP-04 format ``<base64_ciphertext>?iv=<base64_iv>``.
+        private_key_hex: Recipient's 32-byte private key as hex.
+        public_key_hex: Sender's 32-byte x-only public key as hex.
+
+    Returns:
+        Decrypted UTF-8 plaintext string.
+
+    Raises:
+        ValueError: On invalid format, decryption failure, or padding error.
+    """
+    if "?iv=" not in ciphertext_with_iv:
+        raise ValueError(
+            "Invalid NIP-04 format: expected <base64>?iv=<base64>"
+        )
+
+    parts = ciphertext_with_iv.split("?iv=", 1)
+    try:
+        ciphertext = base64.b64decode(parts[0])
+        iv = base64.b64decode(parts[1])
+    except Exception as e:
+        raise ValueError(f"NIP-04 base64 decode failed: {e}") from e
+
+    if len(iv) != 16:
+        raise ValueError(f"NIP-04 IV must be 16 bytes, got {len(iv)}")
+
+    shared_secret = _get_shared_secret(private_key_hex, public_key_hex)
+
+    try:
+        cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv))
+        decryptor = cipher.decryptor()
+        padded = decryptor.update(ciphertext) + decryptor.finalize()
+
+        unpadder = PKCS7(128).unpadder()
+        plaintext_bytes = unpadder.update(padded) + unpadder.finalize()
+    except Exception as e:
+        raise ValueError(f"NIP-04 decryption failed: {e}") from e
+
+    return plaintext_bytes.decode("utf-8")

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -1,0 +1,678 @@
+"""Nostr DM credential exchange — the Secure Courier Service.
+
+Out-of-band credential delivery via NIP-44 (or NIP-04 fallback) encrypted
+Nostr DMs.  Patrons send credentials from their Nostr client to the MCP
+operator's npub; the operator picks them up, validates, stores, and
+destroys the relay copy.
+
+Two-tool operator interface:
+
+    exchange = NostrCredentialExchange(nsec, relays, templates)
+
+    # Tool 1: Tell patron where to send
+    await exchange.open_channel("x")
+
+    # Tool 2: Pick up the sealed pouch
+    await exchange.receive("npub1user...")
+
+Dependencies are optional — install with ``pip install tollbooth-dpyc[nostr]``.
+
+Reference: https://github.com/nostr-protocol/nips/blob/master/44.md (NIP-44)
+           https://github.com/nostr-protocol/nips/blob/master/04.md (NIP-04)
+           https://github.com/nostr-protocol/nips/blob/master/09.md (NIP-09)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from typing import Any
+
+from tollbooth.credential_templates import (
+    CredentialTemplate,
+    FieldSpec,
+    TemplateValidationError,
+    render_template_instructions,
+    validate_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+# Optional imports — graceful degradation
+try:
+    from pynostr.event import Event  # type: ignore[import-untyped]
+    from pynostr.key import PrivateKey, PublicKey  # type: ignore[import-untyped]
+
+    _HAS_PYNOSTR = True
+except ImportError:
+    _HAS_PYNOSTR = False
+
+try:
+    from websocket import create_connection  # type: ignore[import-untyped]
+
+    _HAS_WEBSOCKET = True
+except ImportError:
+    _HAS_WEBSOCKET = False
+
+try:
+    from tollbooth.nip44 import decrypt as _nip44_decrypt
+
+    _HAS_NIP44 = True
+except ImportError:
+    _HAS_NIP44 = False
+
+try:
+    from tollbooth.nip04 import decrypt as _nip04_decrypt
+
+    _HAS_NIP04 = True
+except ImportError:
+    _HAS_NIP04 = False
+
+
+# Nostr event kinds
+_KIND_ENCRYPTED_DM = 4  # NIP-04 legacy DMs
+_KIND_GIFT_WRAP = 1059  # NIP-17/NIP-59 gift-wrapped DMs
+_KIND_SEAL = 13  # NIP-59 seal (inner layer of gift wrap)
+_KIND_PRIVATE_DM = 14  # NIP-17 private DM (innermost content)
+_KIND_DELETION = 5  # NIP-09 event deletion
+
+# Default freshness window (seconds)
+_DEFAULT_FRESHNESS = 600  # 10 minutes
+_DEFAULT_SUBSCRIBE_TIMEOUT = 10
+
+
+def _npub_to_hex(npub: str) -> str:
+    """Convert npub bech32 to 32-byte hex pubkey."""
+    if not _HAS_PYNOSTR:
+        raise RuntimeError("pynostr required for npub conversion")
+    return PublicKey.from_npub(npub).hex()
+
+
+def _hex_to_npub(hex_pubkey: str) -> str:
+    """Convert 32-byte hex pubkey to npub bech32."""
+    if not _HAS_PYNOSTR:
+        raise RuntimeError("pynostr required for npub conversion")
+    return PublicKey(bytes.fromhex(hex_pubkey)).bech32()
+
+
+class CourierError(Exception):
+    """Base error for credential exchange operations."""
+
+
+class CourierNotReady(CourierError):
+    """Raised when dependencies are missing or exchange is not configured."""
+
+
+class CourierTimeout(CourierError):
+    """Raised when no matching DM is found within the freshness window."""
+
+
+class CourierValidationError(CourierError):
+    """Raised when credential payload fails template validation."""
+
+
+class NostrCredentialExchange:
+    """Secure Courier Service — out-of-band credential delivery via Nostr.
+
+    Operators instantiate with their nsec, relay list, and credential
+    templates.  Exposes two async methods for the MCP tool layer:
+    ``open_channel()`` and ``receive()``.
+
+    All relay I/O runs in background threads (sync websocket-client)
+    to avoid blocking the async MCP event loop.
+    """
+
+    def __init__(
+        self,
+        nsec: str,
+        relays: list[str],
+        templates: dict[str, CredentialTemplate],
+        *,
+        freshness_window: int = _DEFAULT_FRESHNESS,
+        nip44_only: bool = False,
+    ) -> None:
+        """Initialize the credential exchange.
+
+        Args:
+            nsec: Operator's Nostr nsec (bech32).
+            relays: List of relay WebSocket URLs.
+            templates: Map of service name → CredentialTemplate.
+            freshness_window: Max age in seconds for accepted DMs.
+            nip44_only: If True, reject NIP-04 DMs entirely.
+        """
+        self._freshness_window = freshness_window
+        self._nip44_only = nip44_only
+        self._templates = templates
+        self._relays = [r.strip() for r in relays if r.strip()]
+
+        # Key material
+        self._privkey_hex: str = ""
+        self._pubkey_hex: str = ""
+        self._npub: str = ""
+        self._enabled = True
+
+        if not _HAS_PYNOSTR:
+            logger.warning(
+                "pynostr not installed — Secure Courier disabled. "
+                "Install with: pip install tollbooth-dpyc[nostr]"
+            )
+            self._enabled = False
+            return
+
+        if not _HAS_WEBSOCKET:
+            logger.warning(
+                "websocket-client not installed — Secure Courier disabled. "
+                "Install with: pip install tollbooth-dpyc[nostr]"
+            )
+            self._enabled = False
+            return
+
+        if not self._relays:
+            logger.warning("No Nostr relays configured — Secure Courier disabled.")
+            self._enabled = False
+            return
+
+        try:
+            pk = PrivateKey.from_nsec(nsec)
+            self._privkey_hex = pk.hex()
+            self._pubkey_hex = pk.public_key.hex()
+            self._npub = pk.public_key.bech32()
+        except Exception as exc:
+            logger.warning("Invalid operator nsec — Secure Courier disabled: %s", exc)
+            self._enabled = False
+
+        # Thread-safe buffer for received events
+        self._lock = threading.Lock()
+        self._received_events: list[dict[str, Any]] = []
+        # Track consumed event IDs (prevent double-pickup)
+        self._consumed_ids: set[str] = set()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the exchange is active and ready."""
+        return self._enabled
+
+    @property
+    def npub(self) -> str:
+        """Operator's npub (bech32)."""
+        return self._npub
+
+    @property
+    def relays(self) -> list[str]:
+        """Configured relay URLs."""
+        return list(self._relays)
+
+    async def open_channel(self, service: str) -> dict[str, Any]:
+        """Open a credential delivery channel for a service.
+
+        Returns the operator's npub, relay list, and template instructions
+        so the patron knows where and what to send.  Also starts a
+        background relay subscription to listen for incoming DMs.
+
+        Args:
+            service: Template service name (e.g., "x", "openai").
+
+        Returns:
+            Dict with npub, relays, template instructions, and freshness window.
+        """
+        if not self._enabled:
+            raise CourierNotReady(
+                "Secure Courier not available. Check logs for missing dependencies."
+            )
+
+        if service not in self._templates:
+            available = ", ".join(sorted(self._templates.keys()))
+            raise CourierValidationError(
+                f"Unknown service '{service}'. Available: {available}"
+            )
+
+        template = self._templates[service]
+        instructions = render_template_instructions(template)
+
+        # Start background subscription
+        self._start_subscription()
+
+        return {
+            "success": True,
+            "npub": self._npub,
+            "relays": self._relays,
+            "service": service,
+            "freshness_window_seconds": self._freshness_window,
+            "instructions": instructions,
+            "message": (
+                f"Send your {template.service} credentials as a Nostr DM "
+                f"to {self._npub} from your Nostr client. "
+                f"The DM must contain a JSON object matching the template above. "
+                f"Then call receive_credentials with your npub."
+            ),
+        }
+
+    async def receive(self, sender_npub: str) -> dict[str, Any]:
+        """Pick up and validate credentials from a sender.
+
+        Checks the received DM buffer for messages from ``sender_npub``
+        within the freshness window.  If not found in the buffer, does
+        a one-shot relay fetch.
+
+        On success, validates the payload against the matching template,
+        publishes a NIP-09 deletion request, and returns the validated
+        credentials (never echoing sensitive values).
+
+        Args:
+            sender_npub: Patron's npub (bech32).
+
+        Returns:
+            Dict with success, service name, and field count.
+            The actual credential values are returned under a
+            ``credentials`` key for the caller to store.
+        """
+        if not self._enabled:
+            raise CourierNotReady(
+                "Secure Courier not available. Check logs for missing dependencies."
+            )
+
+        try:
+            sender_hex = _npub_to_hex(sender_npub)
+        except Exception as exc:
+            raise CourierValidationError(f"Invalid sender npub: {exc}") from exc
+
+        # Try buffer first, then one-shot fetch
+        dm = self._find_dm_in_buffer(sender_hex)
+        if dm is None:
+            self._fetch_dms_from_relays()
+            dm = self._find_dm_in_buffer(sender_hex)
+
+        if dm is None:
+            raise CourierTimeout(
+                f"No DM found from {sender_npub} within the "
+                f"{self._freshness_window}-second freshness window. "
+                f"Make sure you sent the DM from your Nostr client and "
+                f"try again."
+            )
+
+        # Decrypt content
+        plaintext = self._decrypt_dm(dm, sender_hex)
+
+        # Parse JSON payload
+        try:
+            payload = json.loads(plaintext)
+        except json.JSONDecodeError as exc:
+            raise CourierValidationError(
+                f"DM content is not valid JSON: {exc}"
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise CourierValidationError(
+                "DM content must be a JSON object, "
+                f"got {type(payload).__name__}"
+            )
+
+        # Match template
+        service = payload.get("service")
+        template = self._match_template(service, payload)
+
+        # Validate against template
+        try:
+            validated = validate_payload(payload, template)
+        except TemplateValidationError as exc:
+            raise CourierValidationError(str(exc)) from exc
+
+        # Mark event as consumed
+        event_id = dm.get("id", "")
+        with self._lock:
+            self._consumed_ids.add(event_id)
+
+        # Publish NIP-09 deletion request (fire-and-forget)
+        if event_id:
+            self._request_deletion(event_id)
+
+        # Count sensitive vs non-sensitive fields
+        sensitive_count = sum(
+            1 for name in validated if template.fields.get(name, FieldSpec()).sensitive
+        )
+
+        return {
+            "success": True,
+            "service": template.service,
+            "fields_received": len(validated),
+            "sensitive_fields": sensitive_count,
+            "encryption": dm.get("encryption", "unknown"),
+            "credentials": validated,
+            "message": (
+                f"Credentials received for {template.service} "
+                f"({len(validated)} fields). "
+                f"Relay copy deletion requested."
+            ),
+        }
+
+    def _match_template(
+        self, service: str | None, payload: dict,
+    ) -> CredentialTemplate:
+        """Find the matching template for a payload."""
+        # Exact match by service name
+        if service and service in self._templates:
+            return self._templates[service]
+
+        # Single-template shortcut: if only one template, use it
+        if len(self._templates) == 1:
+            return next(iter(self._templates.values()))
+
+        # Try to match by field names
+        payload_fields = {
+            k for k in payload.keys() if k not in {"service", "version"}
+        }
+        for tmpl in self._templates.values():
+            template_fields = set(tmpl.fields.keys())
+            if payload_fields.issubset(template_fields):
+                return tmpl
+
+        available = ", ".join(sorted(self._templates.keys()))
+        raise CourierValidationError(
+            f"Cannot match payload to a template. "
+            f"Include a 'service' field or available services: {available}"
+        )
+
+    def _start_subscription(self) -> None:
+        """Start a background relay subscription for incoming DMs."""
+        thread = threading.Thread(
+            target=self._subscribe_to_relays,
+            daemon=True,
+        )
+        thread.start()
+
+    def _subscribe_to_relays(self) -> None:
+        """Subscribe to all relays for DMs addressed to us."""
+        since = int(time.time()) - self._freshness_window
+        # REQ filter: kind 4 (NIP-04) and kind 1059 (NIP-17 gift wrap)
+        kinds = [_KIND_ENCRYPTED_DM]
+        if not self._nip44_only:
+            kinds.append(_KIND_GIFT_WRAP)
+        else:
+            # For NIP-44-only, still listen for gift wraps
+            kinds = [_KIND_GIFT_WRAP]
+            # Also listen for kind 4 in case sender used NIP-04
+            # (we'll reject it during decrypt if nip44_only is set)
+            kinds.append(_KIND_ENCRYPTED_DM)
+
+        # NIP-04 DMs are tagged with p-tag for recipient
+        # NIP-17 gift wraps are tagged with p-tag for recipient
+        req_filter = {
+            "kinds": kinds,
+            "#p": [self._pubkey_hex],
+            "since": since,
+            "limit": 50,
+        }
+        sub_id = f"courier-{int(time.time())}"
+
+        for relay_url in self._relays:
+            try:
+                self._subscribe_one_relay(relay_url, sub_id, req_filter)
+            except Exception as exc:
+                logger.debug(
+                    "Relay subscription %s failed (non-fatal): %s",
+                    relay_url, exc,
+                )
+
+    def _subscribe_one_relay(
+        self,
+        relay_url: str,
+        sub_id: str,
+        req_filter: dict[str, Any],
+    ) -> None:
+        """Subscribe to one relay and collect events."""
+        sslopt: dict[str, Any] = {}
+        ws = create_connection(relay_url, timeout=_DEFAULT_SUBSCRIBE_TIMEOUT, sslopt=sslopt)
+        try:
+            # Send REQ
+            req_msg = json.dumps(["REQ", sub_id, req_filter])
+            ws.send(req_msg)
+
+            # Read events until EOSE or timeout
+            ws.settimeout(_DEFAULT_SUBSCRIBE_TIMEOUT)
+            while True:
+                try:
+                    raw = ws.recv()
+                except Exception:
+                    break
+
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                if not isinstance(msg, list) or len(msg) < 2:
+                    continue
+
+                msg_type = msg[0]
+
+                if msg_type == "EVENT" and len(msg) >= 3:
+                    event_data = msg[2]
+                    if isinstance(event_data, dict):
+                        event_data["_relay"] = relay_url
+                        with self._lock:
+                            self._received_events.append(event_data)
+
+                elif msg_type == "EOSE":
+                    break
+
+                elif msg_type == "CLOSED" or msg_type == "NOTICE":
+                    break
+
+            # Send CLOSE
+            close_msg = json.dumps(["CLOSE", sub_id])
+            ws.send(close_msg)
+        finally:
+            ws.close()
+
+    def _fetch_dms_from_relays(self) -> None:
+        """One-shot fetch of recent DMs from all relays."""
+        self._subscribe_to_relays()
+
+    def _find_dm_in_buffer(self, sender_hex: str) -> dict[str, Any] | None:
+        """Find the most recent unconsumed DM from a sender."""
+        now = int(time.time())
+        cutoff = now - self._freshness_window
+
+        with self._lock:
+            candidates = []
+            for event in self._received_events:
+                event_id = event.get("id", "")
+                if event_id in self._consumed_ids:
+                    continue
+
+                created_at = event.get("created_at", 0)
+                if created_at < cutoff:
+                    continue
+
+                kind = event.get("kind", 0)
+
+                if kind == _KIND_ENCRYPTED_DM:
+                    # NIP-04: sender is event.pubkey
+                    if event.get("pubkey", "") == sender_hex:
+                        candidates.append(event)
+
+                elif kind == _KIND_GIFT_WRAP:
+                    # NIP-17: sender is hidden inside the seal
+                    # We can't filter by sender until we unwrap, so
+                    # include all gift wraps as candidates
+                    candidates.append(event)
+
+            if not candidates:
+                return None
+
+            # Return the most recent
+            candidates.sort(key=lambda e: e.get("created_at", 0), reverse=True)
+            return candidates[0]
+
+    def _decrypt_dm(
+        self, event: dict[str, Any], sender_hex: str,
+    ) -> str:
+        """Decrypt a DM event (NIP-04 or NIP-17 gift wrap).
+
+        Returns the plaintext content string.
+        """
+        kind = event.get("kind", 0)
+
+        if kind == _KIND_GIFT_WRAP:
+            return self._unwrap_gift_wrap(event, sender_hex)
+
+        if kind == _KIND_ENCRYPTED_DM:
+            return self._decrypt_nip04_dm(event, sender_hex)
+
+        raise CourierValidationError(f"Unexpected event kind: {kind}")
+
+    def _decrypt_nip04_dm(
+        self, event: dict[str, Any], sender_hex: str,
+    ) -> str:
+        """Decrypt a NIP-04 kind 4 DM."""
+        if self._nip44_only:
+            raise CourierValidationError(
+                "NIP-04 DMs rejected — this operator requires NIP-44 "
+                "(NIP-17 gift wrap). Please use a modern Nostr client."
+            )
+
+        if not _HAS_NIP04:
+            raise CourierValidationError(
+                "NIP-04 decryption not available. Install cryptography."
+            )
+
+        content = event.get("content", "")
+        try:
+            plaintext = _nip04_decrypt(content, self._privkey_hex, sender_hex)
+        except Exception as exc:
+            raise CourierValidationError(
+                f"NIP-04 decryption failed: {exc}"
+            ) from exc
+
+        event["encryption"] = "nip04"
+        logger.info(
+            "Received NIP-04 DM (legacy). Consider upgrading to a "
+            "NIP-17/NIP-44 capable client."
+        )
+        return plaintext
+
+    def _unwrap_gift_wrap(
+        self, event: dict[str, Any], sender_hex: str,
+    ) -> str:
+        """Unwrap a NIP-17 gift wrap (kind 1059 → kind 13 → kind 14).
+
+        NIP-17 uses three layers:
+        1. Gift wrap (kind 1059): encrypted to recipient with random key
+        2. Seal (kind 13): encrypted to recipient with sender's key
+        3. Private DM (kind 14): plaintext content
+
+        The gift wrap is encrypted with NIP-44 using a random one-time key,
+        so we decrypt with our privkey + the gift wrap's pubkey.
+        """
+        if not _HAS_NIP44:
+            raise CourierValidationError(
+                "NIP-44 decryption not available for gift wrap unwrapping."
+            )
+
+        # Layer 1: Decrypt gift wrap content with our privkey + wrap pubkey
+        wrap_pubkey = event.get("pubkey", "")
+        wrap_content = event.get("content", "")
+
+        try:
+            seal_json = _nip44_decrypt(
+                wrap_content, self._privkey_hex, wrap_pubkey,
+            )
+        except Exception as exc:
+            raise CourierValidationError(
+                f"Gift wrap decryption failed: {exc}"
+            ) from exc
+
+        # Layer 2: Parse seal event
+        try:
+            seal = json.loads(seal_json)
+        except json.JSONDecodeError as exc:
+            raise CourierValidationError(
+                f"Seal is not valid JSON: {exc}"
+            ) from exc
+
+        if seal.get("kind") != _KIND_SEAL:
+            raise CourierValidationError(
+                f"Expected kind {_KIND_SEAL} seal, got kind {seal.get('kind')}"
+            )
+
+        # Verify sender identity from seal
+        seal_pubkey = seal.get("pubkey", "")
+        if seal_pubkey != sender_hex:
+            raise CourierValidationError(
+                f"Seal sender {_hex_to_npub(seal_pubkey) if _HAS_PYNOSTR else seal_pubkey} "
+                f"does not match expected sender. "
+                f"DM may be from a different npub."
+            )
+
+        # Layer 3: Decrypt seal content with our privkey + sender pubkey
+        try:
+            dm_json = _nip44_decrypt(
+                seal.get("content", ""), self._privkey_hex, seal_pubkey,
+            )
+        except Exception as exc:
+            raise CourierValidationError(
+                f"Seal decryption failed: {exc}"
+            ) from exc
+
+        try:
+            dm = json.loads(dm_json)
+        except json.JSONDecodeError as exc:
+            raise CourierValidationError(
+                f"DM is not valid JSON: {exc}"
+            ) from exc
+
+        if dm.get("kind") != _KIND_PRIVATE_DM:
+            raise CourierValidationError(
+                f"Expected kind {_KIND_PRIVATE_DM} DM, got kind {dm.get('kind')}"
+            )
+
+        event["encryption"] = "nip44"
+        return dm.get("content", "")
+
+    def _request_deletion(self, event_id: str) -> None:
+        """Publish a NIP-09 deletion request for a consumed event.
+
+        Fire-and-forget in a daemon thread.
+        """
+        if not _HAS_PYNOSTR:
+            return
+
+        try:
+            event = Event(
+                kind=_KIND_DELETION,
+                content="credential received",
+                tags=[["e", event_id]],
+                pubkey=self._pubkey_hex,
+                created_at=int(time.time()),
+            )
+            event.sign(self._privkey_hex)
+            message = event.to_message()
+
+            thread = threading.Thread(
+                target=self._publish_to_relays,
+                args=(message,),
+                daemon=True,
+            )
+            thread.start()
+        except Exception as exc:
+            logger.debug("Failed to create deletion event: %s", exc)
+
+    def _publish_to_relays(self, message: str) -> None:
+        """Send an event to all configured relays."""
+        sslopt: dict[str, Any] = {}
+        for relay_url in self._relays:
+            try:
+                ws = create_connection(
+                    relay_url, timeout=_DEFAULT_SUBSCRIBE_TIMEOUT, sslopt=sslopt,
+                )
+                try:
+                    ws.send(message)
+                    ws.recv()
+                finally:
+                    ws.close()
+            except Exception as exc:
+                logger.debug(
+                    "Relay publish %s failed (non-fatal): %s", relay_url, exc,
+                )

--- a/tests/test_credential_templates.py
+++ b/tests/test_credential_templates.py
@@ -1,0 +1,177 @@
+"""Tests for credential template validation."""
+
+import pytest
+
+from tollbooth.credential_templates import (
+    CredentialTemplate,
+    FieldSpec,
+    TemplateValidationError,
+    render_template_instructions,
+    validate_payload,
+)
+
+
+def _x_api_template() -> CredentialTemplate:
+    """Sample X/Twitter API credential template."""
+    return CredentialTemplate(
+        service="x",
+        version=1,
+        fields={
+            "api_key": FieldSpec(required=True, sensitive=True),
+            "api_secret": FieldSpec(required=True, sensitive=True),
+            "access_token": FieldSpec(required=True, sensitive=True),
+            "access_secret": FieldSpec(required=True, sensitive=True),
+            "display_name": FieldSpec(required=False, sensitive=False),
+        },
+        description="X/Twitter API v2 credentials (OAuth 1.0a User Context)",
+    )
+
+
+class TestValidatePayload:
+    """Tests for validate_payload()."""
+
+    def test_valid_full_payload(self):
+        """All required + optional fields accepted."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+            "display_name": "testuser",
+        }
+        result = validate_payload(payload, tmpl)
+        assert result == payload
+
+    def test_valid_required_only(self):
+        """Optional fields can be omitted."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+        }
+        result = validate_payload(payload, tmpl)
+        assert result == payload
+
+    def test_metadata_keys_stripped(self):
+        """service and version keys are ignored in validation."""
+        tmpl = _x_api_template()
+        payload = {
+            "service": "x",
+            "version": 1,
+            "api_key": "key1",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+        }
+        result = validate_payload(payload, tmpl)
+        assert "service" not in result
+        assert "version" not in result
+        assert len(result) == 4
+
+    def test_unknown_fields_rejected(self):
+        """Fields not in template are rejected."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+            "rogue_field": "evil",
+        }
+        with pytest.raises(TemplateValidationError, match="Unknown fields.*rogue_field"):
+            validate_payload(payload, tmpl)
+
+    def test_missing_required_fields(self):
+        """Missing required fields are reported."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+        }
+        with pytest.raises(TemplateValidationError, match="Missing required fields"):
+            validate_payload(payload, tmpl)
+
+    def test_empty_required_field_rejected(self):
+        """Required field with empty/whitespace value is rejected."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "   ",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+        }
+        with pytest.raises(TemplateValidationError, match="must not be empty"):
+            validate_payload(payload, tmpl)
+
+    def test_non_string_value_rejected(self):
+        """Non-string values are rejected."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": 12345,
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+        }
+        with pytest.raises(TemplateValidationError, match="must be a string"):
+            validate_payload(payload, tmpl)
+
+    def test_empty_optional_field_allowed(self):
+        """Optional field can be empty string."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+            "api_secret": "secret1",
+            "access_token": "token1",
+            "access_secret": "asecret1",
+            "display_name": "",
+        }
+        result = validate_payload(payload, tmpl)
+        assert result["display_name"] == ""
+
+
+class TestRenderInstructions:
+    """Tests for render_template_instructions()."""
+
+    def test_includes_service_name(self):
+        """Instructions mention the service name."""
+        tmpl = _x_api_template()
+        text = render_template_instructions(tmpl)
+        assert "x" in text
+        assert "v1" in text
+
+    def test_includes_description(self):
+        """Instructions include the template description."""
+        tmpl = _x_api_template()
+        text = render_template_instructions(tmpl)
+        assert "OAuth 1.0a" in text
+
+    def test_marks_required_fields(self):
+        """Required fields are labeled REQUIRED."""
+        tmpl = _x_api_template()
+        text = render_template_instructions(tmpl)
+        assert "REQUIRED" in text
+
+    def test_marks_optional_fields(self):
+        """Optional fields are labeled optional."""
+        tmpl = _x_api_template()
+        text = render_template_instructions(tmpl)
+        assert "optional" in text
+
+    def test_includes_example_json(self):
+        """Instructions include example JSON."""
+        tmpl = _x_api_template()
+        text = render_template_instructions(tmpl)
+        assert "your_api_key_here" in text
+
+    def test_minimal_template(self):
+        """Template with no description still renders."""
+        tmpl = CredentialTemplate(
+            service="test",
+            version=1,
+            fields={"token": FieldSpec(required=True)},
+        )
+        text = render_template_instructions(tmpl)
+        assert "test" in text
+        assert "token" in text

--- a/tests/test_nip04.py
+++ b/tests/test_nip04.py
@@ -1,0 +1,99 @@
+"""Tests for NIP-04 decryption."""
+
+import base64
+import os
+
+import pytest
+from pynostr.key import PrivateKey
+
+from tollbooth.nip04 import decrypt, _get_shared_secret
+
+
+class TestNip04Decrypt:
+    """NIP-04 AES-256-CBC decryption tests."""
+
+    def _encrypt_nip04(
+        self, plaintext: str, privkey_hex: str, pubkey_hex: str,
+    ) -> str:
+        """Encrypt a message in NIP-04 format for testing."""
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.primitives.padding import PKCS7
+
+        shared_secret = _get_shared_secret(privkey_hex, pubkey_hex)
+        iv = os.urandom(16)
+
+        padder = PKCS7(128).padder()
+        padded = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+
+        cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv))
+        encryptor = cipher.encryptor()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+        ct_b64 = base64.b64encode(ciphertext).decode("ascii")
+        iv_b64 = base64.b64encode(iv).decode("ascii")
+        return f"{ct_b64}?iv={iv_b64}"
+
+    def test_round_trip(self):
+        """Encrypt then decrypt returns original plaintext."""
+        sender = PrivateKey()
+        recipient = PrivateKey()
+
+        plaintext = '{"api_key": "sk-test-123", "api_secret": "secret-456"}'
+        encrypted = self._encrypt_nip04(
+            plaintext, sender.hex(), recipient.public_key.hex(),
+        )
+        decrypted = decrypt(
+            encrypted, recipient.hex(), sender.public_key.hex(),
+        )
+        assert decrypted == plaintext
+
+    def test_symmetric_ecdh(self):
+        """ECDH shared secret is symmetric (sender/recipient order doesn't matter)."""
+        a = PrivateKey()
+        b = PrivateKey()
+        secret_ab = _get_shared_secret(a.hex(), b.public_key.hex())
+        secret_ba = _get_shared_secret(b.hex(), a.public_key.hex())
+        assert secret_ab == secret_ba
+
+    def test_wrong_key_fails(self):
+        """Decrypting with the wrong key raises ValueError."""
+        sender = PrivateKey()
+        recipient = PrivateKey()
+        wrong = PrivateKey()
+
+        encrypted = self._encrypt_nip04(
+            "secret data", sender.hex(), recipient.public_key.hex(),
+        )
+        with pytest.raises(ValueError, match="decryption failed"):
+            decrypt(encrypted, wrong.hex(), sender.public_key.hex())
+
+    def test_invalid_format_no_iv(self):
+        """Missing ?iv= separator raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid NIP-04 format"):
+            decrypt("justbase64data", "a" * 64, "b" * 64)
+
+    def test_invalid_base64(self):
+        """Invalid base64 raises ValueError."""
+        with pytest.raises(ValueError, match="base64 decode failed"):
+            decrypt("not-valid-b64?iv=also-not-valid", "a" * 64, "b" * 64)
+
+    def test_wrong_iv_length(self):
+        """IV that's not 16 bytes raises ValueError."""
+        ct = base64.b64encode(b"ciphertext").decode()
+        iv = base64.b64encode(b"short").decode()
+        with pytest.raises(ValueError, match="IV must be 16 bytes"):
+            decrypt(f"{ct}?iv={iv}", "a" * 64, "b" * 64)
+
+    def test_unicode_content(self):
+        """Non-ASCII content survives round-trip."""
+        sender = PrivateKey()
+        recipient = PrivateKey()
+
+        plaintext = '{"name": "日本語テスト", "emoji": "🔐📬"}'
+        encrypted = self._encrypt_nip04(
+            plaintext, sender.hex(), recipient.public_key.hex(),
+        )
+        decrypted = decrypt(
+            encrypted, recipient.hex(), sender.public_key.hex(),
+        )
+        assert decrypted == plaintext

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1,0 +1,606 @@
+"""Tests for the Nostr credential exchange (Secure Courier Service)."""
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pynostr.key import PrivateKey
+
+from tollbooth.credential_templates import CredentialTemplate, FieldSpec
+from tollbooth.nip44 import encrypt as nip44_encrypt
+from tollbooth.nip04 import _get_shared_secret
+from tollbooth.nostr_credentials import (
+    CourierNotReady,
+    CourierTimeout,
+    CourierValidationError,
+    NostrCredentialExchange,
+    _KIND_ENCRYPTED_DM,
+    _KIND_GIFT_WRAP,
+    _KIND_SEAL,
+    _KIND_PRIVATE_DM,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+def _test_template() -> dict[str, CredentialTemplate]:
+    """Single-service test template."""
+    return {
+        "x": CredentialTemplate(
+            service="x",
+            version=1,
+            fields={
+                "api_key": FieldSpec(required=True, sensitive=True),
+                "api_secret": FieldSpec(required=True, sensitive=True),
+            },
+            description="Test X API credentials",
+        ),
+    }
+
+
+def _make_exchange(
+    nsec: str | None = None,
+    relays: list[str] | None = None,
+    templates: dict[str, CredentialTemplate] | None = None,
+    **kwargs,
+) -> NostrCredentialExchange:
+    """Create an exchange with test defaults."""
+    if nsec is None:
+        nsec = PrivateKey().nsec
+    if relays is None:
+        relays = ["wss://relay.test.com"]
+    return NostrCredentialExchange(
+        nsec=nsec,
+        relays=relays,
+        templates=templates or _test_template(),
+        **kwargs,
+    )
+
+
+def _make_nip04_event(
+    sender_privkey: PrivateKey,
+    recipient_pubkey_hex: str,
+    payload: dict,
+    created_at: int | None = None,
+) -> dict:
+    """Build a kind 4 NIP-04 event dict for testing."""
+    import base64
+    import os
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives.padding import PKCS7
+
+    plaintext = json.dumps(payload).encode("utf-8")
+
+    shared_secret = _get_shared_secret(sender_privkey.hex(), recipient_pubkey_hex)
+    iv = os.urandom(16)
+
+    padder = PKCS7(128).padder()
+    padded = padder.update(plaintext) + padder.finalize()
+    cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    ct_b64 = base64.b64encode(ciphertext).decode()
+    iv_b64 = base64.b64encode(iv).decode()
+
+    return {
+        "id": "event_nip04_test",
+        "kind": _KIND_ENCRYPTED_DM,
+        "pubkey": sender_privkey.public_key.hex(),
+        "content": f"{ct_b64}?iv={iv_b64}",
+        "tags": [["p", recipient_pubkey_hex]],
+        "created_at": created_at or int(time.time()),
+        "sig": "fake_sig",
+    }
+
+
+def _make_gift_wrap_event(
+    sender_privkey: PrivateKey,
+    recipient_privkey_hex: str,
+    recipient_pubkey_hex: str,
+    payload: dict,
+    created_at: int | None = None,
+) -> dict:
+    """Build a kind 1059 NIP-17 gift wrap event dict for testing.
+
+    Three layers:
+    1. DM (kind 14): plaintext JSON payload
+    2. Seal (kind 13): DM encrypted with NIP-44 (sender → recipient)
+    3. Gift wrap (kind 1059): Seal encrypted with NIP-44 (random → recipient)
+    """
+    now = created_at or int(time.time())
+
+    # Layer 3: The actual DM content
+    dm_event = {
+        "kind": _KIND_PRIVATE_DM,
+        "content": json.dumps(payload),
+        "pubkey": sender_privkey.public_key.hex(),
+        "created_at": now,
+        "tags": [["p", recipient_pubkey_hex]],
+    }
+
+    # Layer 2: Seal — DM encrypted to recipient with sender's key
+    seal_content = nip44_encrypt(
+        json.dumps(dm_event),
+        sender_privkey.hex(),
+        recipient_pubkey_hex,
+    )
+    seal_event = {
+        "kind": _KIND_SEAL,
+        "content": seal_content,
+        "pubkey": sender_privkey.public_key.hex(),
+        "created_at": now,
+        "tags": [],
+    }
+
+    # Layer 1: Gift wrap — Seal encrypted to recipient with random key
+    random_key = PrivateKey()
+    wrap_content = nip44_encrypt(
+        json.dumps(seal_event),
+        random_key.hex(),
+        recipient_pubkey_hex,
+    )
+
+    return {
+        "id": "event_giftwrap_test",
+        "kind": _KIND_GIFT_WRAP,
+        "content": wrap_content,
+        "pubkey": random_key.public_key.hex(),
+        "created_at": now,
+        "tags": [["p", recipient_pubkey_hex]],
+        "sig": "fake_sig",
+    }
+
+
+# ── Initialization Tests ─────────────────────────────────────────────
+
+class TestExchangeInit:
+    """Tests for NostrCredentialExchange initialization."""
+
+    def test_valid_init(self):
+        """Exchange initializes with valid nsec."""
+        ex = _make_exchange()
+        assert ex.enabled
+        assert ex.npub.startswith("npub1")
+        assert len(ex.relays) == 1
+
+    def test_invalid_nsec_disables(self):
+        """Invalid nsec disables the exchange."""
+        ex = _make_exchange(nsec="nsec1invalid")
+        assert not ex.enabled
+
+    def test_no_relays_disables(self):
+        """Empty relay list disables the exchange."""
+        ex = _make_exchange(relays=[])
+        assert not ex.enabled
+
+    @patch("tollbooth.nostr_credentials._HAS_PYNOSTR", False)
+    def test_missing_pynostr_disables(self):
+        """Missing pynostr disables the exchange."""
+        ex = NostrCredentialExchange(
+            nsec="ignored",
+            relays=["wss://relay.test.com"],
+            templates=_test_template(),
+        )
+        assert not ex.enabled
+
+    @patch("tollbooth.nostr_credentials._HAS_WEBSOCKET", False)
+    def test_missing_websocket_disables(self):
+        """Missing websocket-client disables the exchange."""
+        ex = _make_exchange()
+        assert not ex.enabled
+
+
+# ── open_channel Tests ────────────────────────────────────────────────
+
+class TestOpenChannel:
+    """Tests for open_channel()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_npub_and_instructions(self):
+        """open_channel returns npub, relays, and template instructions."""
+        ex = _make_exchange()
+        # Mock the subscription to avoid real WebSocket
+        with patch.object(ex, "_start_subscription"):
+            result = await ex.open_channel("x")
+
+        assert result["success"] is True
+        assert result["npub"] == ex.npub
+        assert result["relays"] == ex.relays
+        assert result["service"] == "x"
+        assert "api_key" in result["instructions"]
+        assert "api_secret" in result["instructions"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_service_raises(self):
+        """open_channel with unknown service raises CourierValidationError."""
+        ex = _make_exchange()
+        with pytest.raises(CourierValidationError, match="Unknown service"):
+            await ex.open_channel("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_disabled_exchange_raises(self):
+        """open_channel on disabled exchange raises CourierNotReady."""
+        ex = _make_exchange(nsec="nsec1invalid")
+        with pytest.raises(CourierNotReady):
+            await ex.open_channel("x")
+
+
+# ── receive Tests — NIP-04 ───────────────────────────────────────────
+
+class TestReceiveNip04:
+    """Tests for receive() with NIP-04 kind 4 DMs."""
+
+    @pytest.mark.asyncio
+    async def test_receive_nip04_dm(self):
+        """Receive and decrypt a NIP-04 DM."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "sk-test-123", "api_secret": "secret-456"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        # Inject into buffer
+        with ex._lock:
+            ex._received_events.append(event)
+
+        # Mock relay fetch (already in buffer) and deletion
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["service"] == "x"
+        assert result["fields_received"] == 2
+        assert result["encryption"] == "nip04"
+        assert result["credentials"]["api_key"] == "sk-test-123"
+
+    @pytest.mark.asyncio
+    async def test_nip04_rejected_when_nip44_only(self):
+        """NIP-04 DM rejected when nip44_only=True."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec, nip44_only=True)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             pytest.raises(CourierValidationError, match="NIP-04 DMs rejected"):
+            await ex.receive(sender.public_key.bech32())
+
+
+# ── receive Tests — NIP-17 Gift Wrap ─────────────────────────────────
+
+class TestReceiveNip17:
+    """Tests for receive() with NIP-17 gift-wrapped DMs."""
+
+    @pytest.mark.asyncio
+    async def test_receive_gift_wrap_dm(self):
+        """Receive and unwrap a NIP-17 gift-wrapped DM."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "sk-wrapped-123", "api_secret": "wrapped-secret"}
+        event = _make_gift_wrap_event(
+            sender, operator.hex(), operator.public_key.hex(), payload,
+        )
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["service"] == "x"
+        assert result["encryption"] == "nip44"
+        assert result["credentials"]["api_key"] == "sk-wrapped-123"
+
+    @pytest.mark.asyncio
+    async def test_gift_wrap_wrong_sender_rejected(self):
+        """Gift wrap from wrong sender is rejected."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        impersonator = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        # Wrap is created by impersonator but we claim it's from sender
+        event = _make_gift_wrap_event(
+            impersonator, operator.hex(), operator.public_key.hex(), payload,
+        )
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             pytest.raises(CourierValidationError, match="does not match"):
+            await ex.receive(sender.public_key.bech32())
+
+
+# ── receive Tests — Validation ────────────────────────────────────────
+
+class TestReceiveValidation:
+    """Tests for payload validation during receive."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_rejected(self):
+        """Non-JSON DM content is rejected."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        # Manually build a NIP-04 event with non-JSON content
+        import base64
+        import os
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.primitives.padding import PKCS7
+
+        plaintext = b"this is not json"
+        shared_secret = _get_shared_secret(
+            sender.hex(), operator.public_key.hex(),
+        )
+        iv = os.urandom(16)
+        padder = PKCS7(128).padder()
+        padded = padder.update(plaintext) + padder.finalize()
+        cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv))
+        ct = cipher.encryptor().update(padded) + cipher.encryptor().finalize()
+        content = f"{base64.b64encode(ct).decode()}?iv={base64.b64encode(iv).decode()}"
+
+        event = {
+            "id": "bad_json",
+            "kind": _KIND_ENCRYPTED_DM,
+            "pubkey": sender.public_key.hex(),
+            "content": content,
+            "tags": [["p", operator.public_key.hex()]],
+            "created_at": int(time.time()),
+            "sig": "fake",
+        }
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"):
+            with pytest.raises(CourierValidationError):
+                await ex.receive(sender.public_key.bech32())
+
+    @pytest.mark.asyncio
+    async def test_unknown_fields_rejected(self):
+        """Payload with unknown fields is rejected."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {
+            "api_key": "key",
+            "api_secret": "secret",
+            "rogue_field": "evil",
+        }
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"):
+            with pytest.raises(CourierValidationError, match="Unknown fields"):
+                await ex.receive(sender.public_key.bech32())
+
+    @pytest.mark.asyncio
+    async def test_missing_required_fields_rejected(self):
+        """Payload missing required fields is rejected."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "key"}  # missing api_secret
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"):
+            with pytest.raises(CourierValidationError, match="Missing required"):
+                await ex.receive(sender.public_key.bech32())
+
+
+# ── Freshness and Replay Tests ────────────────────────────────────────
+
+class TestFreshnessAndReplay:
+    """Tests for freshness window and double-pickup prevention."""
+
+    @pytest.mark.asyncio
+    async def test_stale_event_ignored(self):
+        """Events older than freshness window are not matched."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec, freshness_window=60)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(
+            sender, operator.public_key.hex(), payload,
+            created_at=int(time.time()) - 120,  # 2 minutes ago, window is 1 min
+        )
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"):
+            with pytest.raises(CourierTimeout):
+                await ex.receive(sender.public_key.bech32())
+
+    @pytest.mark.asyncio
+    async def test_double_pickup_prevented(self):
+        """Same event cannot be received twice."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            # First receive succeeds
+            result = await ex.receive(sender.public_key.bech32())
+            assert result["success"]
+
+            # Second receive fails (event consumed)
+            with pytest.raises(CourierTimeout):
+                await ex.receive(sender.public_key.bech32())
+
+    @pytest.mark.asyncio
+    async def test_no_dm_found_raises_timeout(self):
+        """No matching DM raises CourierTimeout."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        with patch.object(ex, "_fetch_dms_from_relays"):
+            with pytest.raises(CourierTimeout, match="No DM found"):
+                await ex.receive(sender.public_key.bech32())
+
+
+# ── Relay Subscription Tests ─────────────────────────────────────────
+
+class TestRelaySubscription:
+    """Tests for relay WebSocket subscription."""
+
+    def test_subscribe_parses_events(self):
+        """Subscription collects EVENT messages from relay."""
+        operator = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        fake_event = {
+            "id": "test123",
+            "kind": 4,
+            "pubkey": "abc",
+            "content": "encrypted",
+            "created_at": int(time.time()),
+            "tags": [],
+        }
+
+        mock_ws = MagicMock()
+        mock_ws.recv = MagicMock(side_effect=[
+            json.dumps(["EVENT", "sub1", fake_event]),
+            json.dumps(["EOSE", "sub1"]),
+        ])
+
+        with patch("tollbooth.nostr_credentials.create_connection", return_value=mock_ws):
+            ex._subscribe_to_relays()
+
+        with ex._lock:
+            assert len(ex._received_events) == 1
+            assert ex._received_events[0]["id"] == "test123"
+
+    def test_relay_failure_non_fatal(self):
+        """Relay connection failure doesn't crash."""
+        operator = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        with patch(
+            "tollbooth.nostr_credentials.create_connection",
+            side_effect=ConnectionError("relay down"),
+        ):
+            # Should not raise
+            ex._subscribe_to_relays()
+
+        with ex._lock:
+            assert len(ex._received_events) == 0
+
+
+# ── NIP-09 Deletion Tests ────────────────────────────────────────────
+
+class TestDeletion:
+    """Tests for NIP-09 deletion requests."""
+
+    def test_deletion_event_published(self):
+        """Deletion request is published to relays."""
+        operator = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        mock_ws = MagicMock()
+        mock_ws.recv = MagicMock(return_value='["OK","del1",true,""]')
+
+        with patch(
+            "tollbooth.nostr_credentials.create_connection",
+            return_value=mock_ws,
+        ):
+            ex._publish_to_relays("test_message")
+
+        mock_ws.send.assert_called_once_with("test_message")
+
+    def test_deletion_failure_non_fatal(self):
+        """Deletion relay failure doesn't raise."""
+        operator = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        with patch(
+            "tollbooth.nostr_credentials.create_connection",
+            side_effect=ConnectionError("relay down"),
+        ):
+            # Should not raise
+            ex._publish_to_relays("test_message")
+
+
+# ── Template Matching Tests ───────────────────────────────────────────
+
+class TestTemplateMatching:
+    """Tests for template auto-matching logic."""
+
+    @pytest.mark.asyncio
+    async def test_match_by_service_field(self):
+        """Payload with service field matches correct template."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+
+        templates = {
+            "x": CredentialTemplate(
+                service="x", version=1,
+                fields={"api_key": FieldSpec(), "api_secret": FieldSpec()},
+            ),
+            "openai": CredentialTemplate(
+                service="openai", version=1,
+                fields={"openai_key": FieldSpec()},
+            ),
+        }
+        ex = _make_exchange(nsec=operator.nsec, templates=templates)
+
+        payload = {"service": "openai", "openai_key": "sk-test"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+            assert result["service"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_single_template_auto_match(self):
+        """Single template matches without service field."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+            assert result["service"] == "x"


### PR DESCRIPTION
## Summary

- **NostrCredentialExchange** class for out-of-band credential delivery via Nostr encrypted DMs
- NIP-17 gift wrap (kind 1059 → 13 → 14) unwrapping with NIP-44 decryption — the modern standard
- NIP-04 legacy DM (kind 4) fallback with configurable `nip44_only` rejection
- Strict credential template validation — operators declare expected fields, unknown fields rejected
- NIP-09 deletion request after successful credential ingestion (destroy the relay copy)
- NIP-04 AES-256-CBC decryption module (`nip04.py`) built on existing `coincurve` + `cryptography` deps
- 45 new tests (523 total), zero new dependencies, version bumped to 0.1.29

### Operator integration (two lines + template):

```python
from tollbooth.nostr_credentials import NostrCredentialExchange, CredentialTemplate, FieldSpec

exchange = NostrCredentialExchange(
    nsec=os.environ["TOLLBOOTH_NOSTR_NSEC"],
    relays=["wss://relay.damus.io", "wss://nos.lol"],
    templates={"x": CredentialTemplate(service="x", version=1, fields={
        "api_key": FieldSpec(required=True, sensitive=True),
        "api_secret": FieldSpec(required=True, sensitive=True),
    })}
)

@mcp.tool()
async def request_credential_channel(service: str = "x"):
    return await exchange.open_channel(service)

@mcp.tool()
async def receive_credentials(sender_npub: str):
    return await exchange.receive(sender_npub)
```

## Test plan

- [x] NIP-04 encrypt/decrypt round-trip (7 tests)
- [x] Template validation: required/optional fields, unknown field rejection, type checking (14 tests)
- [x] Exchange init: valid nsec, invalid nsec, no relays, missing deps (5 tests)
- [x] open_channel: returns instructions, unknown service, disabled exchange (3 tests)
- [x] NIP-04 DM receive + decrypt (2 tests)
- [x] NIP-17 gift wrap unwrap + decrypt (2 tests)
- [x] Validation errors: bad JSON, unknown fields, missing required (3 tests)
- [x] Freshness window, double-pickup prevention, timeout (3 tests)
- [x] Relay subscription, relay failure resilience (2 tests)
- [x] NIP-09 deletion, deletion failure resilience (2 tests)
- [x] Template matching by service field and auto-match (2 tests)
- [x] Full suite: 523 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)