### PR TITLE
Add credential vaulting with vault-first lookup

### DIFF
--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -10,6 +10,7 @@ from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
+from tollbooth.credential_vault_backend import CredentialVaultBackend
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
 from tollbooth.pricing import ToolPricing
@@ -57,6 +58,7 @@ __all__ = [
     "BTCPayError",
     "BTCPayAuthError",
     "VaultBackend",
+    "CredentialVaultBackend",
     "LedgerCache",
     "TheBrainVault",
     "NeonVault",

--- a/src/tollbooth/credential_vault_backend.py
+++ b/src/tollbooth/credential_vault_backend.py
@@ -1,0 +1,50 @@
+"""Abstract persistence interface for credential storage.
+
+Defines the CredentialVaultBackend Protocol that NostrCredentialExchange
+uses to persist credentials across sessions.  Concrete implementations
+(e.g., TheBrainVault, NeonVault) live elsewhere.
+
+Separate from VaultBackend (ledger/commerce state).  Credential vaults
+store opaque encrypted blobs keyed by (service, npub).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CredentialVaultBackend(Protocol):
+    """Async persistence backend for encrypted credential blobs.
+
+    Implementations store and retrieve opaque strings (encrypted by the
+    caller before storage).  The vault never sees plaintext credentials.
+    """
+
+    async def store_credentials(
+        self, service: str, npub: str, encrypted_blob: str,
+    ) -> None:
+        """Store an encrypted credential blob.
+
+        Overwrites any existing blob for the same (service, npub) pair.
+        """
+        ...
+
+    async def fetch_credentials(
+        self, service: str, npub: str,
+    ) -> str | None:
+        """Fetch an encrypted credential blob.
+
+        Returns None if no credentials are stored for this pair.
+        """
+        ...
+
+    async def delete_credentials(
+        self, service: str, npub: str,
+    ) -> bool:
+        """Delete stored credentials.
+
+        Returns True if credentials were found and deleted, False if
+        no credentials existed for this pair.
+        """
+        ...

--- a/src/tollbooth/nip04.py
+++ b/src/tollbooth/nip04.py
@@ -36,6 +36,38 @@ def _get_shared_secret(private_key_hex: str, public_key_hex: str) -> bytes:
     return shared_x
 
 
+def encrypt(
+    plaintext: str,
+    private_key_hex: str,
+    public_key_hex: str,
+) -> str:
+    """Encrypt a message using NIP-04 AES-256-CBC.
+
+    Args:
+        plaintext: UTF-8 string to encrypt.
+        private_key_hex: Sender's 32-byte private key as hex.
+        public_key_hex: Recipient's 32-byte x-only public key as hex.
+
+    Returns:
+        NIP-04 format ``<base64_ciphertext>?iv=<base64_iv>``.
+    """
+    import os
+
+    shared_secret = _get_shared_secret(private_key_hex, public_key_hex)
+    iv = os.urandom(16)
+
+    padder = PKCS7(128).padder()
+    padded = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+
+    cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    ct_b64 = base64.b64encode(ciphertext).decode()
+    iv_b64 = base64.b64encode(iv).decode()
+    return f"{ct_b64}?iv={iv_b64}"
+
+
 def decrypt(
     ciphertext_with_iv: str,
     private_key_hex: str,

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -37,6 +37,7 @@ from tollbooth.credential_templates import (
     render_template_instructions,
     validate_payload,
 )
+from tollbooth.credential_vault_backend import CredentialVaultBackend
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,7 @@ class NostrCredentialExchange:
         *,
         freshness_window: int = _DEFAULT_FRESHNESS,
         nip44_only: bool = False,
+        credential_vault: CredentialVaultBackend | None = None,
     ) -> None:
         """Initialize the credential exchange.
 
@@ -141,11 +143,15 @@ class NostrCredentialExchange:
             templates: Map of service name → CredentialTemplate.
             freshness_window: Max age in seconds for accepted DMs.
             nip44_only: If True, reject NIP-04 DMs entirely.
+            credential_vault: Optional vault for persisting credentials
+                across sessions.  If provided, ``receive()`` checks the
+                vault first and stores credentials after successful pickup.
         """
         self._freshness_window = freshness_window
         self._nip44_only = nip44_only
         self._templates = templates
         self._relays = [r.strip() for r in relays if r.strip()]
+        self._credential_vault = credential_vault
 
         # Key material
         self._privkey_hex: str = ""
@@ -249,19 +255,22 @@ class NostrCredentialExchange:
             ),
         }
 
-    async def receive(self, sender_npub: str) -> dict[str, Any]:
+    async def receive(
+        self, sender_npub: str, *, service: str | None = None,
+    ) -> dict[str, Any]:
         """Pick up and validate credentials from a sender.
 
-        Checks the received DM buffer for messages from ``sender_npub``
-        within the freshness window.  If not found in the buffer, does
-        a one-shot relay fetch.
+        If a credential vault is configured, checks it first.  On a vault
+        hit the credentials are returned immediately without any relay I/O.
+        On a miss (or no vault), falls back to the relay DM flow.
 
-        On success, validates the payload against the matching template,
-        publishes a NIP-09 deletion request, and returns the validated
-        credentials (never echoing sensitive values).
+        After a successful relay pickup the validated credentials are
+        encrypted and stored in the vault for future sessions.
 
         Args:
             sender_npub: Patron's npub (bech32).
+            service: Optional service hint for vault lookup.  If omitted
+                and only one template is configured, that service is used.
 
         Returns:
             Dict with success, service name, and field count.
@@ -278,7 +287,32 @@ class NostrCredentialExchange:
         except Exception as exc:
             raise CourierValidationError(f"Invalid sender npub: {exc}") from exc
 
-        # Try buffer first, then one-shot fetch
+        # Resolve service for vault lookup
+        vault_service = self._resolve_service(service)
+
+        # ── Vault-first lookup ──────────────────────────────────────
+        if self._credential_vault is not None and vault_service:
+            vaulted = await self._vault_fetch(vault_service, sender_npub)
+            if vaulted is not None:
+                template = self._templates[vault_service]
+                sensitive_count = sum(
+                    1 for name in vaulted
+                    if template.fields.get(name, FieldSpec()).sensitive
+                )
+                return {
+                    "success": True,
+                    "service": vault_service,
+                    "fields_received": len(vaulted),
+                    "sensitive_fields": sensitive_count,
+                    "encryption": "vault",
+                    "credentials": vaulted,
+                    "message": (
+                        f"Credentials for {vault_service} restored from vault "
+                        f"({len(vaulted)} fields). No relay I/O needed."
+                    ),
+                }
+
+        # ── Relay DM flow (existing) ────────────────────────────────
         dm = self._find_dm_in_buffer(sender_hex)
         if dm is None:
             self._fetch_dms_from_relays()
@@ -310,8 +344,8 @@ class NostrCredentialExchange:
             )
 
         # Match template
-        service = payload.get("service")
-        template = self._match_template(service, payload)
+        payload_service = payload.get("service")
+        template = self._match_template(payload_service, payload)
 
         # Validate against template
         try:
@@ -327,6 +361,10 @@ class NostrCredentialExchange:
         # Publish NIP-09 deletion request (fire-and-forget)
         if event_id:
             self._request_deletion(event_id)
+
+        # Store in vault for next session
+        if self._credential_vault is not None:
+            await self._vault_store(template.service, sender_npub, validated)
 
         # Count sensitive vs non-sensitive fields
         sensitive_count = sum(
@@ -344,8 +382,119 @@ class NostrCredentialExchange:
                 f"Credentials received for {template.service} "
                 f"({len(validated)} fields). "
                 f"Relay copy deletion requested."
+                + (
+                    " Credentials stored in vault for future sessions."
+                    if self._credential_vault is not None else ""
+                )
             ),
         }
+
+    async def forget(
+        self, sender_npub: str, *, service: str | None = None,
+    ) -> dict[str, Any]:
+        """Delete vaulted credentials for a patron.
+
+        Useful when a patron rotates API keys and needs to re-deliver
+        via the courier.
+
+        Args:
+            sender_npub: Patron's npub (bech32).
+            service: Service name to forget.  If omitted and only one
+                template is configured, that service is used.
+
+        Returns:
+            Dict with success and whether credentials were found.
+        """
+        if self._credential_vault is None:
+            return {
+                "success": False,
+                "message": "No credential vault configured.",
+            }
+
+        resolved = self._resolve_service(service)
+        if not resolved:
+            return {
+                "success": False,
+                "message": "Cannot determine service. Provide a service name.",
+            }
+
+        deleted = await self._credential_vault.delete_credentials(
+            resolved, sender_npub,
+        )
+        return {
+            "success": True,
+            "service": resolved,
+            "deleted": deleted,
+            "message": (
+                f"Credentials for {resolved} from {sender_npub} "
+                + ("deleted from vault." if deleted else "not found in vault.")
+            ),
+        }
+
+    def _resolve_service(self, service: str | None) -> str | None:
+        """Resolve service name, defaulting to the single template if only one."""
+        if service and service in self._templates:
+            return service
+        if len(self._templates) == 1:
+            return next(iter(self._templates.keys()))
+        return service
+
+    # ── Vault helpers ──────────────────────────────────────────────────
+
+    async def _vault_fetch(
+        self, service: str, sender_npub: str,
+    ) -> dict[str, str] | None:
+        """Fetch and decrypt credentials from the vault."""
+        assert self._credential_vault is not None
+        blob = await self._credential_vault.fetch_credentials(service, sender_npub)
+        if blob is None:
+            return None
+        try:
+            plaintext = self._vault_decrypt(blob)
+            creds = json.loads(plaintext)
+            if isinstance(creds, dict):
+                return creds
+            logger.warning("Vault blob decoded to non-dict, ignoring")
+            return None
+        except Exception as exc:
+            logger.warning("Vault credential decryption failed: %s", exc)
+            return None
+
+    async def _vault_store(
+        self, service: str, sender_npub: str, credentials: dict[str, str],
+    ) -> None:
+        """Encrypt and store credentials in the vault."""
+        assert self._credential_vault is not None
+        try:
+            plaintext = json.dumps(credentials)
+            blob = self._vault_encrypt(plaintext)
+            await self._credential_vault.store_credentials(
+                service, sender_npub, blob,
+            )
+            logger.info(
+                "Credentials for %s/%s stored in vault", service, sender_npub[:16],
+            )
+        except Exception as exc:
+            logger.warning("Vault credential storage failed: %s", exc)
+
+    def _vault_encrypt(self, plaintext: str) -> str:
+        """Encrypt plaintext for vault storage using operator's key.
+
+        Uses NIP-04 AES-256-CBC with the operator as both sender and
+        recipient (self-encryption).
+        """
+        if not _HAS_NIP04:
+            raise RuntimeError("NIP-04 module required for vault encryption")
+        from tollbooth.nip04 import encrypt as _nip04_encrypt
+        return _nip04_encrypt(plaintext, self._privkey_hex, self._pubkey_hex)
+
+    def _vault_decrypt(self, blob: str) -> str:
+        """Decrypt a vault blob using operator's key."""
+        if not _HAS_NIP04:
+            raise RuntimeError("NIP-04 module required for vault decryption")
+        return _nip04_decrypt(blob, self._privkey_hex, self._pubkey_hex)
+
+    # ── Template matching ───────────────────────────────────────────
 
     def _match_template(
         self, service: str | None, payload: dict,

--- a/tests/test_credential_vault_backend.py
+++ b/tests/test_credential_vault_backend.py
@@ -1,0 +1,36 @@
+"""Tests for CredentialVaultBackend protocol compliance."""
+
+from tollbooth.credential_vault_backend import CredentialVaultBackend
+
+
+class InMemoryVault:
+    """Minimal in-memory implementation for protocol testing."""
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+
+    async def store_credentials(self, service: str, npub: str, encrypted_blob: str) -> None:
+        self._store[f"{service}:{npub}"] = encrypted_blob
+
+    async def fetch_credentials(self, service: str, npub: str) -> str | None:
+        return self._store.get(f"{service}:{npub}")
+
+    async def delete_credentials(self, service: str, npub: str) -> bool:
+        key = f"{service}:{npub}"
+        if key in self._store:
+            del self._store[key]
+            return True
+        return False
+
+
+class TestCredentialVaultBackend:
+    """Protocol compliance tests."""
+
+    def test_in_memory_is_instance(self):
+        """InMemoryVault satisfies the CredentialVaultBackend protocol."""
+        vault = InMemoryVault()
+        assert isinstance(vault, CredentialVaultBackend)
+
+    def test_dict_is_not_instance(self):
+        """A plain dict does NOT satisfy the protocol."""
+        assert not isinstance({}, CredentialVaultBackend)

--- a/tests/test_nip04.py
+++ b/tests/test_nip04.py
@@ -6,7 +6,7 @@ import os
 import pytest
 from pynostr.key import PrivateKey
 
-from tollbooth.nip04 import decrypt, _get_shared_secret
+from tollbooth.nip04 import decrypt, encrypt, _get_shared_secret
 
 
 class TestNip04Decrypt:
@@ -96,4 +96,35 @@ class TestNip04Decrypt:
         decrypted = decrypt(
             encrypted, recipient.hex(), sender.public_key.hex(),
         )
+        assert decrypted == plaintext
+
+
+class TestNip04Encrypt:
+    """NIP-04 AES-256-CBC encryption tests."""
+
+    def test_encrypt_round_trip(self):
+        """encrypt() → decrypt() round-trip succeeds."""
+        sender = PrivateKey()
+        recipient = PrivateKey()
+
+        plaintext = '{"api_key": "sk-test", "api_secret": "secret"}'
+        encrypted = encrypt(plaintext, sender.hex(), recipient.public_key.hex())
+        decrypted = decrypt(encrypted, recipient.hex(), sender.public_key.hex())
+        assert decrypted == plaintext
+
+    def test_encrypt_produces_nip04_format(self):
+        """encrypt() output has NIP-04 format with ?iv= separator."""
+        sender = PrivateKey()
+        recipient = PrivateKey()
+
+        encrypted = encrypt("test", sender.hex(), recipient.public_key.hex())
+        assert "?iv=" in encrypted
+
+    def test_self_encryption(self):
+        """Self-encryption (same key as sender and recipient) works."""
+        key = PrivateKey()
+
+        plaintext = '{"credential": "value"}'
+        encrypted = encrypt(plaintext, key.hex(), key.public_key.hex())
+        decrypted = decrypt(encrypted, key.hex(), key.public_key.hex())
         assert decrypted == plaintext

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -2,12 +2,13 @@
 
 import json
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pynostr.key import PrivateKey
 
 from tollbooth.credential_templates import CredentialTemplate, FieldSpec
+from tollbooth.credential_vault_backend import CredentialVaultBackend
 from tollbooth.nip44 import encrypt as nip44_encrypt
 from tollbooth.nip04 import _get_shared_secret
 from tollbooth.nostr_credentials import (
@@ -604,3 +605,260 @@ class TestTemplateMatching:
              patch.object(ex, "_request_deletion"):
             result = await ex.receive(sender.public_key.bech32())
             assert result["service"] == "x"
+
+
+# ── Mock Credential Vault ────────────────────────────────────────────
+
+class MockCredentialVault:
+    """In-memory credential vault for testing."""
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+
+    def _key(self, service: str, npub: str) -> str:
+        return f"{service}:{npub}"
+
+    async def store_credentials(
+        self, service: str, npub: str, encrypted_blob: str,
+    ) -> None:
+        self._store[self._key(service, npub)] = encrypted_blob
+
+    async def fetch_credentials(
+        self, service: str, npub: str,
+    ) -> str | None:
+        return self._store.get(self._key(service, npub))
+
+    async def delete_credentials(
+        self, service: str, npub: str,
+    ) -> bool:
+        key = self._key(service, npub)
+        if key in self._store:
+            del self._store[key]
+            return True
+        return False
+
+
+# ── Credential Vault Tests ───────────────────────────────────────────
+
+class TestCredentialVault:
+    """Tests for vault-first credential lookup and storage."""
+
+    @pytest.mark.asyncio
+    async def test_vault_store_after_first_receive(self):
+        """Credentials are stored in vault after first relay pickup."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "sk-first-123", "api_secret": "secret-456"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["encryption"] == "nip04"
+        assert result["credentials"]["api_key"] == "sk-first-123"
+        # Vault should have the blob
+        blob = await vault.fetch_credentials("x", sender.public_key.bech32())
+        assert blob is not None
+
+    @pytest.mark.asyncio
+    async def test_vault_hit_skips_relay(self):
+        """Second receive returns from vault without relay I/O."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "sk-cached", "api_secret": "cached-secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        # First receive — from relay
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result1 = await ex.receive(sender.public_key.bech32())
+
+        assert result1["encryption"] == "nip04"
+
+        # Second receive — should come from vault
+        with patch.object(ex, "_fetch_dms_from_relays") as mock_fetch, \
+             patch.object(ex, "_find_dm_in_buffer") as mock_find:
+            result2 = await ex.receive(sender.public_key.bech32())
+
+        assert result2["success"] is True
+        assert result2["encryption"] == "vault"
+        assert result2["credentials"]["api_key"] == "sk-cached"
+        assert result2["credentials"]["api_secret"] == "cached-secret"
+        # Relay methods should NOT have been called
+        mock_fetch.assert_not_called()
+        mock_find.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_vault_blob_is_encrypted(self):
+        """Vault blob is not plaintext JSON — it's NIP-04 encrypted."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "sk-secret", "api_secret": "top-secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            await ex.receive(sender.public_key.bech32())
+
+        blob = await vault.fetch_credentials("x", sender.public_key.bech32())
+        assert blob is not None
+        # Blob should be NIP-04 format, not plaintext
+        assert "?iv=" in blob
+        # Blob should NOT contain plaintext credentials
+        assert "sk-secret" not in blob
+        assert "top-secret" not in blob
+
+    @pytest.mark.asyncio
+    async def test_forget_clears_vault(self):
+        """forget() deletes credentials from vault."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            await ex.receive(sender.public_key.bech32())
+
+        # Vault should have credentials
+        assert await vault.fetch_credentials("x", sender.public_key.bech32()) is not None
+
+        # Forget them
+        result = await ex.forget(sender.public_key.bech32())
+        assert result["success"] is True
+        assert result["deleted"] is True
+
+        # Vault should be empty
+        assert await vault.fetch_credentials("x", sender.public_key.bech32()) is None
+
+    @pytest.mark.asyncio
+    async def test_forget_nonexistent_returns_false(self):
+        """forget() returns deleted=False when no credentials exist."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        result = await ex.forget(sender.public_key.bech32())
+        assert result["success"] is True
+        assert result["deleted"] is False
+
+    @pytest.mark.asyncio
+    async def test_forget_without_vault(self):
+        """forget() without vault returns failure message."""
+        ex = _make_exchange()
+        sender = PrivateKey()
+
+        result = await ex.forget(sender.public_key.bech32())
+        assert result["success"] is False
+        assert "No credential vault" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_no_vault_preserves_existing_behavior(self):
+        """Without a vault, receive() works identically to v0.1.30."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)  # No vault
+
+        payload = {"api_key": "key", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["encryption"] == "nip04"
+        # No vault mention in message
+        assert "vault" not in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_vault_miss_falls_through_to_relay(self):
+        """Empty vault falls through to relay DM flow."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()  # Empty vault
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "fresh-key", "api_secret": "fresh-secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["encryption"] == "nip04"  # Came from relay, not vault
+        assert result["credentials"]["api_key"] == "fresh-key"
+
+    @pytest.mark.asyncio
+    async def test_forget_then_receive_uses_relay(self):
+        """After forget(), receive() falls back to relay."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        vault = MockCredentialVault()
+        ex = _make_exchange(nsec=operator.nsec, credential_vault=vault)
+
+        payload = {"api_key": "original", "api_secret": "secret"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+
+        with ex._lock:
+            ex._received_events.append(event)
+
+        # First receive stores in vault
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            await ex.receive(sender.public_key.bech32())
+
+        # Forget
+        await ex.forget(sender.public_key.bech32())
+
+        # New DM with rotated credentials
+        new_payload = {"api_key": "rotated", "api_secret": "new-secret"}
+        new_event = _make_nip04_event(
+            sender, operator.public_key.hex(), new_payload,
+        )
+        new_event["id"] = "event_rotated"
+
+        with ex._lock:
+            ex._received_events.append(new_event)
+
+        # Second receive should use relay (vault is empty)
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["credentials"]["api_key"] == "rotated"
+        assert result["encryption"] == "nip04"


### PR DESCRIPTION
## Summary
- Adds `CredentialVaultBackend` protocol for persisting encrypted credentials across sessions
- After first relay DM pickup, credentials are NIP-04 encrypted (operator self-encryption) and stored in the vault
- Subsequent `receive()` calls return from vault without any relay I/O
- New `forget()` method clears vaulted credentials for key rotation scenarios
- NIP-04 `encrypt()` function added (symmetric to existing `decrypt()`)
- Fully backwards compatible — no vault parameter = identical to v0.1.30 behavior

## Files changed
- `src/tollbooth/credential_vault_backend.py` — new `CredentialVaultBackend` protocol
- `src/tollbooth/nip04.py` — added `encrypt()` function
- `src/tollbooth/nostr_credentials.py` — vault-first lookup in `receive()`, auto-store after pickup, `forget()` method
- `src/tollbooth/__init__.py` — export `CredentialVaultBackend`
- 3 test files — 14 new tests (537 total, all passing)

## Test plan
- [x] Vault stores encrypted blob after first relay receive
- [x] Second receive returns from vault without relay I/O
- [x] Vault blob is NIP-04 encrypted (not plaintext)
- [x] `forget()` clears vault, forcing relay fallback
- [x] No vault = identical to v0.1.30 (backwards compatible)
- [x] NIP-04 encrypt/decrypt round-trip including self-encryption
- [x] Protocol compliance test for `CredentialVaultBackend`
- [x] All 537 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)