### PR TITLE
Add NostrProfile, welcome DM, and open_channel flip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.31"
+version = "0.1.32"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.31"
+__version__ = "0.1.32"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig
@@ -27,6 +27,7 @@ except ImportError:
 try:
     from tollbooth.nostr_credentials import (
         NostrCredentialExchange,
+        NostrProfile,
         CourierError,
         CourierNotReady,
         CourierTimeout,
@@ -39,6 +40,7 @@ try:
     )
 except ImportError:
     NostrCredentialExchange = None  # type: ignore[assignment,misc]
+    NostrProfile = None  # type: ignore[assignment,misc]
     CourierError = None  # type: ignore[assignment,misc]
     CourierNotReady = None  # type: ignore[assignment,misc]
     CourierTimeout = None  # type: ignore[assignment,misc]
@@ -77,6 +79,7 @@ __all__ = [
     "InclusionProof",
     "OTSCalendarClient",
     "NostrCredentialExchange",
+    "NostrProfile",
     "CourierError",
     "CourierNotReady",
     "CourierTimeout",

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -9,8 +9,8 @@ Two-tool operator interface:
 
     exchange = NostrCredentialExchange(nsec, relays, templates)
 
-    # Tool 1: Tell patron where to send
-    await exchange.open_channel("x")
+    # Tool 1: Send welcome DM to patron (they just reply)
+    await exchange.open_channel("x", recipient_npub="npub1user...")
 
     # Tool 2: Pick up the sealed pouch
     await exchange.receive("npub1user...")
@@ -20,6 +20,7 @@ Dependencies are optional — install with ``pip install tollbooth-dpyc[nostr]``
 Reference: https://github.com/nostr-protocol/nips/blob/master/44.md (NIP-44)
            https://github.com/nostr-protocol/nips/blob/master/04.md (NIP-04)
            https://github.com/nostr-protocol/nips/blob/master/09.md (NIP-09)
+           https://github.com/nostr-protocol/nips/blob/master/01.md (NIP-01 kind 0)
 """
 
 from __future__ import annotations
@@ -28,6 +29,7 @@ import json
 import logging
 import threading
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from tollbooth.credential_templates import (
@@ -73,11 +75,51 @@ except ImportError:
 
 
 # Nostr event kinds
+_KIND_METADATA = 0  # NIP-01 kind 0 (user metadata / profile)
 _KIND_ENCRYPTED_DM = 4  # NIP-04 legacy DMs
 _KIND_GIFT_WRAP = 1059  # NIP-17/NIP-59 gift-wrapped DMs
 _KIND_SEAL = 13  # NIP-59 seal (inner layer of gift wrap)
 _KIND_PRIVATE_DM = 14  # NIP-17 private DM (innermost content)
 _KIND_DELETION = 5  # NIP-09 event deletion
+
+
+@dataclass
+class NostrProfile:
+    """Nostr kind 0 profile metadata for the operator's npub.
+
+    Published so patrons see a friendly name and avatar in their
+    Nostr client instead of a raw npub string.
+    """
+
+    name: str
+    display_name: str | None = None
+    about: str | None = None
+    picture: str | None = None
+    nip05: str | None = None
+    banner: str | None = None
+    website: str | None = None
+    lud16: str | None = None  # Lightning address
+    extra: dict[str, str] = field(default_factory=dict)
+
+    def to_metadata(self) -> dict[str, str]:
+        """Serialize to the NIP-01 kind 0 content dict."""
+        meta: dict[str, str] = {"name": self.name}
+        if self.display_name:
+            meta["display_name"] = self.display_name
+        if self.about:
+            meta["about"] = self.about
+        if self.picture:
+            meta["picture"] = self.picture
+        if self.nip05:
+            meta["nip05"] = self.nip05
+        if self.banner:
+            meta["banner"] = self.banner
+        if self.website:
+            meta["website"] = self.website
+        if self.lud16:
+            meta["lud16"] = self.lud16
+        meta.update(self.extra)
+        return meta
 
 # Default freshness window (seconds)
 _DEFAULT_FRESHNESS = 600  # 10 minutes
@@ -210,15 +252,113 @@ class NostrCredentialExchange:
         """Configured relay URLs."""
         return list(self._relays)
 
-    async def open_channel(self, service: str) -> dict[str, Any]:
+    def publish_profile(self, profile: NostrProfile) -> None:
+        """Publish a NIP-01 kind 0 profile event for the operator's npub.
+
+        Sends the profile metadata to all configured relays so patrons
+        see a friendly name and avatar instead of a raw npub string.
+
+        Args:
+            profile: Operator profile metadata.
+        """
+        if not self._enabled:
+            logger.warning("Cannot publish profile — Secure Courier not enabled.")
+            return
+
+        metadata = profile.to_metadata()
+        content = json.dumps(metadata)
+
+        try:
+            event = Event(
+                kind=_KIND_METADATA,
+                content=content,
+                tags=[],
+                pubkey=self._pubkey_hex,
+                created_at=int(time.time()),
+            )
+            event.sign(self._privkey_hex)
+            message = event.to_message()
+
+            thread = threading.Thread(
+                target=self._publish_to_relays,
+                args=(message,),
+                daemon=True,
+            )
+            thread.start()
+            logger.info("Published kind 0 profile for %s", self._npub[:20])
+        except Exception as exc:
+            logger.warning("Failed to publish profile: %s", exc)
+
+    def send_dm(self, recipient_npub: str, message_text: str) -> None:
+        """Send a NIP-04 encrypted DM to a recipient.
+
+        Used to send welcome messages so patrons can reply in an existing
+        thread rather than composing a new DM to an unfamiliar npub.
+
+        Args:
+            recipient_npub: Patron's npub (bech32).
+            message_text: Plaintext message to encrypt and send.
+        """
+        if not self._enabled:
+            raise CourierNotReady("Secure Courier not enabled.")
+
+        if not _HAS_NIP04:
+            raise CourierNotReady("NIP-04 module required for outbound DMs.")
+
+        try:
+            recipient_hex = _npub_to_hex(recipient_npub)
+        except Exception as exc:
+            raise CourierValidationError(
+                f"Invalid recipient npub: {exc}"
+            ) from exc
+
+        from tollbooth.nip04 import encrypt as _nip04_encrypt
+
+        encrypted = _nip04_encrypt(message_text, self._privkey_hex, recipient_hex)
+
+        try:
+            event = Event(
+                kind=_KIND_ENCRYPTED_DM,
+                content=encrypted,
+                tags=[["p", recipient_hex]],
+                pubkey=self._pubkey_hex,
+                created_at=int(time.time()),
+            )
+            event.sign(self._privkey_hex)
+            message = event.to_message()
+
+            thread = threading.Thread(
+                target=self._publish_to_relays,
+                args=(message,),
+                daemon=True,
+            )
+            thread.start()
+            logger.info(
+                "Sent welcome DM to %s via %d relays",
+                recipient_npub[:20], len(self._relays),
+            )
+        except Exception as exc:
+            logger.warning("Failed to send welcome DM: %s", exc)
+            raise CourierError(f"Failed to send welcome DM: {exc}") from exc
+
+    async def open_channel(
+        self,
+        service: str,
+        *,
+        recipient_npub: str | None = None,
+    ) -> dict[str, Any]:
         """Open a credential delivery channel for a service.
 
-        Returns the operator's npub, relay list, and template instructions
-        so the patron knows where and what to send.  Also starts a
-        background relay subscription to listen for incoming DMs.
+        If ``recipient_npub`` is provided, sends a welcome DM to the
+        patron with template instructions.  The patron just replies
+        to the thread instead of composing a new DM to an unfamiliar npub.
+
+        If ``recipient_npub`` is omitted, falls back to returning the
+        operator's npub and instructions for manual DM initiation.
 
         Args:
             service: Template service name (e.g., "x", "openai").
+            recipient_npub: Optional patron npub to send welcome DM to.
 
         Returns:
             Dict with npub, relays, template instructions, and freshness window.
@@ -240,20 +380,53 @@ class NostrCredentialExchange:
         # Start background subscription
         self._start_subscription()
 
-        return {
+        # Build the welcome message for the patron
+        welcome_text = (
+            f"Hello from {self._npub}!\n\n"
+            f"Reply to this message with your {template.service} credentials "
+            f"as a JSON object:\n\n{instructions}\n\n"
+            f"Your reply is end-to-end encrypted — "
+            f"only this service can read it."
+        )
+
+        result: dict[str, Any] = {
             "success": True,
             "npub": self._npub,
             "relays": self._relays,
             "service": service,
             "freshness_window_seconds": self._freshness_window,
             "instructions": instructions,
-            "message": (
+        }
+
+        if recipient_npub:
+            try:
+                self.send_dm(recipient_npub, welcome_text)
+                result["welcome_dm_sent"] = True
+                result["message"] = (
+                    f"A welcome DM has been sent to {recipient_npub}. "
+                    f"Open your Nostr client, find the message, and reply "
+                    f"with your credentials as JSON. "
+                    f"Then call receive_credentials with your npub."
+                )
+            except Exception as exc:
+                logger.warning("Welcome DM failed, falling back to manual: %s", exc)
+                result["welcome_dm_sent"] = False
+                result["message"] = (
+                    f"Could not send welcome DM ({exc}). "
+                    f"Send your {template.service} credentials as a Nostr DM "
+                    f"to {self._npub} from your Nostr client. "
+                    f"Then call receive_credentials with your npub."
+                )
+        else:
+            result["welcome_dm_sent"] = False
+            result["message"] = (
                 f"Send your {template.service} credentials as a Nostr DM "
                 f"to {self._npub} from your Nostr client. "
                 f"The DM must contain a JSON object matching the template above. "
                 f"Then call receive_credentials with your npub."
-            ),
-        }
+            )
+
+        return result
 
     async def receive(
         self, sender_npub: str, *, service: str | None = None,

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -16,8 +16,10 @@ from tollbooth.nostr_credentials import (
     CourierTimeout,
     CourierValidationError,
     NostrCredentialExchange,
+    NostrProfile,
     _KIND_ENCRYPTED_DM,
     _KIND_GIFT_WRAP,
+    _KIND_METADATA,
     _KIND_SEAL,
     _KIND_PRIVATE_DM,
 )
@@ -862,3 +864,179 @@ class TestCredentialVault:
 
         assert result["credentials"]["api_key"] == "rotated"
         assert result["encryption"] == "nip04"
+
+
+# ── NostrProfile tests ────────────────────────────────────────────────
+
+
+class TestNostrProfile:
+    def test_to_metadata_full(self):
+        profile = NostrProfile(
+            name="excalibur-mcp",
+            display_name="eXcalibur MCP",
+            about="Sword-swift tweets",
+            picture="https://example.com/avatar.png",
+            nip05="excalibur@dpyc.community",
+            website="https://github.com/lonniev/excalibur-mcp",
+        )
+        meta = profile.to_metadata()
+        assert meta["name"] == "excalibur-mcp"
+        assert meta["display_name"] == "eXcalibur MCP"
+        assert meta["about"] == "Sword-swift tweets"
+        assert meta["picture"] == "https://example.com/avatar.png"
+        assert meta["nip05"] == "excalibur@dpyc.community"
+        assert meta["website"] == "https://github.com/lonniev/excalibur-mcp"
+
+    def test_to_metadata_minimal(self):
+        profile = NostrProfile(name="test-mcp")
+        meta = profile.to_metadata()
+        assert meta == {"name": "test-mcp"}
+        assert "display_name" not in meta
+        assert "picture" not in meta
+
+    def test_extra_fields(self):
+        profile = NostrProfile(
+            name="test",
+            extra={"custom_field": "value"},
+        )
+        meta = profile.to_metadata()
+        assert meta["custom_field"] == "value"
+
+
+class TestPublishProfile:
+    def test_publishes_kind_0_event(self):
+        ex = _make_exchange()
+        profile = NostrProfile(name="test-mcp", about="Test service")
+
+        published = []
+        original_publish = ex._publish_to_relays
+
+        def capture_publish(message: str) -> None:
+            published.append(message)
+
+        with patch.object(ex, "_publish_to_relays", side_effect=capture_publish):
+            ex.publish_profile(profile)
+
+            # Wait for daemon thread
+            import time
+            time.sleep(0.2)
+
+        assert len(published) == 1
+        msg = json.loads(published[0])
+        assert msg[0] == "EVENT"
+        event = msg[1]
+        assert event["kind"] == _KIND_METADATA
+        content = json.loads(event["content"])
+        assert content["name"] == "test-mcp"
+        assert content["about"] == "Test service"
+
+    def test_publish_profile_disabled(self):
+        """No error when exchange is disabled."""
+        ex = _make_exchange(relays=[])
+        ex._enabled = False
+        ex.publish_profile(NostrProfile(name="test"))
+        # Should not raise
+
+
+class TestSendDm:
+    def test_sends_nip04_dm(self):
+        ex = _make_exchange()
+        patron = PrivateKey()
+
+        published = []
+
+        def capture_publish(message: str) -> None:
+            published.append(message)
+
+        with patch.object(ex, "_publish_to_relays", side_effect=capture_publish):
+            ex.send_dm(patron.public_key.bech32(), "Hello patron!")
+
+            import time
+            time.sleep(0.2)
+
+        assert len(published) == 1
+        msg = json.loads(published[0])
+        assert msg[0] == "EVENT"
+        event = msg[1]
+        assert event["kind"] == _KIND_ENCRYPTED_DM
+        # p-tag should reference the patron
+        p_tags = [t for t in event["tags"] if t[0] == "p"]
+        assert len(p_tags) == 1
+        assert p_tags[0][1] == patron.public_key.hex()
+        # Content should be NIP-04 encrypted (contains ?iv=)
+        assert "?iv=" in event["content"]
+
+    def test_send_dm_decryptable(self):
+        """Patron can decrypt the welcome DM."""
+        from tollbooth.nip04 import decrypt as nip04_decrypt
+
+        ex = _make_exchange()
+        patron = PrivateKey()
+
+        published = []
+
+        def capture_publish(message: str) -> None:
+            published.append(message)
+
+        with patch.object(ex, "_publish_to_relays", side_effect=capture_publish):
+            ex.send_dm(patron.public_key.bech32(), "Test message")
+
+            import time
+            time.sleep(0.2)
+
+        event = json.loads(published[0])[1]
+        plaintext = nip04_decrypt(
+            event["content"], patron.hex(), ex._pubkey_hex,
+        )
+        assert plaintext == "Test message"
+
+    def test_send_dm_invalid_npub(self):
+        ex = _make_exchange()
+        with pytest.raises(CourierValidationError, match="Invalid recipient"):
+            ex.send_dm("not-an-npub", "hello")
+
+
+class TestOpenChannelWithWelcomeDm:
+    @pytest.mark.asyncio
+    async def test_sends_welcome_dm_when_npub_provided(self):
+        ex = _make_exchange()
+        patron = PrivateKey()
+
+        with patch.object(ex, "_start_subscription"), \
+             patch.object(ex, "send_dm") as mock_send:
+            result = await ex.open_channel("x", recipient_npub=patron.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["welcome_dm_sent"] is True
+        mock_send.assert_called_once()
+        call_args = mock_send.call_args
+        assert call_args[0][0] == patron.public_key.bech32()
+        assert "credentials" in call_args[0][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_welcome_dm_without_npub(self):
+        ex = _make_exchange()
+
+        with patch.object(ex, "_start_subscription"):
+            result = await ex.open_channel("x")
+
+        assert result["success"] is True
+        assert result["welcome_dm_sent"] is False
+        assert self._npub_in_message(result, ex.npub)
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_dm_failure(self):
+        ex = _make_exchange()
+        patron = PrivateKey()
+
+        with patch.object(ex, "_start_subscription"), \
+             patch.object(ex, "send_dm", side_effect=Exception("relay down")):
+            result = await ex.open_channel("x", recipient_npub=patron.public_key.bech32())
+
+        assert result["success"] is True
+        assert result["welcome_dm_sent"] is False
+        assert "could not send" in result["message"].lower()
+
+    @staticmethod
+    def _npub_in_message(result: dict, npub: str) -> bool:
+        return npub in result.get("message", "")


### PR DESCRIPTION
## Summary
- `NostrProfile` dataclass for kind 0 operator profile metadata (name, avatar, about, nip05, etc.)
- `publish_profile()` publishes kind 0 event to relays — patrons see friendly name + avatar instead of raw npub
- `send_dm()` sends NIP-04 encrypted outbound DMs to any npub
- `open_channel(service, recipient_npub=...)` sends welcome DM so patron just replies to existing thread
- Graceful fallback to manual flow if welcome DM fails

## Test plan
- [x] 548 tests pass (11 new)
- [x] `NostrProfile.to_metadata()` — full, minimal, and extra fields
- [x] `publish_profile()` — publishes kind 0 event, disabled exchange no-op
- [x] `send_dm()` — sends NIP-04 DM, patron can decrypt, invalid npub rejected
- [x] `open_channel(recipient_npub=...)` — sends welcome DM, fallback on failure, no DM without npub

🤖 Generated with [Claude Code](https://claude.com/claude-code)