### PR TITLE
Add Constraint Engine Phase 3 — opt-in middleware gate

### DIFF
--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -76,6 +76,7 @@ try:
         PatronIdentity,
         EnvironmentSnapshot,
         ConstraintEngine,
+        ConstraintGate,
         TemporalWindowConstraint,
         FiniteSupplyConstraint,
         PeriodicRefreshConstraint,
@@ -97,6 +98,7 @@ except ImportError:
     PatronIdentity = None  # type: ignore[assignment,misc]
     EnvironmentSnapshot = None  # type: ignore[assignment,misc]
     ConstraintEngine = None  # type: ignore[assignment,misc]
+    ConstraintGate = None  # type: ignore[assignment,misc]
     TemporalWindowConstraint = None  # type: ignore[assignment,misc]
     FiniteSupplyConstraint = None  # type: ignore[assignment,misc]
     PeriodicRefreshConstraint = None  # type: ignore[assignment,misc]
@@ -153,6 +155,7 @@ __all__ = [
     "NotificationManager",
     "NotificationPreferences",
     # Constraint Engine
+    "ConstraintGate",
     "ToolConstraint",
     "ConstraintContext",
     "ConstraintResult",

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -25,3 +25,6 @@ class TollboothConfig:
     # OpenTimestamps Bitcoin anchoring
     ots_enabled: bool = False
     ots_calendars: str | None = None  # Comma-separated URLs; None = defaults
+    # Constraint Engine (opt-in)
+    constraints_enabled: bool = False
+    constraints_config: str | None = None  # JSON string of constraint config

--- a/src/tollbooth/constraints/__init__.py
+++ b/src/tollbooth/constraints/__init__.py
@@ -25,6 +25,7 @@ from tollbooth.constraints.config import (
 )
 from tollbooth.constraints.engine import ConstraintEngine
 from tollbooth.constraints.expression import JsonExpressionConstraint
+from tollbooth.constraints.gate import ConstraintGate
 from tollbooth.constraints.periodic import PeriodicRefreshConstraint, parse_iso_duration
 from tollbooth.constraints.pricing import (
     BulkBonusConstraint,
@@ -57,6 +58,8 @@ __all__ = [
     "JsonExpressionConstraint",
     # Engine
     "ConstraintEngine",
+    # Gate
+    "ConstraintGate",
     # Config
     "CONSTRAINT_REGISTRY",
     "ConfigError",

--- a/src/tollbooth/constraints/gate.py
+++ b/src/tollbooth/constraints/gate.py
@@ -1,0 +1,134 @@
+"""Constraint gate — drop-in helper for operator _debit_or_error flows."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from tollbooth.config import TollboothConfig
+from tollbooth.constraints.base import (
+    ConstraintContext,
+    ConstraintResult,
+    EnvironmentSnapshot,
+    LedgerSnapshot,
+    PatronIdentity,
+)
+from tollbooth.constraints.config import ConfigError, load_constraints
+from tollbooth.constraints.engine import ConstraintEngine
+
+logger = logging.getLogger(__name__)
+
+
+class ConstraintGate:
+    """Evaluates constraints before a tool call.
+
+    Usage in operator code::
+
+        gate = ConstraintGate(config)
+
+        async def _debit_or_error(tool_name, user_id, cache):
+            cost = TOOL_COSTS.get(tool_name, 0)
+            if cost == 0:
+                return None, cost
+
+            ledger = await cache.get(user_id)
+
+            # Check constraints (may modify cost)
+            denial, effective_cost = gate.check(
+                tool_name=tool_name,
+                base_cost=cost,
+                ledger=ledger,
+                npub=user_id,
+            )
+            if denial is not None:
+                return denial, 0
+
+            # Debit at effective_cost (may be discounted)
+            if not ledger.debit(tool_name, effective_cost):
+                return {"success": False, "error": "Insufficient balance"}, 0
+
+            cache.mark_dirty(user_id)
+            return None, effective_cost
+    """
+
+    def __init__(self, config: TollboothConfig) -> None:
+        self._enabled = config.constraints_enabled
+        self._engine: ConstraintEngine | None = None
+
+        if self._enabled and config.constraints_config:
+            try:
+                raw = json.loads(config.constraints_config)
+                self._engine = load_constraints(raw)
+            except (json.JSONDecodeError, ConfigError) as e:
+                logger.error("Failed to load constraint config: %s", e)
+                self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        """True when the gate is active and has a valid engine."""
+        return self._enabled and self._engine is not None
+
+    def check(
+        self,
+        tool_name: str,
+        base_cost: int,
+        ledger: Any,  # UserLedger — use Any to avoid circular import
+        npub: str = "",
+        membership_tier: str = "default",
+        invocation_count: int = 0,
+    ) -> tuple[dict[str, Any] | None, int]:
+        """Evaluate constraints for a tool call.
+
+        Returns
+        -------
+        (denial_dict, effective_cost)
+            If *denial_dict* is not ``None``, the tool call should be blocked
+            with that error.  Otherwise *effective_cost* is the (possibly
+            discounted) cost to debit.
+        """
+        if not self.enabled:
+            return None, base_cost
+
+        assert self._engine is not None  # guarded by self.enabled
+
+        # Build context from ledger snapshot (read-only)
+        context = ConstraintContext(
+            ledger=LedgerSnapshot(
+                balance_api_sats=ledger.balance_api_sats,
+                total_deposited_api_sats=ledger.total_deposited_api_sats,
+                total_consumed_api_sats=ledger.total_consumed_api_sats,
+                total_expired_api_sats=ledger.total_expired_api_sats,
+            ),
+            patron=PatronIdentity(
+                npub=npub,
+                membership_tier=membership_tier,
+            ),
+            env=EnvironmentSnapshot(
+                utc_now=datetime.now(timezone.utc),
+                tool_name=tool_name,
+                invocation_count=invocation_count,
+            ),
+        )
+
+        result = self._engine.evaluate(tool_name, context)
+
+        if not result.allowed:
+            error: dict[str, Any] = {
+                "success": False,
+                "error": result.message or f"Constraint denied: {result.reason}",
+                "constraint_reason": result.reason,
+            }
+            if result.retry_after:
+                error["retry_after"] = result.retry_after.isoformat()
+            if result.metadata:
+                error["constraint_metadata"] = result.metadata
+            return error, 0
+
+        # Apply price modifier if present
+        effective_cost = base_cost
+        if result.price_modifier:
+            effective_cost = result.price_modifier.apply_to(base_cost)
+
+        return None, effective_cost

--- a/tests/test_config_compat.py
+++ b/tests/test_config_compat.py
@@ -1,0 +1,106 @@
+"""Backwards compatibility tests for TollboothConfig.
+
+Ensures that adding constraints_enabled and constraints_config fields
+does not break existing code that constructs TollboothConfig with
+only the original fields.
+"""
+
+from tollbooth.config import TollboothConfig
+
+
+class TestConfigBackwardsCompatibility:
+    def test_no_args(self):
+        """TollboothConfig() with no args still works."""
+        config = TollboothConfig()
+        assert config.btcpay_host is None
+        assert config.btcpay_store_id is None
+        assert config.btcpay_api_key is None
+        assert config.seed_balance_sats == 0
+        assert config.constraints_enabled is False
+        assert config.constraints_config is None
+
+    def test_btcpay_only(self):
+        """TollboothConfig with only btcpay fields works."""
+        config = TollboothConfig(btcpay_host="https://pay.example.com")
+        assert config.btcpay_host == "https://pay.example.com"
+        assert config.constraints_enabled is False
+        assert config.constraints_config is None
+
+    def test_all_existing_fields_present(self):
+        """All original fields have correct defaults."""
+        config = TollboothConfig()
+        assert config.btcpay_host is None
+        assert config.btcpay_store_id is None
+        assert config.btcpay_api_key is None
+        assert config.btcpay_tier_config is None
+        assert config.btcpay_user_tiers is None
+        assert config.seed_balance_sats == 0
+        assert config.tollbooth_royalty_address is None
+        assert config.tollbooth_royalty_percent == 0.02
+        assert config.tollbooth_royalty_min_sats == 10
+        assert config.authority_npub is None
+        assert config.credit_ttl_seconds == 604800
+        assert config.flush_batch_size == 10
+        assert config.flush_staleness_secs == 120.0
+        assert config.ots_enabled is False
+        assert config.ots_calendars is None
+
+    def test_all_existing_fields_settable(self):
+        """All original fields can be set via keyword args."""
+        config = TollboothConfig(
+            btcpay_host="https://pay.example.com",
+            btcpay_store_id="store123",
+            btcpay_api_key="key456",
+            btcpay_tier_config='{"tiers":{}}',
+            btcpay_user_tiers='{"users":{}}',
+            seed_balance_sats=500,
+            tollbooth_royalty_address="bc1q...",
+            tollbooth_royalty_percent=0.05,
+            tollbooth_royalty_min_sats=20,
+            authority_npub="npub1xxx",
+            credit_ttl_seconds=3600,
+            flush_batch_size=5,
+            flush_staleness_secs=60.0,
+            ots_enabled=True,
+            ots_calendars="https://cal1,https://cal2",
+        )
+        assert config.btcpay_host == "https://pay.example.com"
+        assert config.btcpay_store_id == "store123"
+        assert config.btcpay_api_key == "key456"
+        assert config.btcpay_tier_config == '{"tiers":{}}'
+        assert config.btcpay_user_tiers == '{"users":{}}'
+        assert config.seed_balance_sats == 500
+        assert config.tollbooth_royalty_address == "bc1q..."
+        assert config.tollbooth_royalty_percent == 0.05
+        assert config.tollbooth_royalty_min_sats == 20
+        assert config.authority_npub == "npub1xxx"
+        assert config.credit_ttl_seconds == 3600
+        assert config.flush_batch_size == 5
+        assert config.flush_staleness_secs == 60.0
+        assert config.ots_enabled is True
+        assert config.ots_calendars == "https://cal1,https://cal2"
+        # New fields still default
+        assert config.constraints_enabled is False
+        assert config.constraints_config is None
+
+    def test_frozen(self):
+        """TollboothConfig is frozen (immutable)."""
+        config = TollboothConfig()
+        try:
+            config.btcpay_host = "modified"  # type: ignore[misc]
+            assert False, "Should have raised FrozenInstanceError"
+        except AttributeError:
+            pass  # expected — frozen dataclass
+
+    def test_new_fields_with_old_fields(self):
+        """Can mix old and new fields together."""
+        config = TollboothConfig(
+            btcpay_host="https://pay.example.com",
+            seed_balance_sats=100,
+            constraints_enabled=True,
+            constraints_config='{"tool_constraints":{}}',
+        )
+        assert config.btcpay_host == "https://pay.example.com"
+        assert config.seed_balance_sats == 100
+        assert config.constraints_enabled is True
+        assert config.constraints_config == '{"tool_constraints":{}}'

--- a/tests/test_constraints/test_gate.py
+++ b/tests/test_constraints/test_gate.py
@@ -1,0 +1,414 @@
+"""Tests for the ConstraintGate middleware integration helper."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tollbooth.config import TollboothConfig
+from tollbooth.constraints.gate import ConstraintGate
+
+
+# ---------------------------------------------------------------------------
+# Lightweight ledger stub — mirrors UserLedger's public attributes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubLedger:
+    balance_api_sats: int = 1000
+    total_deposited_api_sats: int = 2000
+    total_consumed_api_sats: int = 500
+    total_expired_api_sats: int = 100
+
+
+# ---------------------------------------------------------------------------
+# Helpers — config JSON builders
+# ---------------------------------------------------------------------------
+
+
+def _free_trial_config(first_n_free: int = 3) -> str:
+    """Return a JSON config with a free trial on 'search'."""
+    return json.dumps(
+        {
+            "tool_constraints": {
+                "search": {
+                    "constraints": [
+                        {"type": "free_trial", "first_n_free": first_n_free}
+                    ]
+                }
+            }
+        }
+    )
+
+
+def _coupon_config(discount_percent: float = 50.0) -> str:
+    """Return a JSON config with a coupon discount on 'search'."""
+    return json.dumps(
+        {
+            "tool_constraints": {
+                "search": {
+                    "constraints": [
+                        {
+                            "type": "coupon",
+                            "code": "HALF_OFF",
+                            "discount_percent": discount_percent,
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+
+def _temporal_window_config(schedule: str = "09:00-17:00") -> str:
+    """Return a JSON config with a temporal window on 'search'."""
+    return json.dumps(
+        {
+            "tool_constraints": {
+                "search": {
+                    "constraints": [
+                        {
+                            "type": "temporal_window",
+                            "schedule": schedule,
+                            "timezone": "UTC",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+
+def _supply_config(max_invocations: int = 5, current_count: int = 5) -> str:
+    """Return a JSON config with a finite supply constraint on 'search'."""
+    return json.dumps(
+        {
+            "tool_constraints": {
+                "search": {
+                    "constraints": [
+                        {
+                            "type": "finite_supply",
+                            "max_invocations": max_invocations,
+                            "current_count": current_count,
+                            "scope": "global",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+
+def _wildcard_config() -> str:
+    """Return a JSON config with a wildcard free trial applying to all tools."""
+    return json.dumps(
+        {
+            "tool_constraints": {
+                "*": {
+                    "constraints": [
+                        {"type": "free_trial", "first_n_free": 5}
+                    ]
+                }
+            }
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledByDefault:
+    def test_disabled_by_default(self):
+        """ConstraintGate with default TollboothConfig returns (None, base_cost)."""
+        config = TollboothConfig()
+        gate = ConstraintGate(config)
+
+        assert not gate.enabled
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 100
+
+
+class TestEnabledNoConfig:
+    def test_enabled_no_config(self):
+        """enabled=True but no config JSON falls back to disabled."""
+        config = TollboothConfig(constraints_enabled=True)
+        gate = ConstraintGate(config)
+
+        assert not gate.enabled
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 100
+
+
+class TestEnabledInvalidJson:
+    def test_enabled_invalid_json(self):
+        """Bad JSON falls back to disabled gracefully (no exception)."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config="NOT VALID JSON {{{",
+        )
+        gate = ConstraintGate(config)
+
+        assert not gate.enabled
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 100
+
+
+class TestEnabledValidConfigAllows:
+    def test_enabled_valid_config_allows(self):
+        """A constraint that passes returns (None, base_cost)."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        assert gate.enabled
+
+        # invocation_count=0 is within the free trial, but the result
+        # is (None, effective_cost) where effective_cost=0 because free trial
+        # sets PriceModifier(free=True).  For "allows" without price mod,
+        # test a tool NOT covered by the config — it should pass through.
+        denial, cost = gate.check(
+            tool_name="unconstrained_tool",
+            base_cost=200,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 200
+
+
+class TestEnabledWithFreeTrial:
+    def test_enabled_with_free_trial(self):
+        """Free trial applies PriceModifier(free=True), effective_cost=0."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,  # within trial
+        )
+        assert denial is None
+        assert cost == 0  # free!
+
+    def test_free_trial_exhausted_full_price(self):
+        """After trial, cost returns to base_cost (no price modifier)."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=5,  # beyond trial
+        )
+        assert denial is None
+        assert cost == 100  # full price
+
+
+class TestEnabledWithCouponDiscount:
+    def test_enabled_with_coupon_discount(self):
+        """Coupon applies 50% discount, effective_cost halved."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_coupon_config(discount_percent=50.0),
+        )
+        gate = ConstraintGate(config)
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 50  # 50% off
+
+
+class TestEnabledDeniesTemporalWindow:
+    def test_enabled_denies_temporal_window(self):
+        """Outside window returns (error_dict, 0) with retry_after."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_temporal_window_config("09:00-17:00"),
+        )
+        gate = ConstraintGate(config)
+
+        # Patch datetime.now so the gate sees 03:00 UTC (outside 09:00-17:00)
+        fixed_time = datetime(2026, 2, 27, 3, 0, 0, tzinfo=timezone.utc)
+        with patch(
+            "tollbooth.constraints.gate.datetime"
+        ) as mock_dt:
+            mock_dt.now.return_value = fixed_time
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            denial, cost = gate.check(
+                tool_name="search",
+                base_cost=100,
+                ledger=_StubLedger(),
+            )
+
+        assert denial is not None
+        assert cost == 0
+        assert denial["success"] is False
+        assert denial["constraint_reason"] == "outside_window"
+        assert "retry_after" in denial
+
+
+class TestEnabledDeniesSupplyExhausted:
+    def test_enabled_denies_supply_exhausted(self):
+        """Finite supply at cap returns (error_dict, 0)."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_supply_config(max_invocations=5, current_count=5),
+        )
+        gate = ConstraintGate(config)
+
+        denial, cost = gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+
+        assert denial is not None
+        assert cost == 0
+        assert denial["success"] is False
+        assert denial["constraint_reason"] == "supply_exhausted"
+
+
+class TestConfigFieldOnTollboothConfig:
+    def test_config_field_on_tollboothconfig(self):
+        """TollboothConfig accepts constraints_enabled and constraints_config."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config='{"tool_constraints": {}}',
+        )
+        assert config.constraints_enabled is True
+        assert config.constraints_config == '{"tool_constraints": {}}'
+
+
+class TestExistingConfigUnchanged:
+    def test_existing_config_unchanged(self):
+        """TollboothConfig() with only old fields still works."""
+        config = TollboothConfig(btcpay_host="https://example.com")
+        assert config.btcpay_host == "https://example.com"
+        # New fields default to off
+        assert config.constraints_enabled is False
+        assert config.constraints_config is None
+
+
+class TestCheckBuildsCorrectContext:
+    def test_check_builds_correct_context(self):
+        """Verify LedgerSnapshot/PatronIdentity/EnvironmentSnapshot are built
+        correctly from inputs."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=100),
+        )
+        gate = ConstraintGate(config)
+
+        ledger = _StubLedger(
+            balance_api_sats=999,
+            total_deposited_api_sats=2000,
+            total_consumed_api_sats=800,
+            total_expired_api_sats=50,
+        )
+
+        # Capture the context passed to the engine by monkey-patching evaluate
+        captured_contexts: list[Any] = []
+        original_evaluate = gate._engine.evaluate  # type: ignore[union-attr]
+
+        def capturing_evaluate(tool_name: str, context: Any) -> Any:
+            captured_contexts.append(context)
+            return original_evaluate(tool_name, context)
+
+        gate._engine.evaluate = capturing_evaluate  # type: ignore[union-attr]
+
+        gate.check(
+            tool_name="search",
+            base_cost=100,
+            ledger=ledger,
+            npub="npub1abc",
+            membership_tier="gold",
+            invocation_count=7,
+        )
+
+        assert len(captured_contexts) == 1
+        ctx = captured_contexts[0]
+
+        # LedgerSnapshot
+        assert ctx.ledger.balance_api_sats == 999
+        assert ctx.ledger.total_deposited_api_sats == 2000
+        assert ctx.ledger.total_consumed_api_sats == 800
+        assert ctx.ledger.total_expired_api_sats == 50
+
+        # PatronIdentity
+        assert ctx.patron.npub == "npub1abc"
+        assert ctx.patron.membership_tier == "gold"
+
+        # EnvironmentSnapshot
+        assert ctx.env.tool_name == "search"
+        assert ctx.env.invocation_count == 7
+        assert ctx.env.utc_now.tzinfo is not None
+
+
+class TestWildcardConstraintsApplied:
+    def test_wildcard_constraints_applied(self):
+        """Constraints under '*' key apply to all tools."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_wildcard_config(),
+        )
+        gate = ConstraintGate(config)
+
+        # Any tool name should get the free trial discount
+        denial, cost = gate.check(
+            tool_name="any_random_tool",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,  # within trial
+        )
+        assert denial is None
+        assert cost == 0  # free via wildcard free trial
+
+        # A different tool also gets it
+        denial2, cost2 = gate.check(
+            tool_name="another_tool",
+            base_cost=200,
+            ledger=_StubLedger(),
+            invocation_count=0,
+        )
+        assert denial2 is None
+        assert cost2 == 0


### PR DESCRIPTION
## Summary
- Add `constraints_enabled` + `constraints_config` to `TollboothConfig` (both default OFF)
- New `ConstraintGate` helper class — drop-in for operator `_debit_or_error` flows
- Gate builds `ConstraintContext` from ledger, evaluates engine, returns denial or adjusted cost
- Graceful degradation on bad config (logs error, falls back to disabled)
- 19 new tests (13 gate + 6 backwards-compat), 913 total all passing

## Production Impact
**None.** Both new config fields default to OFF/None. Existing operators are completely unaffected. The gate is a passthrough when disabled.

## Test plan
- [x] 13 gate tests: disabled default, bad config fallback, free trial, coupon discount, temporal denial, supply exhausted, wildcard, context building
- [x] 6 backwards-compat tests: TollboothConfig construction with old-style args, field defaults, frozen immutability
- [x] All 894 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)