### PR TITLE
Bump to v0.1.37 — Constraint Engine Phase 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.35"
+version = "0.1.37"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.35"
+__version__ = "0.1.37"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig


### PR DESCRIPTION
## Summary
- Bump version to 0.1.37 in pyproject.toml and __init__.py
- Covers Constraint Engine Phase 3 (ConstraintGate middleware integration)

## Test plan
- [x] No code changes, version bump only
- [x] All 913 tests pass on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)