### PR TITLE
Fix gift wrap decrypt + anti-replay poison slug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.40"
+version = "0.1.41"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.40"
+__version__ = "0.1.41"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -99,6 +99,27 @@ def _randomize_timestamp() -> int:
     return int(time.time()) - random.randint(0, _TIMESTAMP_FUZZ_SECONDS)
 
 
+# Anti-replay poison slug — memorable adjective-noun-number phrases
+_ADJECTIVES = [
+    "amber", "bold", "calm", "dark", "eager", "faint", "glad", "hazy",
+    "iron", "jade", "keen", "live", "mild", "neat", "opal", "pale",
+    "quick", "rare", "soft", "true", "ultra", "vivid", "warm", "zinc",
+]
+_NOUNS = [
+    "arrow", "blade", "cloud", "dusk", "eagle", "flame", "grove", "hawk",
+    "iris", "jewel", "knot", "lake", "mesa", "nest", "orbit", "peak",
+    "quill", "reef", "spark", "tide", "vale", "wave", "yarn", "zero",
+]
+
+
+def _generate_poison() -> str:
+    """Generate a memorable anti-replay phrase like ``bold-hawk-42``."""
+    adj = random.choice(_ADJECTIVES)
+    noun = random.choice(_NOUNS)
+    num = random.randint(10, 99)
+    return f"{adj}-{noun}-{num}"
+
+
 @dataclass
 class NostrProfile:
     """Nostr kind 0 profile metadata for the operator's npub.
@@ -252,6 +273,8 @@ class NostrCredentialExchange:
         self._received_events: list[dict[str, Any]] = []
         # Track consumed event IDs (prevent double-pickup)
         self._consumed_ids: set[str] = set()
+        # Poison slugs: {recipient_npub: (phrase, expiry_timestamp)}
+        self._pending_poisons: dict[str, tuple[str, float]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -491,6 +514,9 @@ class NostrCredentialExchange:
         template = self._templates[service]
         instructions = render_template_instructions(template)
 
+        # Generate anti-replay poison slug
+        poison = _generate_poison()
+
         # Start background subscription
         self._start_subscription()
 
@@ -504,12 +530,20 @@ class NostrCredentialExchange:
             f"You're receiving this message because you (or your AI agent) "
             f"requested a credential channel from a Claude session.\n\n"
             f"If you'd like to proceed, reply to this message with your "
-            f"credentials as JSON:\n\n{instructions}\n\n"
+            f"credentials as JSON.  IMPORTANT: include the anti-replay "
+            f"token exactly as shown.\n\n"
+            f"{instructions}\n"
+            f'  "poison": "{poison}"\n\n'
             f"Your reply is end-to-end encrypted — "
             f"only this service can read it.\n\n"
             f"If you didn't request this, simply ignore this message.\n\n"
             f"— tollbooth-dpyc v{_tb_version} | {timestamp}"
         )
+
+        # Store poison for validation on receive
+        if recipient_npub:
+            expiry = time.time() + self._freshness_window
+            self._pending_poisons[recipient_npub] = (poison, expiry)
 
         result: dict[str, Any] = {
             "success": True,
@@ -518,6 +552,7 @@ class NostrCredentialExchange:
             "service": service,
             "freshness_window_seconds": self._freshness_window,
             "instructions": instructions,
+            "poison": poison,
         }
 
         if recipient_npub:
@@ -607,13 +642,13 @@ class NostrCredentialExchange:
                     ),
                 }
 
-        # ── Relay DM flow (existing) ────────────────────────────────
-        dm = self._find_dm_in_buffer(sender_hex)
-        if dm is None:
+        # ── Relay DM flow ─────────────────────────────────────────
+        candidates = self._find_dm_candidates(sender_hex)
+        if not candidates:
             self._fetch_dms_from_relays()
-            dm = self._find_dm_in_buffer(sender_hex)
+            candidates = self._find_dm_candidates(sender_hex)
 
-        if dm is None:
+        if not candidates:
             raise CourierTimeout(
                 f"No DM found from {sender_npub} within the "
                 f"{self._freshness_window}-second freshness window. "
@@ -621,8 +656,39 @@ class NostrCredentialExchange:
                 f"try again."
             )
 
-        # Decrypt content
-        plaintext = self._decrypt_dm(dm, sender_hex)
+        # Try each candidate.  NIP-04 events are already sender-filtered
+        # so errors propagate immediately.  Gift wraps may fail to decrypt
+        # (wrong ECDH shared secret) or reveal a different sender inside
+        # the seal — silently skip those and try the next candidate.
+        dm = None
+        plaintext = None
+        for candidate in candidates:
+            kind = candidate.get("kind", 0)
+            if kind == _KIND_GIFT_WRAP:
+                try:
+                    plaintext = self._decrypt_dm(candidate, sender_hex)
+                    dm = candidate
+                    break
+                except CourierValidationError:
+                    logger.debug(
+                        "Skipping gift wrap %s (decrypt/validate failed)",
+                        candidate.get("id", "?")[:16],
+                    )
+                    continue
+            else:
+                # NIP-04: already matched by sender — errors are real
+                plaintext = self._decrypt_dm(candidate, sender_hex)
+                dm = candidate
+                break
+
+        if dm is None or plaintext is None:
+            raise CourierTimeout(
+                f"No decryptable DM found from {sender_npub} within the "
+                f"{self._freshness_window}-second freshness window. "
+                f"Found {len(candidates)} candidate event(s) but none "
+                f"could be decrypted. Make sure you replied from the "
+                f"correct Nostr identity."
+            )
 
         # Resolve template for error DM instructions
         error_template = self._resolve_error_template(service)
@@ -642,6 +708,31 @@ class NostrCredentialExchange:
                 "DM content must be a JSON object, "
                 f"got {type(payload).__name__}"
             )
+
+        # Validate anti-replay poison slug
+        expected = self._pending_poisons.get(sender_npub)
+        if expected is not None:
+            expected_phrase, expiry = expected
+            received_poison = payload.pop("poison", None)
+            if time.time() > expiry:
+                del self._pending_poisons[sender_npub]
+                raise CourierValidationError(
+                    "Anti-replay token expired. Call request_credential_channel "
+                    "again to get a fresh token."
+                )
+            if received_poison != expected_phrase:
+                raise CourierValidationError(
+                    f'Anti-replay token mismatch. Expected "poison": '
+                    f'"{expected_phrase}" but got '
+                    f'"{received_poison}". Include the exact token from '
+                    f"the welcome message."
+                )
+            # Consume the poison — one-time use
+            del self._pending_poisons[sender_npub]
+        else:
+            # No poison pending — remove the field if present so it
+            # doesn't confuse template matching
+            payload.pop("poison", None)
 
         # Match template
         payload_service = payload.get("service")
@@ -918,22 +1009,18 @@ class NostrCredentialExchange:
             "limit": 50,
         }
         # Filter 2: NIP-17 gift wraps addressed to us (p-tag match)
+        # NIP-17 spec requires the outer gift wrap p-tag to be the real
+        # recipient (for relay routing).  A previous broad filter without
+        # a #p constraint pulled in wraps addressed to other users, causing
+        # ECDH/MAC failures on decrypt.
         filter_giftwrap_tagged: dict[str, Any] = {
             "kinds": [_KIND_GIFT_WRAP],
             "#p": [self._pubkey_hex],
             "since": since,
             "limit": 50,
         }
-        # Filter 3: NIP-17 gift wraps without our p-tag
-        # (metadata-protected per NIP-17 — outer p-tag may be random).
-        # Broader search — limit tightly to avoid noise.
-        filter_giftwrap_broad: dict[str, Any] = {
-            "kinds": [_KIND_GIFT_WRAP],
-            "since": since,
-            "limit": 20,
-        }
 
-        filters = [filter_nip04, filter_giftwrap_tagged, filter_giftwrap_broad]
+        filters = [filter_nip04, filter_giftwrap_tagged]
         sub_id = f"courier-{int(time.time())}"
 
         for relay_url in self._relays:
@@ -1011,8 +1098,13 @@ class NostrCredentialExchange:
         """One-shot fetch of recent DMs from all relays."""
         self._subscribe_to_relays()
 
-    def _find_dm_in_buffer(self, sender_hex: str) -> dict[str, Any] | None:
-        """Find the most recent unconsumed DM from a sender."""
+    def _find_dm_candidates(self, sender_hex: str) -> list[dict[str, Any]]:
+        """Find unconsumed DM candidates from a sender, newest first.
+
+        NIP-04 events are filtered by sender pubkey.  NIP-17 gift wraps
+        cannot be filtered by sender until decrypted (the real sender is
+        inside the encrypted seal), so all addressed wraps are included.
+        """
         now = int(time.time())
         cutoff = now - self._freshness_window
 
@@ -1037,15 +1129,12 @@ class NostrCredentialExchange:
                 elif kind == _KIND_GIFT_WRAP:
                     # NIP-17: sender is hidden inside the seal
                     # We can't filter by sender until we unwrap, so
-                    # include all gift wraps as candidates
+                    # include all gift wraps addressed to us
                     candidates.append(event)
 
-            if not candidates:
-                return None
-
-            # Return the most recent
+            # Newest first
             candidates.sort(key=lambda e: e.get("created_at", 0), reverse=True)
-            return candidates[0]
+            return candidates
 
     def _decrypt_dm(
         self, event: dict[str, Any], sender_hex: str,

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -309,8 +309,8 @@ class TestReceiveNip17:
         assert result["credentials"]["api_key"] == "sk-wrapped-123"
 
     @pytest.mark.asyncio
-    async def test_gift_wrap_wrong_sender_rejected(self):
-        """Gift wrap from wrong sender is rejected."""
+    async def test_gift_wrap_wrong_sender_skipped(self):
+        """Gift wrap from wrong sender is skipped (not matching sender)."""
         operator = PrivateKey()
         sender = PrivateKey()
         impersonator = PrivateKey()
@@ -325,8 +325,10 @@ class TestReceiveNip17:
         with ex._lock:
             ex._received_events.append(event)
 
+        # The impersonator's gift wrap decrypts but the seal reveals
+        # a different sender — it gets skipped, resulting in timeout.
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             pytest.raises(CourierValidationError, match="does not match"):
+             pytest.raises(CourierTimeout, match="No decryptable DM found"):
             await ex.receive(sender.public_key.bech32())
 
 
@@ -694,7 +696,7 @@ class TestCredentialVault:
 
         # Second receive — should come from vault
         with patch.object(ex, "_fetch_dms_from_relays") as mock_fetch, \
-             patch.object(ex, "_find_dm_in_buffer") as mock_find:
+             patch.object(ex, "_find_dm_candidates") as mock_find:
             result2 = await ex.receive(sender.public_key.bech32())
 
         assert result2["success"] is True
@@ -1079,6 +1081,110 @@ class TestOpenChannelWithWelcomeDm:
         return npub in result.get("message", "")
 
 
+# ── Poison Slug (Anti-Replay) Tests ──────────────────────────────────────
+
+
+class TestPoisonSlug:
+    """Tests for the anti-replay poison token in the Secure Courier flow."""
+
+    @pytest.mark.asyncio
+    async def test_open_channel_returns_poison(self):
+        """open_channel includes a poison slug in the result."""
+        ex = _make_exchange()
+
+        with patch.object(ex, "_start_subscription"), \
+             patch.object(ex, "send_dm"):
+            result = await ex.open_channel("x", recipient_npub="npub1test123")
+
+        assert "poison" in result
+        # Format: adjective-noun-number
+        parts = result["poison"].split("-")
+        assert len(parts) == 3
+        assert parts[2].isdigit()
+
+    @pytest.mark.asyncio
+    async def test_poison_validated_on_receive(self):
+        """Receive rejects payload with wrong poison."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        # Register a poison
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+
+        # Build a NIP-04 event with wrong poison
+        payload = {"api_key": "k", "api_secret": "s", "poison": "wrong-slug-99"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             pytest.raises(CourierValidationError, match="Anti-replay token mismatch"):
+            await ex.receive(sender_npub)
+
+    @pytest.mark.asyncio
+    async def test_poison_accepted_on_match(self):
+        """Receive accepts payload with correct poison."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+
+        payload = {"api_key": "k", "api_secret": "s", "poison": "bold-hawk-42"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender_npub)
+
+        assert result["success"] is True
+        # Poison should be consumed
+        assert sender_npub not in ex._pending_poisons
+
+    @pytest.mark.asyncio
+    async def test_poison_expired(self):
+        """Receive rejects payload when poison has expired."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        sender_npub = sender.public_key.bech32()
+        # Expired 10 seconds ago
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() - 10)
+
+        payload = {"api_key": "k", "api_secret": "s", "poison": "bold-hawk-42"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             pytest.raises(CourierValidationError, match="expired"):
+            await ex.receive(sender_npub)
+
+    @pytest.mark.asyncio
+    async def test_no_poison_required_without_open_channel(self):
+        """Receive works without poison when no open_channel was called."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        payload = {"api_key": "k", "api_secret": "s"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender.public_key.bech32())
+
+        assert result["success"] is True
+
+
 # ── Conversational DM Flow Tests ──────────────────────────────────────────
 
 
@@ -1272,20 +1378,18 @@ class TestNip17Subscription:
         assert _KIND_ENCRYPTED_DM in all_kinds, "kind 4 (NIP-04) missing from REQ"
         assert _KIND_GIFT_WRAP in all_kinds, "kind 1059 (NIP-17) missing from REQ"
 
-    def test_gift_wrap_without_ptag_collected(self):
-        """Gift wrap event without the operator’s p-tag is collected in the
-        buffer thanks to the broad filter (filter 3)."""
+    def test_gift_wrap_with_operator_ptag_collected(self):
+        """Gift wrap event with the operator’s p-tag is collected in the buffer."""
         operator = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
 
-        random_ptag_pubkey = PrivateKey().public_key.hex()
         gift_wrap_event = {
-            "id": "gw_no_ptag_test",
+            "id": "gw_ptag_test",
             "kind": _KIND_GIFT_WRAP,
             "pubkey": PrivateKey().public_key.hex(),
             "content": "encrypted-content-placeholder",
             "created_at": int(time.time()),
-            "tags": [["p", random_ptag_pubkey]],  # random p-tag, NOT the operator
+            "tags": [["p", operator.public_key.hex()]],  # operator p-tag
             "sig": "fake_sig",
         }
 
@@ -1300,11 +1404,11 @@ class TestNip17Subscription:
 
         with ex._lock:
             assert len(ex._received_events) == 1
-            assert ex._received_events[0]["id"] == "gw_no_ptag_test"
+            assert ex._received_events[0]["id"] == "gw_ptag_test"
 
     def test_gift_wrap_events_in_buffer_included_as_candidates(self):
         """Gift wrap events in the buffer are returned as candidates by
-        _find_dm_in_buffer regardless of their pubkey (sender is hidden)."""
+        _find_dm_candidates regardless of their pubkey (sender is hidden)."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
@@ -1322,15 +1426,15 @@ class TestNip17Subscription:
         with ex._lock:
             ex._received_events.append(gift_wrap_event)
 
-        # _find_dm_in_buffer should return the gift wrap as a candidate
+        # _find_dm_candidates should include the gift wrap
         # even though the sender_hex doesn’t match the event pubkey,
         # because gift wrap sender identity is hidden until unwrap.
-        result = ex._find_dm_in_buffer(sender.public_key.hex())
-        assert result is not None
-        assert result["id"] == "gw_candidate_test"
+        results = ex._find_dm_candidates(sender.public_key.hex())
+        assert len(results) == 1
+        assert results[0]["id"] == "gw_candidate_test"
 
     def test_multiple_filters_in_req(self):
-        """REQ message contains multiple filter objects (not a single merged one)."""
+        """REQ message contains two filter objects: NIP-04 and NIP-17 (p-tagged)."""
         operator = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
 
@@ -1348,7 +1452,7 @@ class TestNip17Subscription:
         assert req_msg[0] == "REQ"
         # sub_id is req_msg[1], filters start at req_msg[2:]
         filters = req_msg[2:]
-        assert len(filters) == 3, f"Expected 3 filters, got {len(filters)}"
+        assert len(filters) == 2, f"Expected 2 filters, got {len(filters)}"
 
         # Filter 1: NIP-04 with p-tag
         assert filters[0]["kinds"] == [_KIND_ENCRYPTED_DM]
@@ -1357,8 +1461,3 @@ class TestNip17Subscription:
         # Filter 2: NIP-17 gift wrap with p-tag
         assert filters[1]["kinds"] == [_KIND_GIFT_WRAP]
         assert "#p" in filters[1]
-
-        # Filter 3: NIP-17 gift wrap broad (no p-tag constraint)
-        assert filters[2]["kinds"] == [_KIND_GIFT_WRAP]
-        assert "#p" not in filters[2]
-        assert filters[2]["limit"] == 20


### PR DESCRIPTION
## Summary
- Remove the broad relay filter (no `#p` constraint) that pulled in gift wraps addressed to other users — root cause of the InvalidTag MAC failures on `receive_credentials`
- Iterate through DM candidates instead of taking only the most recent: undecryptable gift wraps are silently skipped, NIP-04 errors propagate immediately
- Add anti-replay **poison slug** to the Secure Courier flow:
  - `open_channel` generates a memorable phrase (e.g. `bold-hawk-42`)
  - Includes it in the welcome DM instructions and returns it in the result
  - `receive()` validates the poison field before accepting credentials
  - One-time use, expires with the freshness window
- Bump to v0.1.41

## Root cause
The relay subscription included a broad `kinds: [1059]` filter without a `#p` constraint. This pulled in gift wraps encrypted to other recipients. Decrypting with the wrong ECDH key produces `InvalidTag()` (empty message) from ChaCha20-Poly1305.

## Test plan
- [x] 921 tests pass (5 new poison slug tests)
- [ ] After deploy, re-test full Secure Courier flow with poison validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)