### PR TITLE
Repair bare/half-quoted dict keys in lenient JSON parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.43"
+version = "0.1.44"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.43"
+__version__ = "0.1.44"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -133,6 +133,22 @@ def _sanitize_smart_quotes(text: str) -> str:
     return text
 
 
+_BARE_KEY = re.compile(
+    r"""([{,]\s*)"""     # delimiter + optional whitespace (captured)
+    r"""(\w+)"""         # bare word — the key
+    r"""('?\s*:)""",     # optional dangling close-quote + colon
+    re.VERBOSE,
+)
+
+
+def _repair_bare_keys(text: str) -> str:
+    """Insert missing quotes around bare dict keys like ``access_token_secret':``."""
+    def _fix(m: re.Match) -> str:
+        prefix, key, suffix = m.group(1), m.group(2), m.group(3)
+        return f"{prefix}'{key}'{suffix.lstrip(chr(39))}"
+    return _BARE_KEY.sub(_fix, text)
+
+
 def _lenient_json_loads(text: str) -> Any:
     """Parse JSON leniently — tolerate human-typed Python dict syntax.
 
@@ -141,6 +157,8 @@ def _lenient_json_loads(text: str) -> Any:
     2. If that fails, normalize smart quotes and retry.
     3. If still failing, attempt ``ast.literal_eval`` (handles single-quoted
        dicts, missing quotes, trailing commas) and verify the result is a dict.
+    4. If still failing, repair bare/half-quoted keys and retry
+       ``ast.literal_eval``.
     """
     import ast
 
@@ -160,6 +178,15 @@ def _lenient_json_loads(text: str) -> Any:
     # Third pass: Python dict literal (single quotes, trailing commas, etc.)
     try:
         result = ast.literal_eval(cleaned)
+        if isinstance(result, dict):
+            return result
+    except (ValueError, SyntaxError):
+        pass
+
+    # Fourth pass: repair bare/half-quoted keys, then retry literal_eval
+    repaired = _repair_bare_keys(cleaned)
+    try:
+        result = ast.literal_eval(repaired)
         if isinstance(result, dict):
             return result
     except (ValueError, SyntaxError):

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1543,6 +1543,14 @@ class TestLenientJsonParsing:
         assert result["access_token"] == "tok-123"
         assert result["poison"] == "bold-hawk-42"
 
+    def test_missing_opening_quote_on_key(self):
+        """Real user typo: access_token_secret' missing its opening quote."""
+        raw = "{'access_token': 'tok-123', access_token_secret': 'sec-456', 'poison': 'bold-hawk-42'}"
+        result = _lenient_json_loads(raw)
+        assert result["access_token"] == "tok-123"
+        assert result["access_token_secret"] == "sec-456"
+        assert result["poison"] == "bold-hawk-42"
+
     @pytest.mark.asyncio
     async def test_receive_tolerates_single_quoted_dict(self):
         """End-to-end: receive() parses single-quoted Python dict from DM."""


### PR DESCRIPTION
## Summary
- Fourth repair pass in `_lenient_json_loads`: regex detects bare words after `{` or `,` that precede a colon and wraps them in quotes before `ast.literal_eval`
- Handles the real-world case of a human dropping an opening quote on a phone keyboard (e.g., `access_token_secret':` instead of `'access_token_secret':`)
- Version bump to 0.1.44

## Test plan
- [x] New test: `test_missing_opening_quote_on_key` with exact payload from live testing
- [x] Full suite: 936 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)