### PR TITLE
Fix NIP-17 inbound receive path + leftover JSON text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.45"
+version = "0.1.46"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,7 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.45"
+__version__ = "0.1.46"
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -130,7 +130,7 @@ def _parse_delimited_credentials(text: str) -> dict[str, str] | None:
     """Extract ``key = @@@value@@@`` pairs from *text*.
 
     Returns a dict of field→value mappings, or ``None`` if no @@@ patterns
-    were found (so the caller can fall back to JSON parsing).
+    were found (indicating the message doesn't contain credentials).
     """
     matches = _DELIMITED_FIELD.findall(text)
     if not matches:
@@ -580,7 +580,7 @@ class NostrCredentialExchange:
                 result["message"] = (
                     f"A welcome DM has been sent to {recipient_npub}. "
                     f"Open your Nostr client, find the message, and reply "
-                    f"with your credentials as JSON. "
+                    f"with your credentials using the @@@ format shown. "
                     f"Then call receive_credentials with your npub."
                 )
             except Exception as exc:
@@ -597,7 +597,7 @@ class NostrCredentialExchange:
             result["message"] = (
                 f"Send your {template.service} credentials as a Nostr DM "
                 f"to {self._npub} from your Nostr client. "
-                f"The DM must contain a JSON object matching the template above. "
+                f"Reply with your credentials using the @@@ format shown above. "
                 f"Then call receive_credentials with your npub."
             )
 
@@ -1128,11 +1128,17 @@ class NostrCredentialExchange:
                 if event_id in self._consumed_ids:
                     continue
 
-                created_at = event.get("created_at", 0)
-                if created_at < cutoff:
-                    continue
-
                 kind = event.get("kind", 0)
+                created_at = event.get("created_at", 0)
+
+                # NIP-17 created_at is deliberately fuzzed 0-48h into the past
+                if kind == _KIND_GIFT_WRAP:
+                    effective_cutoff = cutoff - _TIMESTAMP_FUZZ_SECONDS
+                else:
+                    effective_cutoff = cutoff
+
+                if created_at < effective_cutoff:
+                    continue
 
                 if kind == _KIND_ENCRYPTED_DM:
                     # NIP-04: sender is event.pubkey

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1588,3 +1588,50 @@ class TestNip17TimestampHardening:
         giftwrap_since = giftwrap_filter["since"]
         assert giftwrap_since < nip04_since
         assert nip04_since - giftwrap_since == _TIMESTAMP_FUZZ_SECONDS
+
+    def test_nip17_fuzzed_timestamp_found_by_candidate_filter(self):
+        """Gift wrap with created_at fuzzed 3h into the past is still returned."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec, freshness_window=900)  # 15 min
+
+        three_hours_ago = int(time.time()) - 3 * 60 * 60
+
+        gift_wrap_event = {
+            "id": "gw_fuzzed_ts",
+            "kind": _KIND_GIFT_WRAP,
+            "pubkey": PrivateKey().public_key.hex(),
+            "content": "encrypted-gift-wrap",
+            "created_at": three_hours_ago,
+            "tags": [["p", operator.public_key.hex()]],
+            "sig": "fake_sig",
+        }
+
+        with ex._lock:
+            ex._received_events.append(gift_wrap_event)
+
+        results = ex._find_dm_candidates(sender.public_key.hex())
+        assert len(results) == 1
+        assert results[0]["id"] == "gw_fuzzed_ts"
+
+    def test_nip04_stale_event_still_filtered(self):
+        """NIP-04 events older than freshness window are still rejected."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec, freshness_window=60)
+
+        stale_event = {
+            "id": "nip04_stale",
+            "kind": _KIND_ENCRYPTED_DM,
+            "pubkey": sender.public_key.hex(),
+            "content": "encrypted-content",
+            "created_at": int(time.time()) - 120,  # 2 min ago, window is 1 min
+            "tags": [["p", operator.public_key.hex()]],
+            "sig": "fake_sig",
+        }
+
+        with ex._lock:
+            ex._received_events.append(stale_event)
+
+        results = ex._find_dm_candidates(sender.public_key.hex())
+        assert len(results) == 0


### PR DESCRIPTION
## Summary

- **Bug 1**: NIP-17 gift wrap events with fuzzed `created_at` (0-48h past per NIP-17 spec) were silently discarded by the local freshness filter in `_find_dm_candidates()`. The relay filter correctly widened `since` by 48h, but the local candidate loop applied the narrow 15-min window. Fixed by widening `effective_cutoff` by `_TIMESTAMP_FUZZ_SECONDS` for kind 1059 events.
- **Bug 2**: Two user-facing messages in `open_channel()` still referenced "JSON" instead of the @@@ delimiter format introduced in PR #48.
- **Bug 3**: Stale docstring in `_parse_delimited_credentials()` referenced JSON fallback.
- Version bump 0.1.45 → 0.1.46.

## Test plan

- [x] `test_nip17_fuzzed_timestamp_found_by_candidate_filter` — gift wrap with `created_at` fuzzed 3h past is accepted
- [x] `test_nip04_stale_event_still_filtered` — NIP-04 events outside freshness window still rejected
- [x] Full suite: 939 passed
- [x] `grep -n "JSON\|json" src/tollbooth/nostr_credentials.py` — no user-facing JSON mentions remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)