### PR TITLE
DRY version: single source of truth in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.46"
+version = "0.1.47"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -3,7 +3,9 @@
 Bitcoin Lightning micropayments for MCP servers.
 """
 
-__version__ = "0.1.46"
+from importlib.metadata import version as _meta_version
+
+__version__ = _meta_version("tollbooth-dpyc")
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
 from tollbooth.config import TollboothConfig


### PR DESCRIPTION
## Summary

- Replace hardcoded `__version__ = "0.1.47"` in `__init__.py` with `importlib.metadata.version("tollbooth-dpyc")`
- `pyproject.toml` is now the single source of truth for the package version
- Bump 0.1.46 → 0.1.47

## Test plan

- [x] `python -c "from tollbooth import __version__; print(__version__)"` → `0.1.47`
- [x] Full suite: 939 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)