### PR TITLE
Fix NIP-44v2: ChaCha20 stream + HMAC-SHA256 (not Poly1305)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.47"
+version = "0.1.48"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nip44.py
+++ b/src/tollbooth/nip44.py
@@ -1,11 +1,13 @@
-"""NIP-44v2 encryption — ECDH + HKDF + ChaCha20-Poly1305 with padding.
+"""NIP-44v2 encryption — ECDH + HKDF + ChaCha20 stream cipher + HMAC-SHA256.
 
 Implements the NIP-44 version 2 payload encryption scheme for Nostr events.
 Used by the audit publisher to encrypt patron balance data so only the
 patron's nsec can decrypt it.
 
+Payload format: version(1) + nonce(32) + ciphertext(N) + hmac(32)
+
 Dependencies: ``coincurve`` (secp256k1 ECDH) and ``cryptography``
-(HKDF-SHA256, ChaCha20-Poly1305) — both already transitive deps of pynostr.
+(HKDF-SHA256, ChaCha20) — both already transitive deps of pynostr.
 
 Reference: https://github.com/nostr-protocol/nips/blob/master/44.md
 """
@@ -19,7 +21,7 @@ import struct
 
 from coincurve import PrivateKey as _CoinPrivateKey  # type: ignore[import-untyped]
 from coincurve import PublicKey as _CoinPublicKey  # type: ignore[import-untyped]
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
 
@@ -106,14 +108,14 @@ def _get_conversation_key(
 
 def _get_message_keys(
     conversation_key: bytes, nonce: bytes,
-) -> tuple[bytes, bytes]:
-    """Derive per-message chacha_key and chacha_nonce via HKDF-expand.
+) -> tuple[bytes, bytes, bytes]:
+    """Derive per-message chacha_key, chacha_nonce, and hmac_key via HKDF-expand.
 
     HKDF-expand(PRK=conversation_key, info=nonce, L=76)
     → chacha_key(32) + chacha_nonce(12) + hmac_key(32)
 
     Returns:
-        (chacha_key: 32 bytes, chacha_nonce: 12 bytes)
+        (chacha_key: 32 bytes, chacha_nonce: 12 bytes, hmac_key: 32 bytes)
     """
     expanded = HKDFExpand(
         algorithm=SHA256(),
@@ -123,7 +125,8 @@ def _get_message_keys(
 
     chacha_key = expanded[:32]
     chacha_nonce = expanded[32:44]
-    return chacha_key, chacha_nonce
+    hmac_key = expanded[44:76]
+    return chacha_key, chacha_nonce, hmac_key
 
 
 def encrypt(
@@ -139,7 +142,7 @@ def encrypt(
         public_key_hex: Recipient's 32-byte x-only public key as hex.
 
     Returns:
-        Base64-encoded NIP-44v2 payload: version(1) + nonce(32) + ciphertext.
+        Base64-encoded NIP-44v2 payload: version(1) + nonce(32) + ciphertext + hmac(32).
     """
     import base64
 
@@ -148,13 +151,19 @@ def encrypt(
 
     conversation_key = _get_conversation_key(private_key_hex, public_key_hex)
     nonce = os.urandom(32)
-    chacha_key, chacha_nonce = _get_message_keys(conversation_key, nonce)
+    chacha_key, chacha_nonce, hmac_key = _get_message_keys(conversation_key, nonce)
 
-    cipher = ChaCha20Poly1305(chacha_key)
-    ciphertext = cipher.encrypt(chacha_nonce, padded, None)
+    # ChaCha20 stream cipher (NOT AEAD). NIP-44 uses a 16-byte nonce:
+    # 4 zero bytes (counter) + 12-byte chacha_nonce.
+    nonce16 = b"\x00" * 4 + chacha_nonce
+    cipher = Cipher(algorithms.ChaCha20(chacha_key, nonce16), mode=None)
+    ciphertext = cipher.encryptor().update(padded)
 
-    # NIP-44v2 payload: version byte + nonce + ciphertext (includes Poly1305 tag)
-    payload = bytes([_VERSION]) + nonce + ciphertext
+    # Separate HMAC-SHA256 over (nonce || ciphertext)
+    mac = hmac.new(hmac_key, nonce + ciphertext, hashlib.sha256).digest()
+
+    # NIP-44v2 payload: version(1) + nonce(32) + ciphertext(N) + mac(32)
+    payload = bytes([_VERSION]) + nonce + ciphertext + mac
     return base64.b64encode(payload).decode("ascii")
 
 
@@ -174,14 +183,15 @@ def decrypt(
         Decrypted UTF-8 plaintext string.
 
     Raises:
-        ValueError: On invalid version, decryption failure, or padding error.
+        ValueError: On invalid version, HMAC failure, or padding error.
     """
     import base64
 
     # Normalize base64 padding — some Nostr clients (Primal) strip trailing '='
     payload_b64 += "=" * (-len(payload_b64) % 4)
     payload = base64.b64decode(payload_b64)
-    if len(payload) < 35:  # 1 version + 32 nonce + 2 min ciphertext
+    # Minimum: 1 version + 32 nonce + 34 min ciphertext (2 pad-prefix + 32 padded) + 32 mac = 99
+    if len(payload) < 99:
         raise ValueError("NIP-44 payload too short")
 
     version = payload[0]
@@ -189,16 +199,21 @@ def decrypt(
         raise ValueError(f"Unsupported NIP-44 version: {version}")
 
     nonce = payload[1:33]
-    ciphertext = payload[33:]
+    ciphertext = payload[33:-32]
+    mac = payload[-32:]
 
     conversation_key = _get_conversation_key(private_key_hex, public_key_hex)
-    chacha_key, chacha_nonce = _get_message_keys(conversation_key, nonce)
+    chacha_key, chacha_nonce, hmac_key = _get_message_keys(conversation_key, nonce)
 
-    cipher = ChaCha20Poly1305(chacha_key)
-    try:
-        padded = cipher.decrypt(chacha_nonce, ciphertext, None)
-    except Exception as e:
-        raise ValueError(f"NIP-44 decryption failed: {e}") from e
+    # Verify HMAC-SHA256 (constant-time comparison)
+    expected_mac = hmac.new(hmac_key, nonce + ciphertext, hashlib.sha256).digest()
+    if not hmac.compare_digest(mac, expected_mac):
+        raise ValueError("NIP-44 decryption failed: HMAC verification failed")
+
+    # ChaCha20 stream cipher decrypt
+    nonce16 = b"\x00" * 4 + chacha_nonce
+    cipher = Cipher(algorithms.ChaCha20(chacha_key, nonce16), mode=None)
+    padded = cipher.decryptor().update(ciphertext)
 
     plaintext_bytes = _unpad(padded)
     return plaintext_bytes.decode("utf-8")

--- a/tests/test_nip44.py
+++ b/tests/test_nip44.py
@@ -10,6 +10,7 @@ from pynostr.key import PrivateKey  # type: ignore[import-untyped]
 from tollbooth.nip44 import (
     _calc_padded_len,
     _get_conversation_key,
+    _get_message_keys,
     _pad,
     _unpad,
     decrypt,
@@ -213,19 +214,21 @@ class TestEncryptDecrypt:
 
     def test_payload_too_short(self) -> None:
         with pytest.raises(ValueError, match="too short"):
-            decrypt(base64.b64encode(b"\x02" + b"\x00" * 10).decode(), "aa" * 32, "bb" * 32)
+            decrypt(base64.b64encode(b"\x02" + b"\x00" * 60).decode(), "aa" * 32, "bb" * 32)
 
     def test_decrypt_unpadded_base64(self) -> None:
         """Decrypt tolerates base64 with stripped '=' padding (Primal, etc.)."""
         sk1 = PrivateKey()
         sk2 = PrivateKey()
 
-        ct = encrypt("hello world", sk1.hex(), sk2.public_key.hex())
+        # Use 33-byte plaintext → padded_len=64 → payload=131 bytes → 131%3=2 → base64 has '='
+        msg = "x" * 33
+        ct = encrypt(msg, sk1.hex(), sk2.public_key.hex())
         # Strip trailing '=' to simulate what Primal sends
         ct_stripped = ct.rstrip("=")
         assert ct_stripped != ct  # sanity: we actually stripped something
         pt = decrypt(ct_stripped, sk2.hex(), sk1.public_key.hex())
-        assert pt == "hello world"
+        assert pt == msg
 
     def test_each_encryption_differs(self) -> None:
         """Random nonce means same plaintext encrypts differently each time."""
@@ -239,3 +242,88 @@ class TestEncryptDecrypt:
         # But both decrypt to the same plaintext
         assert decrypt(ct1, sk2.hex(), sk1.public_key.hex()) == "same"
         assert decrypt(ct2, sk2.hex(), sk1.public_key.hex()) == "same"
+
+
+# ---------------------------------------------------------------------------
+# Official NIP-44 test vectors (from paulmillr/nip44)
+# ---------------------------------------------------------------------------
+
+
+class TestConversationKeyVectors:
+    """Validate conversation key derivation against official NIP-44 vectors."""
+
+    VECTORS = [
+        (
+            "315e59ff51cb9209768cf7da80791ddcaae56ac9775eb25b6dee1234bc5d2268",
+            "c2f9d9948dc8c7c38321e4b85c8558872eafa0641cd269db76848a6073e69133",
+            "3dfef0ce2a4d80a25e7a328accf73448ef67096f65f79588e358d9a0eb9013f1",
+        ),
+        (
+            "a1e37752c9fdc1273be53f68c5f74be7c8905728e8de75800b94262f9497c86e",
+            "03bb7947065dde12ba991ea045132581d0954f042c84e06d8c00066e23c1a800",
+            "4d14f36e81b8452128da64fe6f1eae873baae2f444b02c950b90e43553f2178b",
+        ),
+        (
+            "98a5902fd67518a0c900f0fb62158f278f94a21d6f9d33d30cd3091195500311",
+            "aae65c15f98e5e677b5050de82e3aba47a6fe49b3dab7863cf35d9478ba9f7d1",
+            "9c00b769d5f54d02bf175b7284a1cbd28b6911b06cda6666b2243561ac96bad7",
+        ),
+    ]
+
+    @pytest.mark.parametrize("sec1,pub2,expected", VECTORS)
+    def test_conversation_key_vector(self, sec1: str, pub2: str, expected: str) -> None:
+        ck = _get_conversation_key(sec1, pub2)
+        assert ck.hex() == expected
+
+
+class TestMessageKeyVectors:
+    """Validate message key derivation against official NIP-44 vectors."""
+
+    def test_message_keys_vector(self) -> None:
+        conv_key = bytes.fromhex(
+            "a1a3d60f3470a8612633924e91febf96dc5366ce130f658b1f0fc652c20b3b54"
+        )
+        nonce = bytes.fromhex(
+            "e1e6f880560d6d149ed83dcc7e5861ee62a5ee051f7fde9975fe5d25d2a02d72"
+        )
+        chacha_key, chacha_nonce, hmac_key = _get_message_keys(conv_key, nonce)
+        assert chacha_key.hex() == "f145f3bed47cb70dbeaac07f3a3fe683e822b3715edb7c4fe310829014ce7d76"
+        assert chacha_nonce.hex() == "c4ad129bb01180c0933a160c"
+        assert hmac_key.hex() == "027c1db445f05e2eee864a0975b0ddef5b7110583c8c192de3732571ca5838c4"
+
+
+class TestEncryptDecryptVectors:
+    """Validate encrypt/decrypt against official NIP-44 vector (sec1=0x01, sec2=0x02)."""
+
+    SEC1 = "0000000000000000000000000000000000000000000000000000000000000001"
+    SEC2 = "0000000000000000000000000000000000000000000000000000000000000002"
+    CONV_KEY = "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d"
+    NONCE_HEX = "0000000000000000000000000000000000000000000000000000000000000001"
+    PLAINTEXT = "a"
+    EXPECTED_PAYLOAD_B64 = (
+        "AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABee0G5VSK0/9YypIObAtDKfYEAjD35uVkHyB0F4DwrcNaCXlCWZKaArsGrY6M9wnuTMxWfp1RTN9Xga8no+kF5Vsb"
+    )
+
+    def test_decrypt_official_vector(self) -> None:
+        """Decrypt the official test payload and verify plaintext."""
+        from coincurve import PrivateKey as CoinPriv
+
+        # sec2 is the recipient — derive pub1 from sec1
+        pub1 = CoinPriv(bytes.fromhex(self.SEC1)).public_key.format(compressed=True)[1:].hex()
+        pt = decrypt(self.EXPECTED_PAYLOAD_B64, self.SEC2, pub1)
+        assert pt == self.PLAINTEXT
+
+    def test_encrypt_matches_official_vector(self) -> None:
+        """Encrypt with the official nonce and verify the payload matches exactly."""
+        import os
+        from unittest.mock import patch
+
+        from coincurve import PrivateKey as CoinPriv
+
+        pub2 = CoinPriv(bytes.fromhex(self.SEC2)).public_key.format(compressed=True)[1:].hex()
+
+        fixed_nonce = bytes.fromhex(self.NONCE_HEX)
+        with patch.object(os, "urandom", return_value=fixed_nonce):
+            payload_b64 = encrypt(self.PLAINTEXT, self.SEC1, pub2)
+
+        assert payload_b64 == self.EXPECTED_PAYLOAD_B64


### PR DESCRIPTION
## Summary
- Replace `ChaCha20Poly1305` (AEAD) with `ChaCha20` stream cipher + separate `HMAC-SHA256` per the NIP-44v2 spec
- Fixes interop with real Nostr clients (0xchat, Primal, etc.) — inbound gift-wrap decryption and outbound DM readability
- Adds official NIP-44 test vectors (conversation key, message key, encrypt/decrypt) from paulmillr/nip44
- Bumps version to 0.1.48

## Root cause
The old code used `ChaCha20Poly1305` (AEAD mode) which embeds a Poly1305 MAC tag inside the ciphertext. NIP-44v2 requires plain `ChaCha20` (stream cipher) with a **separate** HMAC-SHA256 appended after the ciphertext. Round-trip tests passed because both encrypt and decrypt used the same wrong scheme, but real clients use the correct one.

## Payload format change
- **Before (broken)**: `version(1) + nonce(32) + chacha20poly1305_ciphertext(N+16)`
- **After (correct)**: `version(1) + nonce(32) + ciphertext(N) + hmac(32)`

## Test plan
- [x] All 3 official conversation key vectors pass
- [x] Official message key derivation vector passes
- [x] Official encrypt/decrypt vector (sec1=0x01, sec2=0x02) passes both directions
- [x] All existing round-trip tests pass (32 NIP-44 tests total)
- [x] Full test suite passes (945 tests)
- [ ] Live e2e: `request_credential_channel` → 0xchat reply → `receive_credentials` (after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)