### PR TITLE
Fix receive_credentials: scan all DMs instead of short-circuiting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.48"
+version = "0.1.49"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -674,32 +674,33 @@ class NostrCredentialExchange:
                 f"try again."
             )
 
-        # Try each candidate.  NIP-04 events are already sender-filtered
-        # so errors propagate immediately.  Gift wraps may fail to decrypt
-        # (wrong ECDH shared secret) or reveal a different sender inside
-        # the seal — silently skip those and try the next candidate.
-        dm = None
-        plaintext = None
+        # Decrypt ALL candidates so we can pick the one with the correct
+        # anti-replay poison.  Previous code broke on first success, which
+        # meant stale DMs with old poisons could block the valid reply.
+        decrypted: list[tuple[dict[str, Any], str]] = []
         for candidate in candidates:
             kind = candidate.get("kind", 0)
-            if kind == _KIND_GIFT_WRAP:
-                try:
-                    plaintext = self._decrypt_dm(candidate, sender_hex)
-                    dm = candidate
-                    break
-                except CourierValidationError:
-                    logger.debug(
-                        "Skipping gift wrap %s (decrypt/validate failed)",
-                        candidate.get("id", "?")[:16],
-                    )
-                    continue
-            else:
-                # NIP-04: already matched by sender — errors are real
-                plaintext = self._decrypt_dm(candidate, sender_hex)
-                dm = candidate
-                break
 
-        if dm is None or plaintext is None:
+            # NIP-04 policy rejection must propagate immediately so the
+            # user gets a clear "upgrade your client" error, not a timeout.
+            if kind == _KIND_ENCRYPTED_DM and self._nip44_only:
+                raise CourierValidationError(
+                    "NIP-04 DMs rejected — this operator requires NIP-44 "
+                    "(NIP-17 gift wrap). Please use a modern Nostr client."
+                )
+
+            try:
+                pt = self._decrypt_dm(candidate, sender_hex)
+                decrypted.append((candidate, pt))
+            except CourierValidationError:
+                logger.debug(
+                    "Skipping %s %s (decrypt/validate failed)",
+                    "gift wrap" if kind == _KIND_GIFT_WRAP else "DM",
+                    candidate.get("id", "?")[:16],
+                )
+                continue
+
+        if not decrypted:
             raise CourierTimeout(
                 f"No decryptable DM found from {sender_npub} within the "
                 f"{self._freshness_window}-second freshness window. "
@@ -707,6 +708,64 @@ class NostrCredentialExchange:
                 f"could be decrypted. Make sure you replied from the "
                 f"correct Nostr identity."
             )
+
+        # ── Poison-aware DM selection ────────────────────────────────
+        expected = self._pending_poisons.get(sender_npub)
+
+        if expected is not None:
+            expected_phrase, expiry = expected
+            if time.time() > expiry:
+                del self._pending_poisons[sender_npub]
+                raise CourierValidationError(
+                    "Anti-replay token expired. Call request_credential_channel "
+                    "again to get a fresh token."
+                )
+
+            # Scan all decrypted DMs for the one with matching poison
+            dm = None
+            plaintext = None
+            stale_events: list[dict[str, Any]] = []
+
+            for event, pt in decrypted:
+                payload = _parse_delimited_credentials(pt)
+                if payload and payload.get("poison") == expected_phrase:
+                    dm = event
+                    plaintext = pt
+                else:
+                    stale_events.append(event)
+
+            if dm is None:
+                found = [
+                    _parse_delimited_credentials(pt).get("poison", "<unparseable>")
+                    for _, pt in decrypted
+                    if _parse_delimited_credentials(pt)
+                ]
+                raise CourierValidationError(
+                    f'Anti-replay token mismatch. Expected "{expected_phrase}" '
+                    f"but none of {len(decrypted)} DM(s) matched. "
+                    f"Found poisons: {found}. "
+                    f"Call request_credential_channel again for a fresh token."
+                )
+
+            # Consume the poison — one-time use
+            del self._pending_poisons[sender_npub]
+
+            # Clean up stale DMs from relays
+            for stale in stale_events:
+                stale_id = stale.get("id", "")
+                if stale_id:
+                    self._request_deletion(stale_id)
+                    with self._lock:
+                        self._consumed_ids.add(stale_id)
+
+            if stale_events:
+                logger.info(
+                    "Cleaned up %d stale DM(s) from relays",
+                    len(stale_events),
+                )
+        else:
+            # No poison expected — use newest (first in list)
+            dm, plaintext = decrypted[0]
 
         # Resolve template for error DM instructions
         error_template = self._resolve_error_template(service)
@@ -721,30 +780,8 @@ class NostrCredentialExchange:
                 "field_name = @@@your_value@@@"
             )
 
-        # Validate anti-replay poison slug
-        expected = self._pending_poisons.get(sender_npub)
-        if expected is not None:
-            expected_phrase, expiry = expected
-            received_poison = payload.pop("poison", None)
-            if time.time() > expiry:
-                del self._pending_poisons[sender_npub]
-                raise CourierValidationError(
-                    "Anti-replay token expired. Call request_credential_channel "
-                    "again to get a fresh token."
-                )
-            if received_poison != expected_phrase:
-                raise CourierValidationError(
-                    f'Anti-replay token mismatch. Expected "poison": '
-                    f'"{expected_phrase}" but got '
-                    f'"{received_poison}". Include the exact token from '
-                    f"the welcome message."
-                )
-            # Consume the poison — one-time use
-            del self._pending_poisons[sender_npub]
-        else:
-            # No poison pending — remove the field if present so it
-            # doesn't confuse template matching
-            payload.pop("poison", None)
+        # Remove poison from payload so it doesn't confuse template matching
+        payload.pop("poison", None)
 
         # Match template
         payload_service = payload.get("service")

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1192,6 +1192,118 @@ class TestPoisonSlug:
 
         assert result["success"] is True
 
+    @pytest.mark.asyncio
+    async def test_poison_picks_correct_dm_from_multiple(self):
+        """When multiple DMs exist, receive picks the one with matching poison."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+
+        # Stale DM with old/wrong poison (injected first)
+        stale_payload = {"api_key": "old_k", "api_secret": "old_s", "poison": "true-quill-26"}
+        stale_event = _make_nip04_event(sender, operator.public_key.hex(), stale_payload)
+        stale_event["id"] = "stale_event_001"
+
+        # Valid DM with correct poison (injected second)
+        valid_payload = {"api_key": "correct_k", "api_secret": "correct_s", "poison": "bold-hawk-42"}
+        valid_event = _make_nip04_event(sender, operator.public_key.hex(), valid_payload)
+        valid_event["id"] = "valid_event_002"
+
+        with ex._lock:
+            ex._received_events.append(stale_event)
+            ex._received_events.append(valid_event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion") as mock_delete:
+            result = await ex.receive(sender_npub)
+
+        assert result["success"] is True
+        assert result["credentials"]["api_key"] == "correct_k"
+        # Poison should be consumed
+        assert sender_npub not in ex._pending_poisons
+
+    @pytest.mark.asyncio
+    async def test_stale_dms_get_deletion_requests(self):
+        """Stale DMs (wrong poison) get NIP-09 deletion requests."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+
+        # Two stale DMs
+        stale1 = _make_nip04_event(
+            sender, operator.public_key.hex(),
+            {"api_key": "k", "api_secret": "s", "poison": "old-slug-01"},
+        )
+        stale1["id"] = "stale_001"
+        stale2 = _make_nip04_event(
+            sender, operator.public_key.hex(),
+            {"api_key": "k", "api_secret": "s", "poison": "old-slug-02"},
+        )
+        stale2["id"] = "stale_002"
+
+        # Valid DM
+        valid = _make_nip04_event(
+            sender, operator.public_key.hex(),
+            {"api_key": "k", "api_secret": "s", "poison": "bold-hawk-42"},
+        )
+        valid["id"] = "valid_003"
+
+        with ex._lock:
+            ex._received_events.extend([stale1, stale2, valid])
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion") as mock_delete:
+            result = await ex.receive(sender_npub)
+
+        assert result["success"] is True
+        # Should have deletion calls for stale events + the valid event
+        deleted_ids = [call.args[0] for call in mock_delete.call_args_list]
+        assert "stale_001" in deleted_ids
+        assert "stale_002" in deleted_ids
+        # Stale events should be in consumed set
+        assert "stale_001" in ex._consumed_ids
+        assert "stale_002" in ex._consumed_ids
+
+    @pytest.mark.asyncio
+    async def test_no_poison_match_reports_found_poisons(self):
+        """When no DM matches the expected poison, error lists found poisons."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(nsec=operator.nsec)
+
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+
+        # Two DMs, neither with the correct poison
+        dm1 = _make_nip04_event(
+            sender, operator.public_key.hex(),
+            {"api_key": "k", "api_secret": "s", "poison": "true-quill-26"},
+        )
+        dm1["id"] = "dm_001"
+        dm2 = _make_nip04_event(
+            sender, operator.public_key.hex(),
+            {"api_key": "k", "api_secret": "s", "poison": "lazy-fox-99"},
+        )
+        dm2["id"] = "dm_002"
+
+        with ex._lock:
+            ex._received_events.extend([dm1, dm2])
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             pytest.raises(CourierValidationError, match="none of 2 DM") as exc_info:
+            await ex.receive(sender_npub)
+
+        err = str(exc_info.value)
+        assert "true-quill-26" in err
+        assert "lazy-fox-99" in err
+        assert "request_credential_channel" in err
+
 
 # ── Conversational DM Flow Tests ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Fixes the stale-DM poison mismatch bug** — `receive_credentials` now decrypts ALL candidate DMs before selecting the one with the matching anti-replay poison token, instead of short-circuiting on the first decryptable DM
- **Cleans up stale DMs** from relays via NIP-09 deletion requests when a valid DM is found alongside stale ones
- **Preserves NIP-04 policy rejection** — immediate error when `nip44_only=True`, not a misleading timeout
- Bumps version to `0.1.49`

## Test plan

- [x] 3 new tests added:
  - `test_poison_picks_correct_dm_from_multiple` — correct poison in 2nd DM is selected
  - `test_stale_dms_get_deletion_requests` — stale DMs get NIP-09 deletions + consumed IDs
  - `test_no_poison_match_reports_found_poisons` — clear error listing all found poisons
- [x] All 74 nostr credential tests pass
- [x] Full suite: 948 tests pass
- [ ] After merge + PyPI publish: bump tollbooth-dpyc dep in excalibur-mcp
- [ ] Live retest with waiting DM via `receive_credentials(sender_npub=..., service="x")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)