### PR TITLE
Parameterize welcome greeting + multi-exchange poison keys

### DIFF
--- a/demos/demo_secure_courier.py
+++ b/demos/demo_secure_courier.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Live demo of the Secure Courier Service.
+
+Generates a fresh operator keypair, prints the npub for you to DM,
+then listens on real Nostr relays for your encrypted message.
+
+Usage:
+    python demos/demo_secure_courier.py
+
+Then send a DM from Primal to the printed npub containing:
+    {"api_key": "test-key-123", "api_secret": "test-secret-456"}
+"""
+
+import asyncio
+import sys
+import time
+
+from pynostr.key import PrivateKey
+
+from tollbooth.credential_templates import CredentialTemplate, FieldSpec
+from tollbooth.nostr_credentials import (
+    NostrCredentialExchange,
+    CourierTimeout,
+    CourierValidationError,
+)
+
+
+RELAYS = [
+    "wss://relay.primal.net",
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+]
+
+TEMPLATES = {
+    "test": CredentialTemplate(
+        service="test",
+        version=1,
+        fields={
+            "api_key": FieldSpec(required=True, sensitive=True),
+            "api_secret": FieldSpec(required=True, sensitive=True),
+        },
+        description="Test credentials for Secure Courier demo",
+    ),
+}
+
+
+async def main():
+    # Generate fresh operator keypair
+    operator_key = PrivateKey()
+    print("=" * 60)
+    print("  SECURE COURIER SERVICE — Live Demo")
+    print("=" * 60)
+    print()
+    print(f"  Operator npub: {operator_key.public_key.bech32()}")
+    print()
+    print("  Send a DM from Primal to the npub above containing:")
+    print()
+    print('    {"api_key": "test-key-123", "api_secret": "test-secret-456"}')
+    print()
+    print(f"  Listening on {len(RELAYS)} relays...")
+    print(f"  Freshness window: 600 seconds")
+    print()
+
+    exchange = NostrCredentialExchange(
+        nsec=operator_key.nsec,
+        relays=RELAYS,
+        templates=TEMPLATES,
+        freshness_window=600,
+    )
+
+    # Open channel (starts subscription)
+    channel = await exchange.open_channel(
+        "test", greeting="Hi — this is the Secure Courier demo.",
+    )
+    print("  Channel open. Waiting for your DM...")
+    print()
+
+    # Poll for the DM
+    sender_npub = input("  Enter your npub (or press Enter for default): ").strip()
+    if not sender_npub:
+        sender_npub = "npub1l94pd4qu4eszrl6ek032ftcnsu3tt9a7xvq2zp7eaxeklp6mrpzssmq8pf"
+    print()
+    print(f"  Looking for DM from: {sender_npub}")
+    print()
+
+    max_attempts = 12
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = await exchange.receive(sender_npub)
+            print("  " + "=" * 56)
+            print("  POUCH RECEIVED!")
+            print("  " + "=" * 56)
+            print(f"  Service:    {result['service']}")
+            print(f"  Fields:     {result['fields_received']}")
+            print(f"  Sensitive:  {result['sensitive_fields']}")
+            print(f"  Encryption: {result['encryption']}")
+            print()
+            # Show credentials (redacted for sensitive)
+            for key, value in result["credentials"].items():
+                display = value[:4] + "..." if len(value) > 4 else value
+                print(f"  {key}: {display}")
+            print()
+            print(f"  {result['message']}")
+            print()
+            return
+
+        except CourierTimeout:
+            print(f"  Attempt {attempt}/{max_attempts} — no DM yet, retrying in 5s...")
+            await asyncio.sleep(5)
+
+        except CourierValidationError as e:
+            print(f"  Validation error: {e}")
+            return
+
+    print("  Timed out waiting for DM. Make sure you sent it to the right npub.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.49"
+version = "0.1.50"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -291,8 +291,8 @@ class NostrCredentialExchange:
         self._received_events: list[dict[str, Any]] = []
         # Track consumed event IDs (prevent double-pickup)
         self._consumed_ids: set[str] = set()
-        # Poison slugs: {recipient_npub: (phrase, expiry_timestamp)}
-        self._pending_poisons: dict[str, tuple[str, float]] = {}
+        # Poison slugs: {(recipient_npub, service): (phrase, expiry_timestamp)}
+        self._pending_poisons: dict[tuple[str, str], tuple[str, float]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -500,6 +500,7 @@ class NostrCredentialExchange:
         self,
         service: str,
         *,
+        greeting: str,
         recipient_npub: str | None = None,
     ) -> dict[str, Any]:
         """Open a credential delivery channel for a service.
@@ -513,6 +514,8 @@ class NostrCredentialExchange:
 
         Args:
             service: Template service name (e.g., "x", "openai").
+            greeting: Operator-provided banner shown at the top of the
+                welcome DM.
             recipient_npub: Optional patron npub to send welcome DM to.
 
         Returns:
@@ -544,24 +547,20 @@ class NostrCredentialExchange:
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         welcome_text = (
-            f"Hi — I'm {self._npub}, a Tollbooth MCP service.\n\n"
-            f"You're receiving this message because you (or your AI agent) "
-            f"requested a credential channel from a Claude session.\n\n"
-            f"If you'd like to proceed, reply to this message with your "
-            f"credentials.  Paste each value between the @@@ markers.\n"
-            f"IMPORTANT: include the anti-replay token exactly as shown.\n\n"
+            f"{greeting}\n\n"
             f"{instructions}\n"
             f"  poison = @@@{poison}@@@\n\n"
+            f"IMPORTANT: include the anti-replay token exactly as shown.\n\n"
+            f"— tollbooth-dpyc v{_tb_version} | {timestamp}\n\n"
             f"Your reply is end-to-end encrypted — "
-            f"only this service can read it.\n\n"
-            f"If you didn't request this, simply ignore this message.\n\n"
-            f"— tollbooth-dpyc v{_tb_version} | {timestamp}"
+            f"only this service can read it.\n"
+            f"If you didn't request this, simply ignore this message."
         )
 
         # Store poison for validation on receive
         if recipient_npub:
             expiry = time.time() + self._freshness_window
-            self._pending_poisons[recipient_npub] = (poison, expiry)
+            self._pending_poisons[(recipient_npub, service)] = (poison, expiry)
 
         result: dict[str, Any] = {
             "success": True,
@@ -710,12 +709,14 @@ class NostrCredentialExchange:
             )
 
         # ── Poison-aware DM selection ────────────────────────────────
-        expected = self._pending_poisons.get(sender_npub)
+        poison_service = self._resolve_service(service)
+        poison_key = (sender_npub, poison_service) if poison_service else None
+        expected = self._pending_poisons.get(poison_key) if poison_key else None
 
         if expected is not None:
             expected_phrase, expiry = expected
             if time.time() > expiry:
-                del self._pending_poisons[sender_npub]
+                del self._pending_poisons[poison_key]
                 raise CourierValidationError(
                     "Anti-replay token expired. Call request_credential_channel "
                     "again to get a fresh token."
@@ -748,7 +749,7 @@ class NostrCredentialExchange:
                 )
 
             # Consume the poison — one-time use
-            del self._pending_poisons[sender_npub]
+            del self._pending_poisons[poison_key]
 
             # Clean up stale DMs from relays
             for stale in stale_events:

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -138,6 +138,8 @@ class SecureCourierService:
     async def open_channel(
         self,
         service: str = "x",
+        *,
+        greeting: str,
         recipient_npub: str | None = None,
     ) -> dict[str, Any]:
         """Open a Secure Courier channel.  Sends welcome DM if *recipient_npub* provided.
@@ -146,13 +148,15 @@ class SecureCourierService:
 
         Args:
             service: Template service name (e.g. ``"x"``).
+            greeting: Operator-provided banner shown at the top of the
+                welcome DM.
             recipient_npub: Optional patron npub to send welcome DM to.
 
         Returns:
             Dict with npub, relays, template instructions, and freshness window.
         """
         return await self._exchange.open_channel(
-            service, recipient_npub=recipient_npub,
+            service, greeting=greeting, recipient_npub=recipient_npub,
         )
 
     async def receive(

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -215,7 +215,7 @@ class TestOpenChannel:
         ex = _make_exchange()
         # Mock the subscription to avoid real WebSocket
         with patch.object(ex, "_start_subscription"):
-            result = await ex.open_channel("x")
+            result = await ex.open_channel("x", greeting="Test greeting")
 
         assert result["success"] is True
         assert result["npub"] == ex.npub
@@ -229,14 +229,14 @@ class TestOpenChannel:
         """open_channel with unknown service raises CourierValidationError."""
         ex = _make_exchange()
         with pytest.raises(CourierValidationError, match="Unknown service"):
-            await ex.open_channel("nonexistent")
+            await ex.open_channel("nonexistent", greeting="Test greeting")
 
     @pytest.mark.asyncio
     async def test_disabled_exchange_raises(self):
         """open_channel on disabled exchange raises CourierNotReady."""
         ex = _make_exchange(nsec="nsec1invalid")
         with pytest.raises(CourierNotReady):
-            await ex.open_channel("x")
+            await ex.open_channel("x", greeting="Test greeting")
 
 
 # ── receive Tests — NIP-04 ───────────────────────────────────────────
@@ -1051,7 +1051,9 @@ class TestOpenChannelWithWelcomeDm:
 
         with patch.object(ex, "_start_subscription"), \
              patch.object(ex, "send_dm") as mock_send:
-            result = await ex.open_channel("x", recipient_npub=patron.public_key.bech32())
+            result = await ex.open_channel(
+                "x", greeting="Test greeting", recipient_npub=patron.public_key.bech32(),
+            )
 
         assert result["success"] is True
         assert result["welcome_dm_sent"] is True
@@ -1065,7 +1067,7 @@ class TestOpenChannelWithWelcomeDm:
         ex = _make_exchange()
 
         with patch.object(ex, "_start_subscription"):
-            result = await ex.open_channel("x")
+            result = await ex.open_channel("x", greeting="Test greeting")
 
         assert result["success"] is True
         assert result["welcome_dm_sent"] is False
@@ -1078,7 +1080,9 @@ class TestOpenChannelWithWelcomeDm:
 
         with patch.object(ex, "_start_subscription"), \
              patch.object(ex, "send_dm", side_effect=Exception("relay down")):
-            result = await ex.open_channel("x", recipient_npub=patron.public_key.bech32())
+            result = await ex.open_channel(
+                "x", greeting="Test greeting", recipient_npub=patron.public_key.bech32(),
+            )
 
         assert result["success"] is True
         assert result["welcome_dm_sent"] is False
@@ -1102,7 +1106,9 @@ class TestPoisonSlug:
 
         with patch.object(ex, "_start_subscription"), \
              patch.object(ex, "send_dm"):
-            result = await ex.open_channel("x", recipient_npub="npub1test123")
+            result = await ex.open_channel(
+                "x", greeting="Test greeting", recipient_npub="npub1test123",
+            )
 
         assert "poison" in result
         # Format: adjective-noun-number
@@ -1119,7 +1125,7 @@ class TestPoisonSlug:
 
         # Register a poison
         sender_npub = sender.public_key.bech32()
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() + 600)
 
         # Build a NIP-04 event with wrong poison
         payload = {"api_key": "k", "api_secret": "s", "poison": "wrong-slug-99"}
@@ -1139,7 +1145,7 @@ class TestPoisonSlug:
         ex = _make_exchange(nsec=operator.nsec)
 
         sender_npub = sender.public_key.bech32()
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() + 600)
 
         payload = {"api_key": "k", "api_secret": "s", "poison": "bold-hawk-42"}
         event = _make_nip04_event(sender, operator.public_key.hex(), payload)
@@ -1152,7 +1158,7 @@ class TestPoisonSlug:
 
         assert result["success"] is True
         # Poison should be consumed
-        assert sender_npub not in ex._pending_poisons
+        assert (sender_npub, "x") not in ex._pending_poisons
 
     @pytest.mark.asyncio
     async def test_poison_expired(self):
@@ -1163,7 +1169,7 @@ class TestPoisonSlug:
 
         sender_npub = sender.public_key.bech32()
         # Expired 10 seconds ago
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() - 10)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() - 10)
 
         payload = {"api_key": "k", "api_secret": "s", "poison": "bold-hawk-42"}
         event = _make_nip04_event(sender, operator.public_key.hex(), payload)
@@ -1200,7 +1206,7 @@ class TestPoisonSlug:
         ex = _make_exchange(nsec=operator.nsec)
 
         sender_npub = sender.public_key.bech32()
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() + 600)
 
         # Stale DM with old/wrong poison (injected first)
         stale_payload = {"api_key": "old_k", "api_secret": "old_s", "poison": "true-quill-26"}
@@ -1223,7 +1229,7 @@ class TestPoisonSlug:
         assert result["success"] is True
         assert result["credentials"]["api_key"] == "correct_k"
         # Poison should be consumed
-        assert sender_npub not in ex._pending_poisons
+        assert (sender_npub, "x") not in ex._pending_poisons
 
     @pytest.mark.asyncio
     async def test_stale_dms_get_deletion_requests(self):
@@ -1233,7 +1239,7 @@ class TestPoisonSlug:
         ex = _make_exchange(nsec=operator.nsec)
 
         sender_npub = sender.public_key.bech32()
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() + 600)
 
         # Two stale DMs
         stale1 = _make_nip04_event(
@@ -1278,7 +1284,7 @@ class TestPoisonSlug:
         ex = _make_exchange(nsec=operator.nsec)
 
         sender_npub = sender.public_key.bech32()
-        ex._pending_poisons[sender_npub] = ("bold-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "x")] = ("bold-hawk-42", time.time() + 600)
 
         # Two DMs, neither with the correct poison
         dm1 = _make_nip04_event(
@@ -1305,6 +1311,103 @@ class TestPoisonSlug:
         assert "request_credential_channel" in err
 
 
+# ── Concurrent Multi-Service Exchange Tests ──────────────────────────────
+
+
+class TestConcurrentExchanges:
+    """Tests for multi-service poison independence."""
+
+    @staticmethod
+    def _two_service_templates() -> dict[str, CredentialTemplate]:
+        return {
+            "x": CredentialTemplate(
+                service="x",
+                version=1,
+                fields={
+                    "api_key": FieldSpec(required=True, sensitive=True),
+                    "api_secret": FieldSpec(required=True, sensitive=True),
+                },
+                description="X API credentials",
+            ),
+            "openai": CredentialTemplate(
+                service="openai",
+                version=1,
+                fields={
+                    "api_key": FieldSpec(required=True, sensitive=True),
+                },
+                description="OpenAI API credentials",
+            ),
+        }
+
+    @pytest.mark.asyncio
+    async def test_two_services_independent_poisons(self):
+        """Two open_channel calls for different services store separate poisons."""
+        ex = _make_exchange(templates=self._two_service_templates())
+        npub = "npub1test123"
+
+        with patch.object(ex, "_start_subscription"), \
+             patch.object(ex, "send_dm"):
+            r1 = await ex.open_channel(
+                "x", greeting="X greeting", recipient_npub=npub,
+            )
+            r2 = await ex.open_channel(
+                "openai", greeting="OpenAI greeting", recipient_npub=npub,
+            )
+
+        assert r1["poison"] != r2["poison"]
+        assert (npub, "x") in ex._pending_poisons
+        assert (npub, "openai") in ex._pending_poisons
+        assert ex._pending_poisons[(npub, "x")][0] == r1["poison"]
+        assert ex._pending_poisons[(npub, "openai")][0] == r2["poison"]
+
+    @pytest.mark.asyncio
+    async def test_receive_matches_correct_service_poison(self):
+        """Receive for service X uses X's poison, leaving OpenAI's intact."""
+        operator = PrivateKey()
+        sender = PrivateKey()
+        ex = _make_exchange(
+            nsec=operator.nsec, templates=self._two_service_templates(),
+        )
+
+        sender_npub = sender.public_key.bech32()
+        ex._pending_poisons[(sender_npub, "x")] = ("x-hawk-42", time.time() + 600)
+        ex._pending_poisons[(sender_npub, "openai")] = ("ai-fox-99", time.time() + 600)
+
+        payload = {"api_key": "k", "api_secret": "s", "poison": "x-hawk-42"}
+        event = _make_nip04_event(sender, operator.public_key.hex(), payload)
+        with ex._lock:
+            ex._received_events.append(event)
+
+        with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"):
+            result = await ex.receive(sender_npub, service="x")
+
+        assert result["success"] is True
+        # X poison consumed
+        assert (sender_npub, "x") not in ex._pending_poisons
+        # OpenAI poison still intact
+        assert (sender_npub, "openai") in ex._pending_poisons
+
+    @pytest.mark.asyncio
+    async def test_second_open_channel_same_service_replaces_poison(self):
+        """Re-opening a channel for the same service overwrites the old poison."""
+        ex = _make_exchange(templates=self._two_service_templates())
+        npub = "npub1test123"
+
+        with patch.object(ex, "_start_subscription"), \
+             patch.object(ex, "send_dm"):
+            r1 = await ex.open_channel(
+                "x", greeting="First attempt", recipient_npub=npub,
+            )
+            r2 = await ex.open_channel(
+                "x", greeting="Second attempt", recipient_npub=npub,
+            )
+
+        # Only the second poison should be stored
+        assert ex._pending_poisons[(npub, "x")][0] == r2["poison"]
+        assert ex._pending_poisons[(npub, "x")][0] != r1["poison"]
+
+
 # ── Conversational DM Flow Tests ──────────────────────────────────────────
 
 
@@ -1313,18 +1416,22 @@ class TestConversationalDmFlow:
 
     @pytest.mark.asyncio
     async def test_welcome_dm_is_conversational(self):
-        """Welcome message contains the new conversational text patterns."""
+        """Welcome message contains the operator greeting and standard elements."""
         ex = _make_exchange()
         patron = PrivateKey()
+        greeting = "Hi — I'm eXcalibur, a Tollbooth MCP service."
 
         with patch.object(ex, "_start_subscription"), \
              patch.object(ex, "send_dm") as mock_send:
-            await ex.open_channel("x", recipient_npub=patron.public_key.bech32())
+            await ex.open_channel(
+                "x", greeting=greeting, recipient_npub=patron.public_key.bech32(),
+            )
 
         mock_send.assert_called_once()
         welcome_text = mock_send.call_args[0][1]
-        assert "requested a credential channel" in welcome_text
+        assert greeting in welcome_text
         assert "If you didn't request this" in welcome_text
+        assert "tollbooth-dpyc v" in welcome_text
 
     @pytest.mark.asyncio
     async def test_success_dm_sent_after_receive(self):

--- a/tests/test_secure_courier_service.py
+++ b/tests/test_secure_courier_service.py
@@ -173,9 +173,11 @@ class TestOpenChannel:
             new_callable=AsyncMock,
             return_value=expected,
         ) as mock_open:
-            result = await service.open_channel("x")
+            result = await service.open_channel("x", greeting="Test greeting")
 
-        mock_open.assert_called_once_with("x", recipient_npub=None)
+        mock_open.assert_called_once_with(
+            "x", greeting="Test greeting", recipient_npub=None,
+        )
         assert result == expected
 
     @pytest.mark.asyncio
@@ -194,9 +196,13 @@ class TestOpenChannel:
             new_callable=AsyncMock,
             return_value={"success": True},
         ) as mock_open:
-            await service.open_channel("x", recipient_npub=npub)
+            await service.open_channel(
+                "x", greeting="Test greeting", recipient_npub=npub,
+            )
 
-        mock_open.assert_called_once_with("x", recipient_npub=npub)
+        mock_open.assert_called_once_with(
+            "x", greeting="Test greeting", recipient_npub=npub,
+        )
 
 
 # ── receive tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `open_channel` now takes a required `greeting` parameter — operators provide their own welcome banner instead of the hardcoded generic message
- `_pending_poisons` keyed by `(npub, service)` tuple instead of bare `npub` — concurrent exchanges for different services from the same patron no longer collide
- Welcome DM restructured: greeting → credential payload → provenance → disclaimer
- Version bumped to `0.1.50`

## Test plan

- [x] All 951 existing tests pass (`venv/bin/pytest -v`)
- [x] 3 new `TestConcurrentExchanges` tests: independent poisons, correct service match, overwrite on re-open
- [x] Updated `TestOpenChannel`, `TestOpenChannelWithWelcomeDm`, `TestPoisonSlug`, `TestConversationalDmFlow`, and `TestSecureCourierService.TestOpenChannel` to use `greeting=`
- [ ] Live test after merge + PyPI publish: `request_credential_channel` in excalibur-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)