### PR TITLE
Add DPYCRegistry with resolve_authority_npub (v0.1.51)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.50"
+version = "0.1.51"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -8,6 +8,7 @@ from importlib.metadata import version as _meta_version
 __version__ = _meta_version("tollbooth-dpyc")
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
+from tollbooth.registry import DPYCRegistry, RegistryError, resolve_authority_npub, DEFAULT_REGISTRY_URL
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -137,6 +138,11 @@ __all__ = [
     "verify_nostr_certificate",
     "NOSTR_CERT_KIND",
     "UNDERSTOOD_PROTOCOLS",
+    # Registry
+    "DPYCRegistry",
+    "RegistryError",
+    "resolve_authority_npub",
+    "DEFAULT_REGISTRY_URL",
     "NostrAuditPublisher",
     "AuditedVault",
     "MerkleTree",

--- a/src/tollbooth/registry.py
+++ b/src/tollbooth/registry.py
@@ -1,0 +1,121 @@
+"""DPYC community registry — cached membership lookup and authority resolution."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/lonniev/dpyc-community/main/members.json"
+)
+
+
+class RegistryError(Exception):
+    """Raised when a registry lookup fails (fail closed)."""
+
+
+class DPYCRegistry:
+    """Cached DPYC community membership lookup via HTTP.
+
+    Fetches the community members.json from the registry URL and caches it
+    with a monotonic-clock TTL. Any HTTP, parse, or structure error raises
+    ``RegistryError`` (fail closed — no silent pass-through).
+    """
+
+    def __init__(self, url: str, cache_ttl_seconds: int = 300) -> None:
+        self._url = url
+        self._ttl = cache_ttl_seconds
+        self._client = httpx.AsyncClient(timeout=10.0)
+        self._cache: list[dict[str, Any]] | None = None
+        self._cache_time: float = 0.0
+
+    async def check_membership(self, npub: str) -> dict[str, Any]:
+        """Return the member record for *npub* or raise ``RegistryError``."""
+        members = await self._fetch()
+
+        for member in members:
+            if member.get("npub") == npub:
+                if member.get("status") != "active":
+                    raise RegistryError(
+                        f"Member {npub} is not active (status={member.get('status')})."
+                    )
+                return member
+
+        raise RegistryError(f"npub {npub} not found in DPYC registry.")
+
+    async def resolve_authority_npub(self, operator_npub: str) -> str:
+        """Look up *operator_npub* and return its ``upstream_authority_npub``.
+
+        Raises ``RegistryError`` if the operator is not found, not active,
+        or has no upstream authority configured (i.e. is a Prime Authority).
+        """
+        member = await self.check_membership(operator_npub)
+        upstream = member.get("upstream_authority_npub")
+        if not upstream:
+            raise RegistryError(
+                f"Member {operator_npub} has no upstream authority "
+                f"(role={member.get('role')})."
+            )
+        return upstream
+
+    async def _fetch(self) -> list[dict[str, Any]]:
+        """Return the cached member list, refreshing if stale."""
+        now = time.monotonic()
+        if self._cache is not None and (now - self._cache_time) < self._ttl:
+            return self._cache
+
+        try:
+            resp = await self._client.get(self._url)
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPError as e:
+            raise RegistryError(f"Registry fetch failed: {e}") from e
+        except Exception as e:
+            raise RegistryError(f"Registry parse failed: {e}") from e
+
+        # Handle both bare list and {"members": [...]} wrapper formats
+        if isinstance(data, dict):
+            if "members" in data and isinstance(data["members"], list):
+                data = data["members"]
+            else:
+                raise RegistryError(
+                    "Registry JSON object missing 'members' list."
+                )
+        elif not isinstance(data, list):
+            raise RegistryError("Registry JSON is not a list or object.")
+
+        self._cache = data
+        self._cache_time = now
+        return data
+
+    def invalidate_cache(self) -> None:
+        """Force the next lookup to re-fetch."""
+        self._cache = None
+        self._cache_time = 0.0
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+
+async def resolve_authority_npub(
+    operator_npub: str,
+    registry_url: str = DEFAULT_REGISTRY_URL,
+    cache_ttl_seconds: int = 300,
+) -> str:
+    """Convenience function: resolve an operator's upstream authority npub.
+
+    Creates a one-shot ``DPYCRegistry``, performs the lookup, and closes.
+    For repeated lookups, prefer creating a ``DPYCRegistry`` instance and
+    reusing it.
+    """
+    registry = DPYCRegistry(url=registry_url, cache_ttl_seconds=cache_ttl_seconds)
+    try:
+        return await registry.resolve_authority_npub(operator_npub)
+    finally:
+        await registry.close()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,230 @@
+"""Tests for tollbooth.registry — DPYC community registry resolution."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+import pytest
+
+from tollbooth.registry import (
+    DEFAULT_REGISTRY_URL,
+    DPYCRegistry,
+    RegistryError,
+    resolve_authority_npub,
+)
+
+SAMPLE_MEMBERS = [
+    {
+        "npub": "npub1prime",
+        "role": "prime_authority",
+        "status": "active",
+        "upstream_authority_npub": None,
+    },
+    {
+        "npub": "npub1authority",
+        "role": "authority",
+        "status": "active",
+        "upstream_authority_npub": "npub1prime",
+    },
+    {
+        "npub": "npub1operator",
+        "role": "operator",
+        "status": "active",
+        "upstream_authority_npub": "npub1authority",
+    },
+    {
+        "npub": "npub1banned",
+        "role": "operator",
+        "status": "banned",
+        "upstream_authority_npub": "npub1authority",
+    },
+]
+
+
+def _mock_response(data, status_code=200):
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+# --- resolve_authority_npub (instance method) ---
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_npub_success():
+    """resolve_authority_npub returns upstream npub for an active operator."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    result = await registry.resolve_authority_npub("npub1operator")
+    assert result == "npub1authority"
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_npub_no_upstream_raises():
+    """resolve_authority_npub raises for Prime Authority (no upstream)."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    with pytest.raises(RegistryError, match="no upstream authority"):
+        await registry.resolve_authority_npub("npub1prime")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_npub_not_found_raises():
+    """resolve_authority_npub raises for unknown npub."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    with pytest.raises(RegistryError, match="not found"):
+        await registry.resolve_authority_npub("npub1unknown")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_npub_inactive_raises():
+    """resolve_authority_npub raises for banned member."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    with pytest.raises(RegistryError, match="not active"):
+        await registry.resolve_authority_npub("npub1banned")
+    await registry.close()
+
+
+# --- Cache TTL ---
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_respected():
+    """Registry re-fetches after TTL expires."""
+    registry = DPYCRegistry(url="https://example.com/members.json", cache_ttl_seconds=1)
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    # First call fetches
+    await registry.check_membership("npub1operator")
+    assert registry._client.get.call_count == 1
+
+    # Second call uses cache
+    await registry.check_membership("npub1operator")
+    assert registry._client.get.call_count == 1
+
+    # Force cache to expire by backdating cache_time
+    registry._cache_time = time.monotonic() - 2.0
+
+    # Third call re-fetches
+    await registry.check_membership("npub1operator")
+    assert registry._client.get.call_count == 2
+    await registry.close()
+
+
+# --- HTTP error ---
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises_registry_error():
+    """HTTP errors are wrapped in RegistryError."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({}, status_code=500)
+    )
+
+    with pytest.raises(RegistryError, match="fetch failed"):
+        await registry.check_membership("npub1operator")
+    await registry.close()
+
+
+# --- Bare list format ---
+
+
+@pytest.mark.asyncio
+async def test_bare_list_format():
+    """Registry accepts bare list format (no wrapper object)."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response(SAMPLE_MEMBERS)  # bare list, no wrapper
+    )
+
+    result = await registry.check_membership("npub1operator")
+    assert result["npub"] == "npub1operator"
+    await registry.close()
+
+
+# --- invalidate_cache ---
+
+
+@pytest.mark.asyncio
+async def test_invalidate_cache():
+    """invalidate_cache forces next lookup to re-fetch."""
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(
+        return_value=_mock_response({"members": SAMPLE_MEMBERS})
+    )
+
+    await registry.check_membership("npub1operator")
+    assert registry._client.get.call_count == 1
+
+    registry.invalidate_cache()
+
+    await registry.check_membership("npub1operator")
+    assert registry._client.get.call_count == 2
+    await registry.close()
+
+
+# --- Convenience function ---
+
+
+@pytest.mark.asyncio
+async def test_convenience_function():
+    """Module-level resolve_authority_npub() creates a one-shot registry."""
+    mock_resp = _mock_response({"members": SAMPLE_MEMBERS})
+
+    with patch("tollbooth.registry.httpx.AsyncClient") as MockClient:
+        instance = AsyncMock()
+        instance.get = AsyncMock(return_value=mock_resp)
+        MockClient.return_value = instance
+
+        result = await resolve_authority_npub(
+            "npub1operator",
+            registry_url="https://example.com/members.json",
+        )
+        assert result == "npub1authority"
+        instance.aclose.assert_awaited_once()
+
+
+# --- Default URL ---
+
+
+def test_default_registry_url():
+    """DEFAULT_REGISTRY_URL points to dpyc-community on GitHub."""
+    assert "dpyc-community" in DEFAULT_REGISTRY_URL
+    assert "members.json" in DEFAULT_REGISTRY_URL


### PR DESCRIPTION
## Summary
- Move `DPYCRegistry` class from tollbooth-authority into the shared `tollbooth-dpyc` library
- Add `resolve_authority_npub()` method — looks up an operator's upstream authority npub from the dpyc-community registry
- Add module-level convenience function and `DEFAULT_REGISTRY_URL` constant
- Bump version to 0.1.51

## Context
Part of NSEC-Only Identity task (`4155f84a`). Services will use this to derive their authority npub from the registry instead of storing it in env vars.

## Test plan
- [x] 10 new tests in `test_registry.py` — resolve success, no-upstream raises, not-found raises, inactive raises, cache TTL, HTTP error, bare list format, invalidate cache, convenience function, default URL
- [x] Full suite: 961 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)