### PR TITLE
feat: add NeonCredentialVault (v0.1.53)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.52"
+version = "0.1.53"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/vaults/__init__.py
+++ b/src/tollbooth/vaults/__init__.py
@@ -1,6 +1,6 @@
 """Built-in VaultBackend implementations for tollbooth-dpyc."""
 
 from tollbooth.vaults.thebrain import TheBrainVault
-from tollbooth.vaults.neon import NeonVault, NeonQueryError
+from tollbooth.vaults.neon import NeonVault, NeonQueryError, NeonCredentialVault
 
-__all__ = ["TheBrainVault", "NeonVault", "NeonQueryError"]
+__all__ = ["TheBrainVault", "NeonVault", "NeonQueryError", "NeonCredentialVault"]

--- a/src/tollbooth/vaults/neon.py
+++ b/src/tollbooth/vaults/neon.py
@@ -375,3 +375,65 @@ class NeonVault:
             return sum(t.get("remaining_sats", 0) for t in obj.get("tranches", []))
         except (json.JSONDecodeError, TypeError, AttributeError):
             return 0
+
+
+class NeonCredentialVault:
+    """CredentialVaultBackend backed by Neon serverless Postgres.
+
+    Implements the ``CredentialVaultBackend`` protocol for encrypted
+    credential persistence.  Shares the httpx client and ``_execute()``
+    helper from a ``NeonVault`` instance — no new connections or config.
+
+    Schema: ``credentials`` table with composite PK ``(service, npub)``.
+    Call ``ensure_schema()`` at startup alongside ``NeonVault.ensure_schema()``.
+    """
+
+    def __init__(self, *, neon_vault: NeonVault) -> None:
+        self._neon = neon_vault
+
+    async def ensure_schema(self) -> None:
+        """Create the ``credentials`` table if it doesn't exist."""
+        await self._neon._execute(
+            "CREATE TABLE IF NOT EXISTS credentials ("
+            "    service TEXT NOT NULL,"
+            "    npub TEXT NOT NULL,"
+            "    encrypted_blob TEXT NOT NULL,"
+            "    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+            "    PRIMARY KEY (service, npub)"
+            ")"
+        )
+
+    async def store_credentials(
+        self, service: str, npub: str, encrypted_blob: str,
+    ) -> None:
+        """Store an encrypted credential blob. Overwrites existing."""
+        await self._neon._execute(
+            "INSERT INTO credentials (service, npub, encrypted_blob, updated_at) "
+            "VALUES ($1, $2, $3, now()) "
+            "ON CONFLICT (service, npub) DO UPDATE "
+            "SET encrypted_blob = EXCLUDED.encrypted_blob, "
+            "    updated_at = now()",
+            [service, npub, encrypted_blob],
+        )
+
+    async def fetch_credentials(
+        self, service: str, npub: str,
+    ) -> str | None:
+        """Fetch an encrypted credential blob. Returns None if not found."""
+        result = await self._neon._execute(
+            "SELECT encrypted_blob FROM credentials "
+            "WHERE service = $1 AND npub = $2",
+            [service, npub],
+        )
+        rows = result.get("rows", [])
+        return rows[0]["encrypted_blob"] if rows else None
+
+    async def delete_credentials(
+        self, service: str, npub: str,
+    ) -> bool:
+        """Delete stored credentials. Returns True if found and deleted."""
+        result = await self._neon._execute(
+            "DELETE FROM credentials WHERE service = $1 AND npub = $2",
+            [service, npub],
+        )
+        return (result.get("rowCount", 0) or 0) > 0

--- a/tests/test_neon_credential_vault.py
+++ b/tests/test_neon_credential_vault.py
@@ -1,0 +1,187 @@
+"""Tests for NeonCredentialVault — CredentialVaultBackend via Neon Postgres."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from tollbooth.credential_vault_backend import CredentialVaultBackend
+from tollbooth.vaults.neon import NeonCredentialVault, NeonVault
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DATABASE_URL = "postgresql://user:password@ep-test.us-east-2.aws.neon.tech/testdb"
+HTTP_ENDPOINT = "https://ep-test.us-east-2.aws.neon.tech/sql"
+
+
+def _neon_vault() -> NeonVault:
+    return NeonVault(database_url=DATABASE_URL)
+
+
+def _cred_vault(neon: NeonVault | None = None) -> NeonCredentialVault:
+    return NeonCredentialVault(neon_vault=neon or _neon_vault())
+
+
+def _response(
+    status_code: int = 200, json_data: dict | list | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("POST", HTTP_ENDPOINT),
+    )
+
+
+def _sql_result(
+    rows: list[dict] | None = None,
+    row_count: int | None = None,
+    command: str = "SELECT",
+) -> dict:
+    result: dict = {"command": command}
+    if rows is not None:
+        result["rows"] = rows
+        result["rowCount"] = row_count if row_count is not None else len(rows)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# ensure_schema
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureSchema:
+    @pytest.mark.asyncio
+    async def test_creates_credentials_table(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="CREATE"))
+        )
+        vault = _cred_vault(neon)
+        await vault.ensure_schema()
+        neon._client.post.assert_called_once()
+        body = neon._client.post.call_args.kwargs.get(
+            "json", neon._client.post.call_args[1] if len(neon._client.post.call_args.args) > 1 else None
+        )
+        assert "credentials" in body["query"]
+        assert "IF NOT EXISTS" in body["query"]
+
+    @pytest.mark.asyncio
+    async def test_schema_idempotent(self) -> None:
+        """Calling ensure_schema twice doesn't raise."""
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="CREATE"))
+        )
+        vault = _cred_vault(neon)
+        await vault.ensure_schema()
+        await vault.ensure_schema()
+        assert neon._client.post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# store_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestStoreCredentials:
+    @pytest.mark.asyncio
+    async def test_stores_blob(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], row_count=1, command="INSERT"))
+        )
+        vault = _cred_vault(neon)
+        await vault.store_credentials("thebrain", "npub1abc", "encrypted-data")
+
+        body = neon._client.post.call_args.kwargs.get(
+            "json", neon._client.post.call_args[1] if len(neon._client.post.call_args.args) > 1 else None
+        )
+        assert body["params"] == ["thebrain", "npub1abc", "encrypted-data"]
+        assert "ON CONFLICT" in body["query"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCredentials:
+    @pytest.mark.asyncio
+    async def test_returns_blob(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(
+                rows=[{"encrypted_blob": "my-secret-blob"}],
+            ))
+        )
+        vault = _cred_vault(neon)
+        result = await vault.fetch_credentials("thebrain", "npub1abc")
+        assert result == "my-secret-blob"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[]))
+        )
+        vault = _cred_vault(neon)
+        result = await vault.fetch_credentials("thebrain", "npub1unknown")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_overwrite_returns_latest(self) -> None:
+        """Store twice, fetch returns the latest blob."""
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            side_effect=[
+                _response(200, _sql_result(rows=[], row_count=1, command="INSERT")),
+                _response(200, _sql_result(rows=[], row_count=1, command="INSERT")),
+                _response(200, _sql_result(rows=[{"encrypted_blob": "blob-v2"}])),
+            ]
+        )
+        vault = _cred_vault(neon)
+        await vault.store_credentials("thebrain", "npub1abc", "blob-v1")
+        await vault.store_credentials("thebrain", "npub1abc", "blob-v2")
+        result = await vault.fetch_credentials("thebrain", "npub1abc")
+        assert result == "blob-v2"
+
+
+# ---------------------------------------------------------------------------
+# delete_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteCredentials:
+    @pytest.mark.asyncio
+    async def test_delete_existing_returns_true(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], row_count=1, command="DELETE"))
+        )
+        vault = _cred_vault(neon)
+        result = await vault.delete_credentials("thebrain", "npub1abc")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_returns_false(self) -> None:
+        neon = _neon_vault()
+        neon._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], row_count=0, command="DELETE"))
+        )
+        vault = _cred_vault(neon)
+        result = await vault.delete_credentials("thebrain", "npub1unknown")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_implements_credential_vault_backend(self) -> None:
+        vault = _cred_vault()
+        assert isinstance(vault, CredentialVaultBackend)


### PR DESCRIPTION
## Summary
- Adds `NeonCredentialVault` class to `src/tollbooth/vaults/neon.py` — `CredentialVaultBackend` backed by Neon serverless Postgres
- Shares `NeonVault`'s httpx client and `_execute()` helper — no new connections or config
- Composite PK `(service, npub)` with UPSERT semantics, `ensure_schema()` for idempotent table creation
- Exported from `tollbooth.vaults` alongside `NeonVault` and `NeonQueryError`
- Version bump: 0.1.52 → 0.1.53

## Test plan
- [x] Happy path: store → fetch → returns blob
- [x] Overwrite: store twice → fetch returns latest
- [x] Fetch missing → returns None
- [x] Delete existing → returns True
- [x] Delete missing → returns False
- [x] Schema idempotent (call ensure_schema twice)
- [x] Protocol conformance: `isinstance(vault, CredentialVaultBackend)`
- [x] All 991 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)