### PR TITLE
fix: @@@ regex handles multiline values, drop (REQUIRED) labels (v0.1.54)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.53"
+version = "0.1.54"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/credential_templates.py
+++ b/src/tollbooth/credential_templates.py
@@ -108,9 +108,8 @@ def render_delimited_instructions(template: CredentialTemplate) -> str:
     lines.append("")
 
     for name, spec in template.fields.items():
-        req = "REQUIRED" if spec.required else "optional"
         placeholder = f"PASTE_YOUR_{name.upper()}_HERE"
-        lines.append(f"  {name} = @@@{placeholder}@@@  ({req})")
+        lines.append(f"  {name} = @@@{placeholder}@@@")
 
     return "\n".join(lines)
 

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -123,7 +123,7 @@ def _generate_poison() -> str:
 
 
 # @@@ delimiter extraction — mobile-friendly credential format
-_DELIMITED_FIELD = re.compile(r"(\w+)\s*=\s*@@@(.+?)@@@")
+_DELIMITED_FIELD = re.compile(r"(\w+)\s*=\s*@@@(.+?)@@@", re.DOTALL)
 
 
 def _parse_delimited_credentials(text: str) -> dict[str, str] | None:
@@ -135,7 +135,8 @@ def _parse_delimited_credentials(text: str) -> dict[str, str] | None:
     matches = _DELIMITED_FIELD.findall(text)
     if not matches:
         return None
-    return {key.strip(): value.strip() for key, value in matches}
+    # Strip newlines that mobile clients may inject; preserve intentional spaces
+    return {key.strip(): re.sub(r"\r?\n", "", value).strip() for key, value in matches}
 
 
 @dataclass

--- a/tests/test_credential_templates.py
+++ b/tests/test_credential_templates.py
@@ -195,12 +195,12 @@ class TestRenderDelimitedInstructions:
         assert "x" in text
         assert "v1" in text
 
-    def test_marks_required_and_optional(self):
-        """Required and optional labels present."""
+    def test_no_required_or_optional_labels(self):
+        """Field lines should not include (REQUIRED) or (optional) labels."""
         tmpl = _x_api_template()
         text = render_delimited_instructions(tmpl)
-        assert "REQUIRED" in text
-        assert "optional" in text
+        assert "REQUIRED" not in text
+        assert "(optional)" not in text
 
     def test_includes_description(self):
         """Template description is rendered."""


### PR DESCRIPTION
## Summary
- `_DELIMITED_FIELD` regex now uses `re.DOTALL` so `@@@value@@@` matches across newlines injected by mobile Nostr clients (0xchat, Damus, etc.)
- Parsed values strip newlines but preserve intentional spaces
- Removed `(REQUIRED)` / `(optional)` suffixes from delimited template instructions — clutters the DM without helping

## Test plan
- [x] 991 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)