### PR TITLE
fix: tempered greedy @@@ regex for robust multi-field parsing (v0.1.55)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.54"
+version = "0.1.55"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -123,7 +123,11 @@ def _generate_poison() -> str:
 
 
 # @@@ delimiter extraction — mobile-friendly credential format
-_DELIMITED_FIELD = re.compile(r"(\w+)\s*=\s*@@@(.+?)@@@", re.DOTALL)
+# Tempered greedy: match any non-@ char, or @ not followed by @@.
+# [^@] matches newlines naturally (no DOTALL needed), so this handles
+# line-wrapped values from mobile Nostr clients without bleeding across
+# adjacent @@@ delimiters.
+_DELIMITED_FIELD = re.compile(r"(\w+)\s*=\s*@@@((?:[^@]|@(?!@@))*)@@@")
 
 
 def _parse_delimited_credentials(text: str) -> dict[str, str] | None:


### PR DESCRIPTION
## Summary
- Replace `.+?` with `re.DOTALL` with tempered greedy token `(?:[^@]|@(?!@@))*`
- Matches content between `@@@` delimiters without bleeding across adjacent fields
- `[^@]` naturally matches newlines — no `re.DOTALL` flag needed
- Fixes `brain_id` parse failure when mobile clients inject newlines between fields

## Test plan
- [x] 991 tests passing
- [x] Manual regex verification against 6 edge cases (multiline, embedded @, all-three-fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)