### PR TITLE
feat: pop-and-acknowledge all relay DMs (v0.1.57)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.56"
+version = "0.1.57"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -664,7 +664,12 @@ class NostrCredentialExchange:
                     ),
                 }
 
-        # ── Relay DM flow ─────────────────────────────────────────
+        # ── Relay DM flow (pop-and-acknowledge) ────────────────────
+        #
+        # Treat the relay like a message queue: pop every DM from the
+        # candidate pool, delete it from the relay, and send the sender
+        # an acknowledgement explaining why it was accepted or rejected.
+        # Stop on the first valid match, or exhaust the queue.
         candidates = self._find_dm_candidates(sender_hex)
         if not candidates:
             self._fetch_dms_from_relays()
@@ -678,42 +683,7 @@ class NostrCredentialExchange:
                 f"try again."
             )
 
-        # Decrypt ALL candidates so we can pick the one with the correct
-        # anti-replay poison.  Previous code broke on first success, which
-        # meant stale DMs with old poisons could block the valid reply.
-        decrypted: list[tuple[dict[str, Any], str]] = []
-        for candidate in candidates:
-            kind = candidate.get("kind", 0)
-
-            # NIP-04 policy rejection must propagate immediately so the
-            # user gets a clear "upgrade your client" error, not a timeout.
-            if kind == _KIND_ENCRYPTED_DM and self._nip44_only:
-                raise CourierValidationError(
-                    "NIP-04 DMs rejected — this operator requires NIP-44 "
-                    "(NIP-17 gift wrap). Please use a modern Nostr client."
-                )
-
-            try:
-                pt = self._decrypt_dm(candidate, sender_hex)
-                decrypted.append((candidate, pt))
-            except CourierValidationError:
-                logger.debug(
-                    "Skipping %s %s (decrypt/validate failed)",
-                    "gift wrap" if kind == _KIND_GIFT_WRAP else "DM",
-                    candidate.get("id", "?")[:16],
-                )
-                continue
-
-        if not decrypted:
-            raise CourierTimeout(
-                f"No decryptable DM found from {sender_npub} within the "
-                f"{self._freshness_window}-second freshness window. "
-                f"Found {len(candidates)} candidate event(s) but none "
-                f"could be decrypted. Make sure you replied from the "
-                f"correct Nostr identity."
-            )
-
-        # ── Poison-aware DM selection ────────────────────────────────
+        # Resolve poison expectation up front
         poison_service = self._resolve_service(service)
         poison_key = (sender_npub, poison_service) if poison_service else None
         expected = self._pending_poisons.get(poison_key) if poison_key else None
@@ -726,65 +696,88 @@ class NostrCredentialExchange:
                     "Anti-replay token expired. Call request_credential_channel "
                     "again to get a fresh token."
                 )
-
-            # Scan all decrypted DMs for the one with matching poison
-            dm = None
-            plaintext = None
-            stale_events: list[dict[str, Any]] = []
-
-            for event, pt in decrypted:
-                payload = _parse_delimited_credentials(pt)
-                if payload and payload.get("poison") == expected_phrase:
-                    dm = event
-                    plaintext = pt
-                else:
-                    stale_events.append(event)
-
-            if dm is None:
-                found = [
-                    _parse_delimited_credentials(pt).get("poison", "<unparseable>")
-                    for _, pt in decrypted
-                    if _parse_delimited_credentials(pt)
-                ]
-                raise CourierValidationError(
-                    f'Anti-replay token mismatch. Expected "{expected_phrase}" '
-                    f"but none of {len(decrypted)} DM(s) matched. "
-                    f"Found poisons: {found}. "
-                    f"Call request_credential_channel again for a fresh token."
-                )
-
-            # Consume the poison — one-time use
-            del self._pending_poisons[poison_key]
-
-            # Clean up stale DMs — delete from relays AND purge from
-            # in-memory queue so they never re-enter the candidate pool.
-            if stale_events:
-                stale_ids = set()
-                for stale in stale_events:
-                    stale_id = stale.get("id", "")
-                    if stale_id:
-                        self._request_deletion(stale_id)
-                        stale_ids.add(stale_id)
-
-                with self._lock:
-                    self._consumed_ids.update(stale_ids)
-                    self._received_events = [
-                        e for e in self._received_events
-                        if e.get("id", "") not in stale_ids
-                    ]
-
-                logger.info(
-                    "Purged %d stale DM(s) from relays and local queue",
-                    len(stale_events),
-                )
         else:
-            # No poison expected — use newest (first in list)
-            dm, plaintext = decrypted[0]
+            expected_phrase = None
 
-        # Resolve template for error DM instructions
         error_template = self._resolve_error_template(service)
 
-        # Parse credential payload — @@@ delimited format only
+        # Pop-and-acknowledge: decrypt each candidate, consume it from
+        # the queue regardless of validity, and reply with the outcome.
+        dm = None
+        plaintext = None
+        pop_count = 0
+        undecryptable = 0
+
+        for candidate in candidates:
+            event_id = candidate.get("id", "")
+            kind = candidate.get("kind", 0)
+
+            # NIP-04 policy check
+            if kind == _KIND_ENCRYPTED_DM and self._nip44_only:
+                self._pop_event(event_id, sender_npub,
+                    "Rejected: NIP-04 DMs not accepted. "
+                    "Please use a modern Nostr client with NIP-44 support.")
+                pop_count += 1
+                continue
+
+            # Decrypt
+            try:
+                pt = self._decrypt_dm(candidate, sender_hex)
+            except CourierValidationError:
+                self._pop_event(event_id)
+                undecryptable += 1
+                pop_count += 1
+                continue
+
+            # Parse @@@ fields
+            payload = _parse_delimited_credentials(pt)
+            if payload is None:
+                self._pop_event(event_id, sender_npub,
+                    "Rejected: could not find @@@ field markers in your message. "
+                    "Please use the format: field_name = @@@value@@@")
+                pop_count += 1
+                continue
+
+            # Poison check (if expected)
+            if expected_phrase is not None:
+                msg_poison = payload.get("poison", "")
+                if msg_poison != expected_phrase:
+                    reason = (
+                        f"Rejected: wrong anti-replay token "
+                        f"(got \"{msg_poison or '<missing>'}\")"
+                    ) if msg_poison else (
+                        "Rejected: anti-replay token missing from your message."
+                    )
+                    self._pop_event(event_id, sender_npub, reason)
+                    pop_count += 1
+                    continue
+
+            # This DM is the valid match — pop it and stop scanning
+            dm = candidate
+            plaintext = pt
+            self._pop_event(event_id)  # no reply yet — success DM sent later
+            pop_count += 1
+            break
+
+        logger.info(
+            "Popped %d DM(s) (%d undecryptable), match=%s",
+            pop_count, undecryptable, "found" if dm else "none",
+        )
+
+        if dm is None:
+            raise CourierValidationError(
+                f"Scanned {pop_count} DM(s) but none contained valid "
+                f"credentials with the expected anti-replay token. "
+                f"All have been acknowledged and deleted. "
+                f"Call request_credential_channel again for a fresh token."
+            )
+
+        # Consume the poison — one-time use
+        if poison_key and poison_key in self._pending_poisons:
+            del self._pending_poisons[poison_key]
+
+        # Parse credential payload (already parsed above, but re-parse
+        # cleanly for the validation path below)
         payload = _parse_delimited_credentials(plaintext)
         if payload is None:
             self._send_error_dm(sender_npub, error_template)
@@ -807,20 +800,6 @@ class NostrCredentialExchange:
         except TemplateValidationError as exc:
             self._send_error_dm(sender_npub, template)
             raise CourierValidationError(str(exc)) from exc
-
-        # Mark event as consumed and purge from local queue
-        event_id = dm.get("id", "")
-        with self._lock:
-            self._consumed_ids.add(event_id)
-            if event_id:
-                self._received_events = [
-                    e for e in self._received_events
-                    if e.get("id", "") != event_id
-                ]
-
-        # Publish NIP-09 deletion request (fire-and-forget)
-        if event_id:
-            self._request_deletion(event_id)
 
         # Store in vault for next session
         if self._credential_vault is not None:
@@ -914,6 +893,43 @@ class NostrCredentialExchange:
                 "Success DM to %s failed (non-fatal): %s",
                 sender_npub[:20], exc,
             )
+
+    def _pop_event(
+        self,
+        event_id: str,
+        reply_npub: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Pop a DM from the local queue and relay.
+
+        Unconditionally consumes the event: adds to ``_consumed_ids``,
+        removes from ``_received_events``, and sends a NIP-09 deletion
+        request to all relays.
+
+        If *reply_npub* and *reason* are provided, sends an acknowledgement
+        DM to the sender explaining why the message was rejected.
+        Acknowledgement failures are non-fatal.
+        """
+        if not event_id:
+            return
+
+        with self._lock:
+            self._consumed_ids.add(event_id)
+            self._received_events = [
+                e for e in self._received_events
+                if e.get("id", "") != event_id
+            ]
+
+        self._request_deletion(event_id)
+
+        if reply_npub and reason:
+            try:
+                self.send_dm(reply_npub, reason)
+            except Exception as exc:
+                logger.debug(
+                    "Ack DM to %s failed (non-fatal): %s",
+                    reply_npub[:20], exc,
+                )
 
     def _send_error_dm(
         self,

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -271,7 +271,7 @@ class TestReceiveNip04:
 
     @pytest.mark.asyncio
     async def test_nip04_rejected_when_nip44_only(self):
-        """NIP-04 DM rejected when nip44_only=True."""
+        """NIP-04 DM popped and rejected when nip44_only=True."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec, nip44_only=True)
@@ -283,8 +283,13 @@ class TestReceiveNip04:
             ex._received_events.append(event)
 
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             pytest.raises(CourierValidationError, match="NIP-04 DMs rejected"):
+             patch.object(ex, "send_dm"), \
+             patch.object(ex, "_request_deletion"), \
+             pytest.raises(CourierValidationError, match="Scanned 1 DM"):
             await ex.receive(sender.public_key.bech32())
+
+        # Event should be purged from the queue
+        assert len(ex._received_events) == 0
 
 
 # ── receive Tests — NIP-17 Gift Wrap ─────────────────────────────────
@@ -318,7 +323,7 @@ class TestReceiveNip17:
 
     @pytest.mark.asyncio
     async def test_gift_wrap_wrong_sender_skipped(self):
-        """Gift wrap from wrong sender is skipped (not matching sender)."""
+        """Gift wrap from wrong sender is popped and acknowledged."""
         operator = PrivateKey()
         sender = PrivateKey()
         impersonator = PrivateKey()
@@ -334,10 +339,17 @@ class TestReceiveNip17:
             ex._received_events.append(event)
 
         # The impersonator's gift wrap decrypts but the seal reveals
-        # a different sender — it gets skipped, resulting in timeout.
+        # a different sender — it gets popped (undecryptable from the
+        # expected sender's perspective) and the queue is drained.
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             pytest.raises(CourierTimeout, match="No decryptable DM found"):
+             patch.object(ex, "_pop_event") as mock_pop, \
+             pytest.raises(CourierValidationError, match="Scanned 1 DM"):
             await ex.receive(sender.public_key.bech32())
+
+        # The wrong-sender gift wrap was popped silently (no reply npub
+        # since we can't trust the sender identity from a failed decrypt)
+        mock_pop.assert_called_once()
+        assert mock_pop.call_args[0][0] == event["id"]
 
 
 # ── receive Tests — Validation ────────────────────────────────────────
@@ -1118,7 +1130,7 @@ class TestPoisonSlug:
 
     @pytest.mark.asyncio
     async def test_poison_validated_on_receive(self):
-        """Receive rejects payload with wrong poison."""
+        """Receive rejects payload with wrong poison (popped and acknowledged)."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
@@ -1133,9 +1145,16 @@ class TestPoisonSlug:
         with ex._lock:
             ex._received_events.append(event)
 
+        # Wrong poison DM is popped with ack, then aggregate error raised
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             pytest.raises(CourierValidationError, match="Anti-replay token mismatch"):
+             patch.object(ex, "_pop_event") as mock_pop, \
+             pytest.raises(CourierValidationError, match="Scanned 1 DM"):
             await ex.receive(sender_npub)
+
+        # Verify the DM was popped with a rejection reason
+        mock_pop.assert_called_once()
+        call_args = mock_pop.call_args[0]
+        assert "wrong anti-replay token" in (call_args[2] if len(call_args) > 2 else "")
 
     @pytest.mark.asyncio
     async def test_poison_accepted_on_match(self):
@@ -1278,7 +1297,7 @@ class TestPoisonSlug:
 
     @pytest.mark.asyncio
     async def test_no_poison_match_reports_found_poisons(self):
-        """When no DM matches the expected poison, error lists found poisons."""
+        """When no DM matches the expected poison, all are popped with ack."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
@@ -1302,13 +1321,18 @@ class TestPoisonSlug:
             ex._received_events.extend([dm1, dm2])
 
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             pytest.raises(CourierValidationError, match="none of 2 DM") as exc_info:
+             patch.object(ex, "_pop_event") as mock_pop, \
+             pytest.raises(CourierValidationError, match="Scanned 2 DM") as exc_info:
             await ex.receive(sender_npub)
 
         err = str(exc_info.value)
-        assert "true-quill-26" in err
-        assert "lazy-fox-99" in err
         assert "request_credential_channel" in err
+
+        # Both DMs were popped with rejection reasons
+        assert mock_pop.call_count == 2
+        reasons = [c[0][2] for c in mock_pop.call_args_list if len(c[0]) > 2]
+        assert any("true-quill-26" in r for r in reasons)
+        assert any("lazy-fox-99" in r for r in reasons)
 
 
 # ── Concurrent Multi-Service Exchange Tests ──────────────────────────────
@@ -1458,7 +1482,7 @@ class TestConversationalDmFlow:
 
     @pytest.mark.asyncio
     async def test_error_dm_sent_on_validation_failure(self):
-        """When credential parsing fails, an error DM is sent before raising."""
+        """When credential parsing fails, a rejection DM is sent via pop."""
         import base64
         import os
 
@@ -1496,14 +1520,16 @@ class TestConversationalDmFlow:
         with ex._lock:
             ex._received_events.append(event)
 
+        # Pop-and-ack: _pop_event sends rejection via send_dm
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             patch.object(ex, "send_dm") as mock_send:
-            with pytest.raises(CourierValidationError):
+             patch.object(ex, "send_dm") as mock_send, \
+             patch.object(ex, "_request_deletion"):
+            with pytest.raises(CourierValidationError, match="Scanned 1 DM"):
                 await ex.receive(sender.public_key.bech32())
 
         mock_send.assert_called_once()
         error_text = mock_send.call_args[0][1]
-        assert "couldn’t process" in error_text
+        assert "@@@" in error_text
 
     @pytest.mark.asyncio
     async def test_success_dm_failure_nonfatal(self):
@@ -1528,8 +1554,7 @@ class TestConversationalDmFlow:
 
     @pytest.mark.asyncio
     async def test_error_dm_failure_nonfatal(self):
-        """If the error DM fails to send, the original
-        CourierValidationError still propagates."""
+        """If the ack DM fails to send, the aggregate error still propagates."""
         import base64
         import os
 
@@ -1567,9 +1592,11 @@ class TestConversationalDmFlow:
         with ex._lock:
             ex._received_events.append(event)
 
+        # _pop_event catches send_dm failure internally; aggregate error still raised
         with patch.object(ex, "_fetch_dms_from_relays"), \
+             patch.object(ex, "_request_deletion"), \
              patch.object(ex, "send_dm", side_effect=Exception("relay down")):
-            with pytest.raises(CourierValidationError, match="@@@"):
+            with pytest.raises(CourierValidationError, match="Scanned 1 DM"):
                 await ex.receive(sender.public_key.bech32())
 
 
@@ -1696,7 +1723,7 @@ class TestReceiveFormatEnforcement:
 
     @pytest.mark.asyncio
     async def test_receive_rejects_json_payload(self):
-        """receive() rejects raw JSON (@@@ format required)."""
+        """receive() rejects raw JSON (@@@ format required), popped with ack."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
@@ -1707,9 +1734,14 @@ class TestReceiveFormatEnforcement:
             ex._received_events.append(event)
 
         with patch.object(ex, "_fetch_dms_from_relays"), \
-             patch.object(ex, "send_dm"), \
-             pytest.raises(CourierValidationError, match="@@@"):
+             patch.object(ex, "_pop_event") as mock_pop, \
+             pytest.raises(CourierValidationError, match="Scanned 1 DM"):
             await ex.receive(sender.public_key.bech32())
+
+        # JSON payload popped with @@@ hint in rejection reason
+        mock_pop.assert_called_once()
+        reason = mock_pop.call_args[0][2] if len(mock_pop.call_args[0]) > 2 else ""
+        assert "@@@" in reason
 
     @pytest.mark.asyncio
     async def test_receive_delimited_payload(self):


### PR DESCRIPTION
## Summary
- Every DM encountered during `receive()` is now popped from the relay (NIP-09 deletion + local queue purge) regardless of validity
- Each popped DM gets a reply to the sender explaining acceptance or rejection reason (wrong poison, no @@@ markers, NIP-04 rejected, etc.)
- New `_pop_event()` helper method handles the consume-delete-acknowledge cycle
- Keeps relay queues clean and gives users immediate feedback on malformed credentials

## Test plan
- [x] All 991 tests pass (77 in test_nostr_credentials.py)
- [x] Updated tests for pop-and-acknowledge behavior: wrong sender, wrong poison, no @@@ markers, JSON payloads, error DM failures
- [ ] Live test with 0xchat after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)