### PR TITLE
fix: tolerant credential parser (v0.1.59)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.58"
+version = "0.1.59"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/credential_templates.py
+++ b/src/tollbooth/credential_templates.py
@@ -23,8 +23,8 @@ class CredentialTemplate:
     """Schema for a service's credential payload.
 
     Operators declare expected fields; incoming payloads are validated
-    against this schema.  Unknown fields are rejected, required fields
-    enforced, and the ``description`` is rendered for the end user.
+    against this schema.  Unknown fields are silently ignored, required
+    fields enforced, and the ``description`` is rendered for the end user.
     """
 
     service: str
@@ -59,14 +59,9 @@ def validate_payload(
     metadata_keys = {"service", "version"}
     payload_fields = {k: v for k, v in payload.items() if k not in metadata_keys}
 
-    # Check for unknown fields
+    # Silently drop fields not declared in the template
     known = set(template.fields.keys())
-    unknown = set(payload_fields.keys()) - known
-    if unknown:
-        raise TemplateValidationError(
-            f"Unknown fields: {', '.join(sorted(unknown))}. "
-            f"Expected: {', '.join(sorted(known))}"
-        )
+    payload_fields = {k: v for k, v in payload_fields.items() if k in known}
 
     # Check required fields
     missing = []

--- a/tests/test_credential_templates.py
+++ b/tests/test_credential_templates.py
@@ -72,8 +72,8 @@ class TestValidatePayload:
         assert "version" not in result
         assert len(result) == 4
 
-    def test_unknown_fields_rejected(self):
-        """Fields not in template are rejected."""
+    def test_unknown_fields_silently_dropped(self):
+        """Fields not in template are silently stripped, known fields pass through."""
         tmpl = _x_api_template()
         payload = {
             "api_key": "key1",
@@ -81,8 +81,23 @@ class TestValidatePayload:
             "access_token": "token1",
             "access_secret": "asecret1",
             "rogue_field": "evil",
+            "notes": "sent from my phone",
         }
-        with pytest.raises(TemplateValidationError, match="Unknown fields.*rogue_field"):
+        result = validate_payload(payload, tmpl)
+        assert "rogue_field" not in result
+        assert "notes" not in result
+        assert result["api_key"] == "key1"
+        assert len(result) == 4
+
+    def test_unknown_fields_do_not_affect_required_check(self):
+        """Extra fields don't mask missing required fields."""
+        tmpl = _x_api_template()
+        payload = {
+            "api_key": "key1",
+            "rogue_field": "evil",
+            "notes": "extra stuff",
+        }
+        with pytest.raises(TemplateValidationError, match="Missing required fields"):
             validate_payload(payload, tmpl)
 
     def test_missing_required_fields(self):

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -399,8 +399,8 @@ class TestReceiveValidation:
                 await ex.receive(sender.public_key.bech32())
 
     @pytest.mark.asyncio
-    async def test_unknown_fields_rejected(self):
-        """Payload with unknown fields is rejected."""
+    async def test_unknown_fields_silently_dropped(self):
+        """Payload with unknown fields has them stripped silently."""
         operator = PrivateKey()
         sender = PrivateKey()
         ex = _make_exchange(nsec=operator.nsec)
@@ -416,8 +416,12 @@ class TestReceiveValidation:
             ex._received_events.append(event)
 
         with patch.object(ex, "_fetch_dms_from_relays"):
-            with pytest.raises(CourierValidationError, match="Unknown fields"):
-                await ex.receive(sender.public_key.bech32())
+            result = await ex.receive(sender.public_key.bech32())
+        assert result["success"] is True
+        creds = result["credentials"]
+        assert "rogue_field" not in creds
+        assert creds["api_key"] == "key"
+        assert creds["api_secret"] == "secret"
 
     @pytest.mark.asyncio
     async def test_missing_required_fields_rejected(self):


### PR DESCRIPTION
## Summary
- Unknown fields in credential payloads are now silently dropped instead of rejected with `TemplateValidationError`
- Users can include extra metadata, notes, or client-injected fields without triggering validation errors
- Required field checks and type validation remain enforced as before

## Test plan
- [x] `test_unknown_fields_silently_dropped` — verifies unknown fields are stripped, known fields pass through
- [x] `test_unknown_fields_do_not_affect_required_check` — verifies extra fields don't mask missing required fields
- [x] Integration test in `test_nostr_credentials.py` updated to verify end-to-end tolerant behavior
- [x] Full suite: 992 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)