### PR TITLE
feat: QR credential card for scan-and-paste reuse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.59"
+version = "0.1.60"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,6 +32,7 @@ dependencies = [
 nostr = [
     "websocket-client>=1.6.0",
 ]
+qr = ["segno>=1.6.0"]
 ots = []  # Reserved — no extra deps needed (uses stdlib hashlib + existing httpx)
 constraints = []  # No external deps — stdlib only (datetime, zoneinfo, re)
 dev = [

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -58,6 +58,25 @@ except ImportError:
     SecureCourierService = None  # type: ignore[assignment,misc]
 
 try:
+    from tollbooth.credential_card import (
+        CREDENTIAL_CARD_KIND,
+        CredentialCardError,
+        CredentialCardExpired,
+        CredentialCardInvalid,
+        decode_credential_card,
+        encode_credential_card,
+        render_qr,
+    )
+except ImportError:
+    CREDENTIAL_CARD_KIND = None  # type: ignore[assignment,misc]
+    CredentialCardError = None  # type: ignore[assignment,misc]
+    CredentialCardExpired = None  # type: ignore[assignment,misc]
+    CredentialCardInvalid = None  # type: ignore[assignment,misc]
+    decode_credential_card = None  # type: ignore[assignment,misc]
+    encode_credential_card = None  # type: ignore[assignment,misc]
+    render_qr = None  # type: ignore[assignment,misc]
+
+try:
     from tollbooth.nostr_diagnostics import courier_health, courier_ping
 except ImportError:
     courier_health = None  # type: ignore[assignment,misc]
@@ -158,6 +177,14 @@ __all__ = [
     "FieldSpec",
     "TemplateValidationError",
     "SecureCourierService",
+    # Credential Card
+    "CREDENTIAL_CARD_KIND",
+    "CredentialCardError",
+    "CredentialCardExpired",
+    "CredentialCardInvalid",
+    "encode_credential_card",
+    "decode_credential_card",
+    "render_qr",
     "courier_health",
     "courier_ping",
     "NotificationManager",

--- a/src/tollbooth/credential_card.py
+++ b/src/tollbooth/credential_card.py
@@ -1,0 +1,331 @@
+"""QR Credential Card — scan-and-paste credential reuse for Secure Courier.
+
+Returning users can scan a QR code or paste an ``ncred1...`` string to
+reactivate credentials without re-typing.  The card is a self-contained
+Nostr event (kind 21420) with NIP-44 encrypted credentials, Schnorr-signed
+by the operator, and bech32-encoded with HRP ``ncred``.
+
+Encoding flow::
+
+    credentials dict
+      → JSON → NIP-44 encrypt(operator_nsec, user_npub)
+      → kind-21420 event with service/expiry tags
+      → sign(operator_nsec)
+      → JSON serialize → bech32("ncred", ...)
+      → ncred1<data>
+
+Decoding flow::
+
+    ncred1<data>
+      → bech32 decode → JSON → Event
+      → verify signature
+      → check expiration
+      → NIP-44 decrypt(operator_nsec, tagged user_npub)
+      → credentials dict
+
+Dependencies: pynostr (core dep), segno (optional, for QR rendering).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Custom Nostr event kind for credential cards
+CREDENTIAL_CARD_KIND = 21420
+
+# Default expiry for credential cards
+DEFAULT_EXPIRY_DAYS = 90
+
+# ── Exceptions ─────────────────────────────────────────────────────────
+
+
+class CredentialCardError(Exception):
+    """Base error for credential card operations."""
+
+
+class CredentialCardExpired(CredentialCardError):
+    """Raised when a credential card has expired."""
+
+
+class CredentialCardInvalid(CredentialCardError):
+    """Raised when a credential card fails validation (bad sig, corrupt data, etc.)."""
+
+
+# ── Bech32 ncred encoding ─────────────────────────────────────────────
+
+try:
+    from pynostr.bech32 import (  # type: ignore[import-untyped]
+        Encoding,
+        bech32_decode,
+        bech32_encode,
+        convertbits,
+    )
+    from pynostr.event import Event  # type: ignore[import-untyped]
+    from pynostr.key import PrivateKey, PublicKey  # type: ignore[import-untyped]
+
+    _HAS_PYNOSTR = True
+except ImportError:
+    _HAS_PYNOSTR = False
+
+try:
+    from tollbooth.nip44 import decrypt as _nip44_decrypt
+    from tollbooth.nip44 import encrypt as _nip44_encrypt
+
+    _HAS_NIP44 = True
+except ImportError:
+    _HAS_NIP44 = False
+
+_HRP = "ncred"
+
+
+def _ncred_encode(event_json_bytes: bytes) -> str:
+    """Encode raw bytes as ``ncred1<bech32data>``."""
+    if not _HAS_PYNOSTR:
+        raise CredentialCardError("pynostr required for ncred encoding")
+    bits5 = convertbits(event_json_bytes, 8, 5)
+    return bech32_encode(_HRP, bits5, Encoding.BECH32)
+
+
+def _ncred_decode(ncred: str) -> dict[str, Any]:
+    """Decode ``ncred1<bech32data>`` back to the event dict."""
+    if not _HAS_PYNOSTR:
+        raise CredentialCardError("pynostr required for ncred decoding")
+
+    hrp, bits5, spec = bech32_decode(ncred.lower())
+    if hrp != _HRP:
+        raise CredentialCardInvalid(
+            f"Invalid credential card prefix: expected '{_HRP}', got '{hrp}'"
+        )
+    if bits5 is None:
+        raise CredentialCardInvalid("Corrupt credential card: bech32 decode failed")
+
+    raw = bytes(convertbits(bits5, 5, 8, False))
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise CredentialCardInvalid(f"Corrupt credential card payload: {exc}") from exc
+
+
+# ── Public API ─────────────────────────────────────────────────────────
+
+
+def encode_credential_card(
+    credentials: dict[str, str],
+    service: str,
+    operator_nsec: str,
+    user_npub: str,
+    *,
+    expiry_days: int = DEFAULT_EXPIRY_DAYS,
+) -> str:
+    """Build a kind-21420 credential card event and encode as ``ncred1...``.
+
+    Args:
+        credentials: Field name → value mapping to encrypt.
+        service: Service identifier (e.g. ``"thebrain"``).
+        operator_nsec: Operator's Nostr nsec (bech32).
+        user_npub: Patron's npub (bech32) — used as NIP-44 encryption target.
+        expiry_days: Card validity in days (default 90).
+
+    Returns:
+        ``ncred1<bech32data>`` string.
+
+    Raises:
+        CredentialCardError: If dependencies are missing or encoding fails.
+    """
+    if not _HAS_PYNOSTR:
+        raise CredentialCardError("pynostr required for credential cards")
+    if not _HAS_NIP44:
+        raise CredentialCardError("NIP-44 module required for credential cards")
+
+    try:
+        pk = PrivateKey.from_nsec(operator_nsec)
+    except Exception as exc:
+        raise CredentialCardError(f"Invalid operator nsec: {exc}") from exc
+
+    try:
+        user_hex = PublicKey.from_npub(user_npub).hex()
+    except Exception as exc:
+        raise CredentialCardError(f"Invalid user npub: {exc}") from exc
+
+    operator_privkey_hex = pk.hex()
+    operator_pubkey_hex = pk.public_key.hex()
+
+    now = int(time.time())
+    expires_at = now + (expiry_days * 86400)
+
+    # NIP-44 encrypt the credentials JSON
+    encrypted_content = _nip44_encrypt(
+        json.dumps(credentials),
+        operator_privkey_hex,
+        user_hex,
+    )
+
+    event = Event(
+        kind=CREDENTIAL_CARD_KIND,
+        content=encrypted_content,
+        tags=[
+            ["service", service],
+            ["v", "1"],
+            ["p", user_hex],
+            ["expiration", str(expires_at)],
+        ],
+        pubkey=operator_pubkey_hex,
+        created_at=now,
+    )
+    event.sign(operator_privkey_hex)
+
+    event_json = json.dumps(event.to_dict(), separators=(",", ":"))
+    return _ncred_encode(event_json.encode("utf-8"))
+
+
+def decode_credential_card(
+    ncred: str,
+    operator_nsec: str,
+) -> dict[str, Any]:
+    """Decode and verify an ``ncred1...`` credential card.
+
+    Args:
+        ncred: The ``ncred1...`` bech32 string.
+        operator_nsec: Operator's Nostr nsec for decryption and sig verification.
+
+    Returns:
+        Dict with keys: ``service``, ``credentials``, ``user_npub``,
+        ``issued_at``, ``expires_at``.
+
+    Raises:
+        CredentialCardInvalid: Bad signature, wrong operator, corrupt data.
+        CredentialCardExpired: Card past its expiration date.
+    """
+    if not _HAS_PYNOSTR:
+        raise CredentialCardError("pynostr required for credential cards")
+    if not _HAS_NIP44:
+        raise CredentialCardError("NIP-44 module required for credential cards")
+
+    # Decode bech32 → event dict
+    event_dict = _ncred_decode(ncred)
+
+    # Reconstruct Event for signature verification
+    try:
+        event = Event(
+            id=event_dict["id"],
+            kind=event_dict["kind"],
+            content=event_dict["content"],
+            tags=event_dict["tags"],
+            pubkey=event_dict["pubkey"],
+            created_at=event_dict["created_at"],
+            sig=event_dict["sig"],
+        )
+    except (KeyError, TypeError) as exc:
+        raise CredentialCardInvalid(
+            f"Malformed credential card event: {exc}"
+        ) from exc
+
+    # Verify kind
+    if event.kind != CREDENTIAL_CARD_KIND:
+        raise CredentialCardInvalid(
+            f"Wrong event kind: expected {CREDENTIAL_CARD_KIND}, got {event.kind}"
+        )
+
+    # Verify signature
+    try:
+        pk = PrivateKey.from_nsec(operator_nsec)
+    except Exception as exc:
+        raise CredentialCardError(f"Invalid operator nsec: {exc}") from exc
+
+    if event.pubkey != pk.public_key.hex():
+        raise CredentialCardInvalid(
+            "Credential card was not signed by this operator"
+        )
+
+    if not event.verify():
+        raise CredentialCardInvalid(
+            "Credential card signature verification failed"
+        )
+
+    # Extract tags
+    tags = {tag[0]: tag[1] for tag in event.tags if len(tag) >= 2}
+
+    service = tags.get("service")
+    if not service:
+        raise CredentialCardInvalid("Credential card missing 'service' tag")
+
+    user_hex = tags.get("p")
+    if not user_hex:
+        raise CredentialCardInvalid("Credential card missing 'p' tag (user pubkey)")
+
+    expiration_str = tags.get("expiration")
+    if not expiration_str:
+        raise CredentialCardInvalid("Credential card missing 'expiration' tag")
+
+    try:
+        expires_at = int(expiration_str)
+    except ValueError as exc:
+        raise CredentialCardInvalid(
+            f"Invalid expiration timestamp: {expiration_str}"
+        ) from exc
+
+    # Check expiration
+    if time.time() > expires_at:
+        raise CredentialCardExpired(
+            f"Credential card expired at {expires_at} "
+            f"({int(time.time()) - expires_at} seconds ago)"
+        )
+
+    # Decrypt credentials
+    operator_privkey_hex = pk.hex()
+    try:
+        plaintext = _nip44_decrypt(event.content, operator_privkey_hex, user_hex)
+        credentials = json.loads(plaintext)
+    except Exception as exc:
+        raise CredentialCardInvalid(
+            f"Failed to decrypt credential card content: {exc}"
+        ) from exc
+
+    if not isinstance(credentials, dict):
+        raise CredentialCardInvalid("Decrypted content is not a JSON object")
+
+    user_npub = PublicKey(bytes.fromhex(user_hex)).bech32()
+
+    return {
+        "service": service,
+        "credentials": credentials,
+        "user_npub": user_npub,
+        "issued_at": event.created_at,
+        "expires_at": expires_at,
+    }
+
+
+def render_qr(ncred: str, *, scale: int = 6) -> bytes:
+    """Render an ``ncred1...`` string as a QR code PNG.
+
+    Uppercases the ncred string for optimal QR alphanumeric mode encoding.
+
+    Args:
+        ncred: The ``ncred1...`` bech32 string.
+        scale: Module size in pixels (default 6).
+
+    Returns:
+        PNG image as bytes.
+
+    Raises:
+        CredentialCardError: If segno is not installed or rendering fails.
+    """
+    try:
+        import segno  # type: ignore[import-untyped]
+    except ImportError:
+        raise CredentialCardError(
+            "segno required for QR rendering. Install with: pip install segno"
+        )
+
+    import io
+
+    # Uppercase for QR alphanumeric mode (better capacity)
+    qr = segno.make(ncred.upper())
+    buf = io.BytesIO()
+    qr.save(buf, kind="png", scale=scale)
+    return buf.getvalue()

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -284,6 +284,7 @@ class NostrCredentialExchange:
 
         try:
             pk = PrivateKey.from_nsec(nsec)
+            self._nsec = nsec
             self._privkey_hex = pk.hex()
             self._pubkey_hex = pk.public_key.hex()
             self._npub = pk.public_key.bech32()
@@ -870,6 +871,102 @@ class NostrCredentialExchange:
             "message": (
                 f"Credentials for {resolved} from {sender_npub} "
                 + ("deleted from vault." if deleted else "not found in vault.")
+            ),
+        }
+
+    async def redeem_credential_card(
+        self, ncred: str, *, service: str | None = None,
+    ) -> dict[str, Any]:
+        """Redeem an ``ncred1...`` credential card — bypass relay DM flow.
+
+        Decodes the card, verifies signature and expiration, validates
+        against the matching template, and stores in vault if configured.
+
+        Args:
+            ncred: The ``ncred1...`` bech32 credential card string.
+            service: Optional service hint for template matching.
+                If omitted, uses the service from the card.
+
+        Returns:
+            Dict with same shape as ``receive()`` — success, service,
+            field counts, and credentials.
+
+        Raises:
+            CourierNotReady: If dependencies are missing.
+            CourierValidationError: If card fails validation.
+        """
+        if not self._enabled:
+            raise CourierNotReady(
+                "Secure Courier not available. Check logs for missing dependencies."
+            )
+
+        try:
+            from tollbooth.credential_card import (
+                CredentialCardError,
+                CredentialCardExpired,
+                CredentialCardInvalid,
+                decode_credential_card,
+            )
+        except ImportError:
+            raise CourierNotReady(
+                "credential_card module not available"
+            )
+
+        try:
+            decoded = decode_credential_card(ncred, self._nsec)
+        except CredentialCardExpired as exc:
+            raise CourierValidationError(f"Credential card expired: {exc}") from exc
+        except (CredentialCardInvalid, CredentialCardError) as exc:
+            raise CourierValidationError(f"Invalid credential card: {exc}") from exc
+
+        card_service = decoded["service"]
+        credentials = decoded["credentials"]
+        user_npub = decoded["user_npub"]
+
+        # Resolve service: prefer explicit param, fall back to card's service
+        resolved = self._resolve_service(service) or card_service
+
+        # Validate against template
+        if resolved in self._templates:
+            template = self._templates[resolved]
+            try:
+                credentials = validate_payload(credentials, template)
+            except TemplateValidationError as exc:
+                raise CourierValidationError(str(exc)) from exc
+        elif service is not None:
+            # Explicit service requested but no template found
+            raise CourierValidationError(
+                f"No template found for service '{service}'"
+            )
+
+        # Store in vault
+        if self._credential_vault is not None and resolved:
+            await self._vault_store(resolved, user_npub, credentials)
+
+        # Count sensitive fields
+        sensitive_count = 0
+        if resolved and resolved in self._templates:
+            template = self._templates[resolved]
+            sensitive_count = sum(
+                1 for name in credentials
+                if template.fields.get(name, FieldSpec()).sensitive
+            )
+
+        return {
+            "success": True,
+            "service": resolved or card_service,
+            "fields_received": len(credentials),
+            "sensitive_fields": sensitive_count,
+            "encryption": "credential_card",
+            "credentials": credentials,
+            "user_npub": user_npub,
+            "message": (
+                f"Credentials for {resolved or card_service} redeemed from "
+                f"credential card ({len(credentials)} fields)."
+                + (
+                    " Credentials stored in vault for future sessions."
+                    if self._credential_vault is not None else ""
+                )
             ),
         }
 

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -48,6 +48,17 @@ try:
 except ImportError:
     _HAS_COURIER = False
 
+try:
+    from tollbooth.credential_card import (
+        CredentialCardError,
+        encode_credential_card,
+        render_qr,
+    )
+
+    _HAS_CREDENTIAL_CARD = True
+except ImportError:
+    _HAS_CREDENTIAL_CARD = False
+
 
 class SecureCourierService:
     """Reusable Secure Courier -- operators import and wire 3 MCP tools.
@@ -96,6 +107,8 @@ class SecureCourierService:
                 "Secure Courier dependencies not installed. "
                 "Install with: pip install tollbooth-dpyc[nostr]"
             )
+
+        self._operator_nsec = operator_nsec
 
         self._exchange = NostrCredentialExchange(
             nsec=operator_nsec,
@@ -199,6 +212,22 @@ class SecureCourierService:
                     )
                     result["callback_error"] = str(exc)
 
+            # Generate credential card for scan-and-paste reuse
+            if _HAS_CREDENTIAL_CARD:
+                try:
+                    ncred, qr_png = self.generate_credential_card(
+                        sender_npub, matched_service, credentials,
+                    )
+                    result["credential_card"] = ncred
+                    if qr_png is not None:
+                        import base64
+
+                        result["credential_card_qr_base64"] = base64.b64encode(
+                            qr_png
+                        ).decode()
+                except Exception as exc:
+                    logger.warning("Credential card generation failed: %s", exc)
+
             # NEVER echo credential values
             result.pop("credentials", None)
 
@@ -219,3 +248,87 @@ class SecureCourierService:
             Dict with success and whether credentials were found.
         """
         return await self._exchange.forget(sender_npub, service=service)
+
+    def generate_credential_card(
+        self,
+        sender_npub: str,
+        service: str,
+        credentials: dict[str, str],
+        *,
+        expiry_days: int = 90,
+    ) -> tuple[str, bytes | None]:
+        """Generate an ``ncred1...`` credential card with optional QR PNG.
+
+        Args:
+            sender_npub: Patron's npub (bech32).
+            service: Service name for the card.
+            credentials: Validated credential dict.
+            expiry_days: Card validity in days.
+
+        Returns:
+            Tuple of (ncred_string, qr_png_bytes_or_None).
+        """
+        if not _HAS_CREDENTIAL_CARD:
+            raise RuntimeError("credential_card module not available")
+
+        ncred = encode_credential_card(
+            credentials, service, self._operator_nsec, sender_npub,
+            expiry_days=expiry_days,
+        )
+
+        qr_png: bytes | None = None
+        try:
+            qr_png = render_qr(ncred)
+        except Exception as exc:
+            logger.debug("QR rendering skipped: %s", exc)
+
+        return ncred, qr_png
+
+    async def redeem_card(
+        self,
+        ncred: str,
+        service: str | None = None,
+    ) -> dict[str, Any]:
+        """Redeem an ``ncred1...`` credential card — bypasses relay DM flow.
+
+        1. Delegates to the exchange for decode/verify/decrypt.
+        2. On success, calls ``on_credentials_received`` if set.
+        3. Merges callback result into the response.
+        4. **Always** strips credential values before returning.
+
+        Args:
+            ncred: The ``ncred1...`` bech32 credential card string.
+            service: Optional service hint for template matching.
+
+        Returns:
+            Dict with success, service, field count, and any callback-added
+            metadata.  **NEVER** returns credential values.
+        """
+        result = await self._exchange.redeem_credential_card(
+            ncred, service=service,
+        )
+
+        if result.get("success") and result.get("credentials"):
+            credentials: dict[str, str] = result["credentials"]
+            matched_service: str = result.get("service", service or "")
+
+            # Invoke operator callback (same pattern as receive())
+            if self._on_received is not None:
+                try:
+                    extra = await self._on_received(
+                        result.get("user_npub", ""),
+                        credentials,
+                        matched_service,
+                    )
+                    if extra and isinstance(extra, dict):
+                        result.update(extra)
+                except Exception as exc:
+                    logger.warning(
+                        "on_credentials_received callback failed: %s", exc,
+                    )
+                    result["callback_error"] = str(exc)
+
+            # NEVER echo credential values
+            result.pop("credentials", None)
+
+        return result

--- a/tests/test_credential_card.py
+++ b/tests/test_credential_card.py
@@ -1,0 +1,311 @@
+"""Tests for QR Credential Card — ncred encoding, encrypt/decrypt roundtrip, QR rendering."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+from pynostr.event import Event
+from pynostr.key import PrivateKey, PublicKey
+
+from tollbooth.credential_card import (
+    CREDENTIAL_CARD_KIND,
+    DEFAULT_EXPIRY_DAYS,
+    CredentialCardError,
+    CredentialCardExpired,
+    CredentialCardInvalid,
+    _ncred_decode,
+    _ncred_encode,
+    decode_credential_card,
+    encode_credential_card,
+    render_qr,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def operator_key():
+    return PrivateKey()
+
+
+@pytest.fixture
+def user_key():
+    return PrivateKey()
+
+
+@pytest.fixture
+def operator_nsec(operator_key):
+    return operator_key.nsec
+
+
+@pytest.fixture
+def user_npub(user_key):
+    return user_key.public_key.bech32()
+
+
+@pytest.fixture
+def sample_credentials():
+    return {"api_key": "sk-test-abc123", "brain_id": "9e115e02-fedb-4254-a1ae-39cce16c63e6"}
+
+
+# ── TestNcredEncoding ──────────────────────────────────────────────────
+
+
+class TestNcredEncoding:
+    """Bech32 roundtrip, invalid prefix, corrupt checksum."""
+
+    def test_roundtrip(self):
+        """Encode → decode preserves bytes exactly."""
+        data = json.dumps({"hello": "world"}).encode("utf-8")
+        ncred = _ncred_encode(data)
+        assert ncred.startswith("ncred1")
+        decoded = _ncred_decode(ncred)
+        assert decoded == {"hello": "world"}
+
+    def test_large_payload_roundtrip(self):
+        """Large JSON payloads survive encoding."""
+        big = {"key": "x" * 500}
+        data = json.dumps(big).encode("utf-8")
+        ncred = _ncred_encode(data)
+        decoded = _ncred_decode(ncred)
+        assert decoded == big
+
+    def test_invalid_prefix_rejected(self):
+        """Non-ncred bech32 strings are rejected."""
+        # Encode with a different HRP
+        from pynostr.bech32 import Encoding, bech32_encode, convertbits
+
+        bits5 = convertbits(b"test", 8, 5)
+        wrong_hrp = bech32_encode("wrong", bits5, Encoding.BECH32)
+        with pytest.raises(CredentialCardInvalid, match="Invalid credential card prefix"):
+            _ncred_decode(wrong_hrp)
+
+    def test_corrupt_checksum_rejected(self):
+        """Corrupted bech32 checksum fails decode."""
+        data = json.dumps({"a": 1}).encode("utf-8")
+        ncred = _ncred_encode(data)
+        # Flip last char to corrupt checksum
+        corrupted = ncred[:-1] + ("q" if ncred[-1] != "q" else "p")
+        with pytest.raises(CredentialCardInvalid):
+            _ncred_decode(corrupted)
+
+
+# ── TestEncodeDecodeRoundtrip ──────────────────────────────────────────
+
+
+class TestEncodeDecodeRoundtrip:
+    """Full cycle with real keys — preserves credentials, service, user_npub."""
+
+    def test_basic_roundtrip(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "thebrain", operator_nsec, user_npub,
+        )
+        assert ncred.startswith("ncred1")
+
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["service"] == "thebrain"
+        assert result["credentials"] == sample_credentials
+        assert result["user_npub"] == user_npub
+        assert result["issued_at"] > 0
+        assert result["expires_at"] > result["issued_at"]
+
+    def test_custom_expiry(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "myservice", operator_nsec, user_npub,
+            expiry_days=7,
+        )
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["expires_at"] - result["issued_at"] == 7 * 86400
+
+    def test_default_expiry(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["expires_at"] - result["issued_at"] == DEFAULT_EXPIRY_DAYS * 86400
+
+    def test_different_services(self, operator_nsec, user_npub):
+        for svc in ("thebrain", "myapp", "test-service"):
+            ncred = encode_credential_card(
+                {"key": "val"}, svc, operator_nsec, user_npub,
+            )
+            result = decode_credential_card(ncred, operator_nsec)
+            assert result["service"] == svc
+
+    def test_unicode_credentials(self, operator_nsec, user_npub):
+        creds = {"name": "José García", "token": "日本語テスト"}
+        ncred = encode_credential_card(creds, "test", operator_nsec, user_npub)
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["credentials"] == creds
+
+
+# ── TestExpiration ─────────────────────────────────────────────────────
+
+
+class TestExpiration:
+    """Expired cards rejected, valid cards accepted."""
+
+    def test_expired_card_rejected(self, operator_nsec, user_npub, sample_credentials):
+        # Create card with 1-day expiry, then simulate time passing
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub, expiry_days=1,
+        )
+        # Fast-forward 2 days
+        future = time.time() + 2 * 86400
+        with patch("tollbooth.credential_card.time") as mock_time:
+            mock_time.time.return_value = future
+            with pytest.raises(CredentialCardExpired, match="expired"):
+                decode_credential_card(ncred, operator_nsec)
+
+    def test_valid_card_accepted(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub, expiry_days=90,
+        )
+        # Should not raise
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["credentials"] == sample_credentials
+
+
+# ── TestSignatureVerification ──────────────────────────────────────────
+
+
+class TestSignatureVerification:
+    """Tampered content, wrong operator, forged sig."""
+
+    def test_tampered_content_rejected(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        # Decode the bech32, tamper with content, re-encode
+        event_dict = _ncred_decode(ncred)
+        event_dict["content"] = "tampered"
+        tampered_json = json.dumps(event_dict, separators=(",", ":")).encode("utf-8")
+        tampered_ncred = _ncred_encode(tampered_json)
+
+        with pytest.raises(CredentialCardInvalid, match="signature verification failed"):
+            decode_credential_card(tampered_ncred, operator_nsec)
+
+    def test_wrong_operator_rejected(self, user_npub, sample_credentials):
+        operator1 = PrivateKey()
+        operator2 = PrivateKey()
+
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator1.nsec, user_npub,
+        )
+        with pytest.raises(CredentialCardInvalid, match="not signed by this operator"):
+            decode_credential_card(ncred, operator2.nsec)
+
+    def test_forged_sig_rejected(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        # Replace sig with a different key's signature
+        event_dict = _ncred_decode(ncred)
+        forger = PrivateKey()
+        # Create a valid event from forger but with our operator's pubkey
+        event_dict["sig"] = "0" * 128  # invalid sig
+        forged_json = json.dumps(event_dict, separators=(",", ":")).encode("utf-8")
+        forged_ncred = _ncred_encode(forged_json)
+
+        with pytest.raises(CredentialCardInvalid, match="signature verification failed"):
+            decode_credential_card(forged_ncred, operator_nsec)
+
+
+# ── TestDecryption ─────────────────────────────────────────────────────
+
+
+class TestDecryption:
+    """Uses tagged p-tag for shared secret, missing p-tag rejected."""
+
+    def test_uses_p_tag_for_decryption(self, operator_nsec, user_npub, sample_credentials):
+        """Decryption uses the p-tag user pubkey, not a hardcoded value."""
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        result = decode_credential_card(ncred, operator_nsec)
+        assert result["user_npub"] == user_npub
+        assert result["credentials"] == sample_credentials
+
+    def test_missing_p_tag_rejected(self, operator_nsec, user_npub, sample_credentials):
+        """Card with p-tag removed should fail."""
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        event_dict = _ncred_decode(ncred)
+        # Remove p-tag
+        event_dict["tags"] = [t for t in event_dict["tags"] if t[0] != "p"]
+        # Re-sign with the operator key (so sig is valid but p-tag missing)
+        pk = PrivateKey.from_nsec(operator_nsec)
+        event = Event(
+            kind=event_dict["kind"],
+            content=event_dict["content"],
+            tags=event_dict["tags"],
+            pubkey=pk.public_key.hex(),
+            created_at=event_dict["created_at"],
+        )
+        event.sign(pk.hex())
+        modified_json = json.dumps(event.to_dict(), separators=(",", ":")).encode("utf-8")
+        modified_ncred = _ncred_encode(modified_json)
+
+        with pytest.raises(CredentialCardInvalid, match="missing 'p' tag"):
+            decode_credential_card(modified_ncred, operator_nsec)
+
+
+# ── TestQRRendering ────────────────────────────────────────────────────
+
+
+class TestQRRendering:
+    """Produces valid PNG, realistic payload renders, scale parameter."""
+
+    def test_produces_valid_png(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        png = render_qr(ncred)
+        # PNG magic bytes
+        assert png[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_realistic_payload_renders(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "thebrain", operator_nsec, user_npub,
+        )
+        png = render_qr(ncred)
+        assert len(png) > 100  # non-trivial image
+
+    def test_scale_parameter(self, operator_nsec, user_npub, sample_credentials):
+        ncred = encode_credential_card(
+            sample_credentials, "x", operator_nsec, user_npub,
+        )
+        small = render_qr(ncred, scale=2)
+        large = render_qr(ncred, scale=10)
+        assert len(large) > len(small)
+
+
+# ── TestCapacity ───────────────────────────────────────────────────────
+
+
+class TestCapacity:
+    """2-field payload under 1500 chars, 5-field payload under 4296 chars."""
+
+    def test_two_field_under_1500(self, operator_nsec, user_npub):
+        creds = {
+            "api_key": "sk-test-" + "a" * 40,
+            "brain_id": "9e115e02-fedb-4254-a1ae-39cce16c63e6",
+        }
+        ncred = encode_credential_card(creds, "thebrain", operator_nsec, user_npub)
+        assert len(ncred) < 1500, f"2-field ncred too long: {len(ncred)} chars"
+
+    def test_five_field_under_4296(self, operator_nsec, user_npub):
+        creds = {
+            "api_key": "sk-test-" + "a" * 40,
+            "brain_id": "9e115e02-fedb-4254-a1ae-39cce16c63e6",
+            "secret_token": "tok-" + "b" * 60,
+            "endpoint": "https://api.example.com/v1/long/path/endpoint",
+            "org_id": "org-" + "c" * 40,
+        }
+        ncred = encode_credential_card(creds, "thebrain", operator_nsec, user_npub)
+        assert len(ncred) < 4296, f"5-field ncred too long: {len(ncred)} chars"


### PR DESCRIPTION
## Summary
- New `credential_card.py` module: `encode_credential_card()`, `decode_credential_card()`, `render_qr()` using kind-21420 Nostr events with NIP-44 encryption and `ncred1...` bech32 encoding
- `NostrCredentialExchange`: stores nsec bech32, adds `redeem_credential_card()` method for card-based credential redemption
- `SecureCourierService`: generates credential cards automatically on `receive()`, adds `redeem_card()` for bypassing relay DM flow
- Version bump 0.1.59 → 0.1.60, new `qr` optional dependency (`segno>=1.6.0`)

## Test plan
- [x] 21 new tests in `test_credential_card.py` (encoding roundtrip, expiry, signature verification, QR rendering, capacity)
- [x] Full suite: 1013 tests pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)