### PR TITLE
feat: add probe_relay_liveness for dynamic relay negotiation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.60"
+version = "0.1.61"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -50,3 +50,4 @@ packages = ["src/tollbooth"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -77,10 +77,11 @@ except ImportError:
     render_qr = None  # type: ignore[assignment,misc]
 
 try:
-    from tollbooth.nostr_diagnostics import courier_health, courier_ping
+    from tollbooth.nostr_diagnostics import courier_health, courier_ping, probe_relay_liveness
 except ImportError:
     courier_health = None  # type: ignore[assignment,misc]
     courier_ping = None  # type: ignore[assignment,misc]
+    probe_relay_liveness = None  # type: ignore[assignment,misc]
 
 try:
     from tollbooth.nostr_notifications import NotificationManager, NotificationPreferences
@@ -187,6 +188,7 @@ __all__ = [
     "render_qr",
     "courier_health",
     "courier_ping",
+    "probe_relay_liveness",
     "NotificationManager",
     "NotificationPreferences",
     # Constraint Engine

--- a/src/tollbooth/nostr_diagnostics.py
+++ b/src/tollbooth/nostr_diagnostics.py
@@ -134,31 +134,41 @@ def _extract_nip_support(nip11: dict[str, Any]) -> dict[str, bool]:
     }
 
 
-def _test_ws_connectivity(
+def test_ws_connectivity(
     relay_url: str,
+    *,
+    timeout: int | None = None,
 ) -> dict[str, Any]:
     """Test WebSocket connectivity to a single relay.
 
+    Args:
+        relay_url: WebSocket URL of the relay (e.g. ``wss://nostr.wine``).
+        timeout: Connection timeout in seconds. Defaults to module-level
+            ``_WS_CONNECT_TIMEOUT`` (10s).
+
     Returns:
-        Dict with ``connected`` (bool), ``latency_ms`` (float or None),
-        and ``error`` (str or None).
+        Dict with ``relay`` (str), ``connected`` (bool),
+        ``latency_ms`` (float or None), and ``error`` (str or None).
     """
     if not _HAS_WEBSOCKET:
         return {
+            "relay": relay_url,
             "connected": False,
             "latency_ms": None,
             "error": "websocket-client not installed",
         }
 
+    effective_timeout = timeout if timeout is not None else _WS_CONNECT_TIMEOUT
     t0 = time.monotonic()
     try:
-        ws = create_connection(relay_url, timeout=_WS_CONNECT_TIMEOUT)
+        ws = create_connection(relay_url, timeout=effective_timeout)
         latency = (time.monotonic() - t0) * 1000
         try:
             ws.close()
         except Exception:
             pass
         return {
+            "relay": relay_url,
             "connected": True,
             "latency_ms": round(latency, 1),
             "error": None,
@@ -166,10 +176,35 @@ def _test_ws_connectivity(
     except Exception as exc:
         latency = (time.monotonic() - t0) * 1000
         return {
+            "relay": relay_url,
             "connected": False,
             "latency_ms": round(latency, 1),
             "error": str(exc),
         }
+
+
+# Backward-compat alias (used internally in this module)
+_test_ws_connectivity = test_ws_connectivity
+
+
+def probe_relay_liveness(
+    relay_urls: list[str],
+    *,
+    timeout: int = 5,
+) -> list[dict[str, Any]]:
+    """Probe WebSocket connectivity for a list of relays.
+
+    Returns a list of dicts: ``{relay, connected, latency_ms, error}``.
+    Sorted: connected relays first (by latency), then disconnected.
+
+    Args:
+        relay_urls: Relay WebSocket URLs to probe.
+        timeout: Per-relay connection timeout in seconds (default 5).
+    """
+    results = [test_ws_connectivity(url, timeout=timeout) for url in relay_urls]
+    # Sort: connected first (by latency), then disconnected
+    results.sort(key=lambda r: (not r["connected"], r["latency_ms"] or float("inf")))
+    return results
 
 
 def _test_subscription_filter(

--- a/tests/test_relay_probe.py
+++ b/tests/test_relay_probe.py
@@ -1,0 +1,141 @@
+"""Tests for probe_relay_liveness and public test_ws_connectivity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tollbooth.nostr_diagnostics import probe_relay_liveness
+from tollbooth import nostr_diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_create_connection_factory(live_relays: dict[str, float]):
+    """Return a mock create_connection that succeeds for relays in *live_relays*.
+
+    *live_relays* maps relay URL → simulated latency in seconds.
+    Unlisted relays raise ConnectionRefusedError.
+    """
+
+    def _mock_create(url, timeout=10):
+        if url in live_relays:
+            ws = MagicMock()
+            ws.close = MagicMock()
+            return ws
+        raise ConnectionRefusedError(f"Connection refused: {url}")
+
+    return _mock_create
+
+
+# ---------------------------------------------------------------------------
+# TestProbeRelayLiveness
+# ---------------------------------------------------------------------------
+
+class TestProbeRelayLiveness:
+    """Tests for probe_relay_liveness()."""
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_all_reachable_sorted_by_latency(self, mock_cc):
+        """All relays connect — results sorted by latency (lowest first)."""
+        relays = ["wss://a.example", "wss://b.example", "wss://c.example"]
+        mock_cc.side_effect = _mock_create_connection_factory({r: 0.01 for r in relays})
+
+        results = probe_relay_liveness(relays, timeout=3)
+
+        assert len(results) == 3
+        for r in results:
+            assert r["connected"] is True
+            assert r["error"] is None
+            assert r["latency_ms"] is not None
+        # All connected — sorted by latency ascending
+        latencies = [r["latency_ms"] for r in results]
+        assert latencies == sorted(latencies)
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_some_down_connected_first(self, mock_cc):
+        """Mixed liveness — connected relays appear before disconnected."""
+        live = {"wss://good.example": 0.005}
+        mock_cc.side_effect = _mock_create_connection_factory(live)
+
+        relays = ["wss://bad.example", "wss://good.example"]
+        results = probe_relay_liveness(relays, timeout=2)
+
+        assert len(results) == 2
+        assert results[0]["connected"] is True
+        assert results[0]["relay"] == "wss://good.example"
+        assert results[1]["connected"] is False
+        assert results[1]["relay"] == "wss://bad.example"
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_all_down(self, mock_cc):
+        """All relays down — every result has connected=False."""
+        mock_cc.side_effect = ConnectionRefusedError("nope")
+
+        relays = ["wss://a.example", "wss://b.example"]
+        results = probe_relay_liveness(relays, timeout=2)
+
+        assert len(results) == 2
+        for r in results:
+            assert r["connected"] is False
+            assert r["error"] is not None
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_custom_timeout_passed_through(self, mock_cc):
+        """Custom timeout is forwarded to create_connection."""
+        mock_cc.side_effect = _mock_create_connection_factory({"wss://r.example": 0.001})
+
+        probe_relay_liveness(["wss://r.example"], timeout=7)
+
+        mock_cc.assert_called_once_with("wss://r.example", timeout=7)
+
+    def test_empty_list(self):
+        """Empty relay list returns empty results."""
+        results = probe_relay_liveness([], timeout=1)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# TestWsConnectivityPublic
+# ---------------------------------------------------------------------------
+
+class TestWsConnectivityPublic:
+    """Verify test_ws_connectivity is importable and functional."""
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_importable_and_returns_dict(self, mock_cc):
+        """test_ws_connectivity is a public function returning expected keys."""
+        ws = MagicMock()
+        mock_cc.return_value = ws
+
+        result = nostr_diagnostics.test_ws_connectivity("wss://test.example")
+
+        assert isinstance(result, dict)
+        assert result["relay"] == "wss://test.example"
+        assert result["connected"] is True
+        assert result["latency_ms"] is not None
+        assert result["error"] is None
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_custom_timeout(self, mock_cc):
+        """Custom timeout parameter is honoured."""
+        ws = MagicMock()
+        mock_cc.return_value = ws
+
+        nostr_diagnostics.test_ws_connectivity("wss://test.example", timeout=3)
+
+        mock_cc.assert_called_once_with("wss://test.example", timeout=3)
+
+    @patch("tollbooth.nostr_diagnostics.create_connection")
+    def test_connection_failure(self, mock_cc):
+        """Connection failure returns connected=False with error message."""
+        mock_cc.side_effect = ConnectionRefusedError("refused")
+
+        result = nostr_diagnostics.test_ws_connectivity("wss://down.example")
+
+        assert result["connected"] is False
+        assert "refused" in result["error"]
+        assert result["relay"] == "wss://down.example"


### PR DESCRIPTION
## Summary
- Make `test_ws_connectivity` public (keep `_test_ws_connectivity` alias for backward compat)
- Add `probe_relay_liveness()` — probes a list of relays, returns results sorted by liveness/latency
- Export `probe_relay_liveness` from `tollbooth.__init__`
- Add `testpaths = ["tests"]` to pytest config (prevents false collection of `test_*` source functions)
- Bump version to 0.1.61

## Test plan
- [x] 8 new tests in `tests/test_relay_probe.py` (all mocked, no network)
- [x] Full suite: 1021 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)