### PR TITLE
feat: instruct agent to share poison phrase with human

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.61"
+version = "0.1.62"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -584,26 +584,30 @@ class NostrCredentialExchange:
                 result["welcome_dm_sent"] = True
                 result["message"] = (
                     f"A welcome DM has been sent to {recipient_npub}. "
-                    f"Open your Nostr client, find the message, and reply "
-                    f"with your credentials using the @@@ format shown. "
-                    f"Then call receive_credentials with your npub."
+                    f"Tell the user to look for a DM containing the session phrase "
+                    f"\"{poison}\" — share this phrase in chat so they can identify "
+                    f"the correct message. It is not sensitive. "
+                    f"They should reply with their credentials using the @@@ format shown. "
+                    f"Then call receive_credentials with their npub."
                 )
             except Exception as exc:
                 logger.warning("Welcome DM failed, falling back to manual: %s", exc)
                 result["welcome_dm_sent"] = False
                 result["message"] = (
                     f"Could not send welcome DM ({exc}). "
-                    f"Send your {template.service} credentials as a Nostr DM "
-                    f"to {self._npub} from your Nostr client. "
-                    f"Then call receive_credentials with your npub."
+                    f"The user should send their {template.service} credentials as a Nostr DM "
+                    f"to {self._npub} from their Nostr client, including the session phrase "
+                    f"\"{poison}\" — share this phrase in chat so they can include it. "
+                    f"Then call receive_credentials with their npub."
                 )
         else:
             result["welcome_dm_sent"] = False
             result["message"] = (
-                f"Send your {template.service} credentials as a Nostr DM "
-                f"to {self._npub} from your Nostr client. "
-                f"Reply with your credentials using the @@@ format shown above. "
-                f"Then call receive_credentials with your npub."
+                f"The user should send their {template.service} credentials as a Nostr DM "
+                f"to {self._npub} from their Nostr client, including the session phrase "
+                f"\"{poison}\" — share this phrase in chat so they can include it. "
+                f"Reply with credentials using the @@@ format shown above. "
+                f"Then call receive_credentials with their npub."
             )
 
         return result


### PR DESCRIPTION
## Summary
- Update all three `message` paths in `open_channel()` to explicitly tell the AI agent to share the session poison phrase in chat
- The poison phrase helps the human identify the correct DM in their Nostr client
- Not sensitive — it's a session fingerprint only
- Bump version to 0.1.62

## Test plan
- [x] Full suite: 1021 passed
- [ ] Deploy and call `request_credential_channel` — verify message includes poison phrase instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)