### PR TITLE
feat: define OperatorProtocol, AuthorityProtocol, OracleProtocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.62"
+version = "0.1.63"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -14,6 +14,10 @@ from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
 from tollbooth.credential_vault_backend import CredentialVaultBackend
+from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+from tollbooth.operator_protocol import OperatorProtocol
+from tollbooth.authority_protocol import AuthorityProtocol
+from tollbooth.oracle_protocol import OracleProtocol
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
 from tollbooth.pricing import ToolPricing
@@ -146,6 +150,13 @@ __all__ = [
     "BTCPayAuthError",
     "VaultBackend",
     "CredentialVaultBackend",
+    # Actor Protocols
+    "ActorRole",
+    "ToolPath",
+    "ToolPathInfo",
+    "OperatorProtocol",
+    "AuthorityProtocol",
+    "OracleProtocol",
     "LedgerCache",
     "TheBrainVault",
     "NeonVault",

--- a/src/tollbooth/actor_types.py
+++ b/src/tollbooth/actor_types.py
@@ -1,0 +1,63 @@
+"""Supporting types for DPYC actor protocols.
+
+Defines the ActorRole enum, ToolPath enum, and ToolPathInfo frozen
+dataclass used by OperatorProtocol, AuthorityProtocol, and OracleProtocol
+to describe their tool surfaces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ActorRole(str, Enum):
+    """DPYC ecosystem actor types."""
+
+    OPERATOR = "operator"
+    AUTHORITY = "authority"
+    ORACLE = "oracle"
+
+
+class ToolPath(str, Enum):
+    """Categorizes a tool's latency and dependency profile.
+
+    hot — local computation only, no outbound HTTP.
+    cold — requires external I/O (BTCPay, GitHub, etc.).
+    delegation — forwards to another actor via MCP-to-MCP HTTP.
+    """
+
+    HOT = "hot"
+    COLD = "cold"
+    DELEGATION = "delegation"
+
+
+@dataclass(frozen=True)
+class ToolPathInfo:
+    """Metadata for a single tool exposed by a DPYC actor.
+
+    Parameters
+    ----------
+    tool_name : str
+        The tool's registration name (without slug prefix).
+    path : ToolPath
+        Latency/dependency category.
+    delegates_to : ActorRole | None
+        If this tool delegates, which actor handles it.
+    requires_auth : bool
+        Whether the caller must be authenticated.
+    cost_tier : str
+        Billing tier: FREE, READ, WRITE, or HEAVY.
+    agent_hint : str
+        Short routing guidance surfaced in MCP tool descriptions.
+    supersedes : str
+        Migration hint for AI conversations that learned old workflows.
+    """
+
+    tool_name: str
+    path: ToolPath
+    delegates_to: ActorRole | None = None
+    requires_auth: bool = True
+    cost_tier: str = "FREE"
+    agent_hint: str = ""
+    supersedes: str = ""

--- a/src/tollbooth/authority_protocol.py
+++ b/src/tollbooth/authority_protocol.py
@@ -1,0 +1,85 @@
+"""Protocol defining the AuthorityProtocol — certification and operator ledger.
+
+The Authority is the institutional backbone of the Tollbooth ecosystem.
+It registers MCP operators, collects a certification fee via Bitcoin
+Lightning, and issues signed certificates proving an operator has paid.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+
+
+@runtime_checkable
+class AuthorityProtocol(Protocol):
+    """Contract for a DPYC Authority MCP server.
+
+    Hot-path tools operate on the local operator ledger.
+    Cold-path tools reach BTCPay or the DPYC registry.
+    """
+
+    @property
+    def slug(self) -> str:
+        """Short identifier for tool-name prefixing."""
+        ...
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        """Return metadata for every tool this actor exposes."""
+        ...
+
+    # ── Hot-path (local ledger) ──────────────────────────────────
+
+    async def certify_credits(
+        self, operator_id: str, amount_sats: int
+    ) -> dict[str, Any]:
+        """(hot) Core product — certify a credit purchase for an operator."""
+        ...
+
+    async def register_operator(self, npub: str) -> dict[str, Any]:
+        """(hot) Register a new operator in the ledger."""
+        ...
+
+    async def operator_status(self) -> dict[str, Any]:
+        """(hot) Return the calling operator's registration info."""
+        ...
+
+    async def check_balance(self) -> dict[str, Any]:
+        """(hot) Return the calling operator's credit balance."""
+        ...
+
+    async def account_statement(self) -> dict[str, Any]:
+        """(hot) Return the calling operator's transaction history."""
+        ...
+
+    async def account_statement_infographic(self) -> dict[str, Any]:
+        """(hot) Return a visual summary of the operator's account."""
+        ...
+
+    async def service_status(self) -> dict[str, Any]:
+        """(hot) Return the Authority's health and version info."""
+        ...
+
+    async def report_upstream_purchase(
+        self, amount_sats: int
+    ) -> dict[str, Any]:
+        """(hot) Admin-only: record an upstream credit purchase."""
+        ...
+
+    # ── Cold-path (BTCPay) ───────────────────────────────────────
+
+    async def purchase_credits(self, amount_sats: int) -> dict[str, Any]:
+        """(cold) Create a Lightning invoice for credit purchase."""
+        ...
+
+    async def check_payment(self, invoice_id: str) -> dict[str, Any]:
+        """(cold) Poll a Lightning invoice for settlement status."""
+        ...
+
+    # ── Cold-path (registry) ─────────────────────────────────────
+
+    async def check_dpyc_membership(self, npub: str) -> dict[str, Any]:
+        """(cold) Check whether an npub is a registered DPYC member."""
+        ...

--- a/src/tollbooth/operator_protocol.py
+++ b/src/tollbooth/operator_protocol.py
@@ -1,0 +1,112 @@
+"""Protocol defining the OperatorProtocol — user ledger and delegation.
+
+The Operator runs an MCP service and manages patron (user) credit
+balances. It delegates certification to the Authority and community
+queries to the Oracle, either directly or via the Authority.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+
+
+@runtime_checkable
+class OperatorProtocol(Protocol):
+    """Contract for a DPYC Operator MCP server.
+
+    Hot-path tools operate on the local patron ledger.
+    Cold-path tools reach BTCPay or delegate to Authority/Oracle.
+
+    Operator methods take explicit ``npub`` because the patron is
+    always identified by their Nostr public key.
+    """
+
+    @property
+    def slug(self) -> str:
+        """Short identifier for tool-name prefixing."""
+        ...
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        """Return metadata for every tool this actor exposes."""
+        ...
+
+    # ── Hot-path (local ledger) ──────────────────────────────────
+
+    async def check_balance(self, npub: str) -> dict[str, Any]:
+        """(hot) Return the patron's credit balance."""
+        ...
+
+    async def account_statement(self, npub: str) -> dict[str, Any]:
+        """(hot) Return the patron's transaction history."""
+        ...
+
+    async def account_statement_infographic(
+        self, npub: str
+    ) -> dict[str, Any]:
+        """(hot) Return a visual summary of the patron's account."""
+        ...
+
+    async def restore_credits(
+        self, npub: str, invoice_id: str
+    ) -> dict[str, Any]:
+        """(hot) Restore credits from a previously paid invoice."""
+        ...
+
+    async def service_status(self) -> dict[str, Any]:
+        """(hot) Return the Operator's health and version info."""
+        ...
+
+    # ── Cold-path (BTCPay) ───────────────────────────────────────
+
+    async def purchase_credits(
+        self, npub: str, amount_sats: int, certificate: str
+    ) -> dict[str, Any]:
+        """(cold) Create a Lightning invoice for patron credit purchase."""
+        ...
+
+    async def check_payment(
+        self, npub: str, invoice_id: str
+    ) -> dict[str, Any]:
+        """(cold) Poll a Lightning invoice for settlement status."""
+        ...
+
+    # ── Cold-path (delegates to Authority) ───────────────────────
+
+    async def certify_credits(
+        self, operator_id: str, amount_sats: int
+    ) -> dict[str, Any]:
+        """(cold, delegates to Authority) Certify a credit purchase."""
+        ...
+
+    async def register_operator(self, npub: str) -> dict[str, Any]:
+        """(cold, delegates to Authority) Register as an operator."""
+        ...
+
+    async def operator_status(self) -> dict[str, Any]:
+        """(cold, delegates to Authority) Get operator registration info."""
+        ...
+
+    # ── Cold-path (delegates via Authority to Oracle) ────────────
+
+    async def lookup_member(self, npub: str) -> dict[str, Any] | str:
+        """(cold, delegates to Oracle) Look up a DPYC member."""
+        ...
+
+    async def how_to_join(self) -> str:
+        """(cold, delegates to Oracle) Get onboarding instructions."""
+        ...
+
+    async def get_tax_rate(self) -> dict[str, Any]:
+        """(cold, delegates to Oracle) Get the current tax rate."""
+        ...
+
+    async def about(self) -> str:
+        """(cold, delegates to Oracle) Describe the DPYC ecosystem."""
+        ...
+
+    async def network_advisory(self) -> str:
+        """(cold, delegates to Oracle) Get active network advisories."""
+        ...

--- a/src/tollbooth/oracle_protocol.py
+++ b/src/tollbooth/oracle_protocol.py
@@ -1,0 +1,83 @@
+"""Protocol defining the OracleProtocol — free community concierge tools.
+
+The Oracle is a free, unauthenticated concierge that answers questions
+about DPYC membership, governance, onboarding, and tax rates. It does
+not require payment or credentials.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+
+
+@runtime_checkable
+class OracleProtocol(Protocol):
+    """Contract for a DPYC Oracle MCP server.
+
+    All tools are free and unauthenticated. Hot-path tools resolve
+    locally; cold-path tools fetch from the GitHub registry.
+    """
+
+    @property
+    def slug(self) -> str:
+        """Short identifier for tool-name prefixing."""
+        ...
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        """Return metadata for every tool this actor exposes."""
+        ...
+
+    # ── Hot-path (local) ─────────────────────────────────────────
+
+    async def get_tax_rate(self) -> dict[str, Any]:
+        """(hot) Return the current certification tax rate."""
+        ...
+
+    async def how_to_join(self) -> str:
+        """(hot) Return onboarding instructions for new members."""
+        ...
+
+    async def service_status(self) -> dict[str, Any]:
+        """(hot) Return the Oracle's health and version info."""
+        ...
+
+    async def request_citizenship(
+        self, npub: str, display_name: str
+    ) -> dict[str, Any]:
+        """(hot) Begin the citizenship application process."""
+        ...
+
+    # ── Cold-path (GitHub HTTP) ──────────────────────────────────
+
+    async def about(self) -> str:
+        """(cold) Return a description of the DPYC ecosystem."""
+        ...
+
+    async def lookup_member(self, npub: str) -> dict[str, Any] | str:
+        """(cold) Look up a member by their Nostr npub."""
+        ...
+
+    async def get_rulebook(self) -> str:
+        """(cold) Return the community governance rulebook."""
+        ...
+
+    async def who_is_first_curator(self) -> dict[str, Any] | str:
+        """(cold) Identify the Prime Authority / First Curator."""
+        ...
+
+    async def network_versions(self) -> dict[str, Any]:
+        """(cold) Return version info for all network components."""
+        ...
+
+    async def network_advisory(self) -> str:
+        """(cold) Return any active network advisories."""
+        ...
+
+    async def confirm_citizenship(
+        self, npub: str, challenge_id: str, signed_event_json: str
+    ) -> dict[str, Any]:
+        """(cold) Confirm citizenship with a signed Nostr challenge."""
+        ...

--- a/tests/test_actor_types.py
+++ b/tests/test_actor_types.py
@@ -1,0 +1,76 @@
+"""Tests for actor_types module — enums and frozen dataclass."""
+
+import pytest
+
+from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+
+
+class TestActorRole:
+    """ActorRole enum tests."""
+
+    def test_values(self):
+        assert ActorRole.OPERATOR == "operator"
+        assert ActorRole.AUTHORITY == "authority"
+        assert ActorRole.ORACLE == "oracle"
+
+    def test_all_members(self):
+        assert set(ActorRole) == {
+            ActorRole.OPERATOR,
+            ActorRole.AUTHORITY,
+            ActorRole.ORACLE,
+        }
+
+
+class TestToolPath:
+    """ToolPath enum tests."""
+
+    def test_values(self):
+        assert ToolPath.HOT == "hot"
+        assert ToolPath.COLD == "cold"
+        assert ToolPath.DELEGATION == "delegation"
+
+    def test_all_members(self):
+        assert set(ToolPath) == {
+            ToolPath.HOT,
+            ToolPath.COLD,
+            ToolPath.DELEGATION,
+        }
+
+
+class TestToolPathInfo:
+    """ToolPathInfo frozen dataclass tests."""
+
+    def test_creation_with_defaults(self):
+        info = ToolPathInfo(tool_name="check_balance", path=ToolPath.HOT)
+        assert info.tool_name == "check_balance"
+        assert info.path == ToolPath.HOT
+        assert info.delegates_to is None
+        assert info.requires_auth is True
+        assert info.cost_tier == "FREE"
+        assert info.agent_hint == ""
+        assert info.supersedes == ""
+
+    def test_creation_with_all_fields(self):
+        info = ToolPathInfo(
+            tool_name="certify_credits",
+            path=ToolPath.DELEGATION,
+            delegates_to=ActorRole.AUTHORITY,
+            requires_auth=True,
+            cost_tier="HEAVY",
+            agent_hint="Delegates to Authority — may be slow.",
+            supersedes="Previously required separate Authority connection.",
+        )
+        assert info.delegates_to == ActorRole.AUTHORITY
+        assert info.cost_tier == "HEAVY"
+        assert "Authority" in info.agent_hint
+        assert "Previously" in info.supersedes
+
+    def test_frozen_immutability(self):
+        info = ToolPathInfo(tool_name="about", path=ToolPath.COLD)
+        with pytest.raises(AttributeError):
+            info.tool_name = "something_else"  # type: ignore[misc]
+
+    def test_frozen_immutability_path(self):
+        info = ToolPathInfo(tool_name="about", path=ToolPath.COLD)
+        with pytest.raises(AttributeError):
+            info.path = ToolPath.HOT  # type: ignore[misc]

--- a/tests/test_authority_protocol.py
+++ b/tests/test_authority_protocol.py
@@ -1,0 +1,70 @@
+"""Tests for AuthorityProtocol compliance."""
+
+from typing import Any
+
+from tollbooth.actor_types import ToolPath, ToolPathInfo
+from tollbooth.authority_protocol import AuthorityProtocol
+
+
+class StubAuthority:
+    """Minimal stub satisfying AuthorityProtocol."""
+
+    @property
+    def slug(self) -> str:
+        return "authority"
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        return [
+            ToolPathInfo(tool_name="certify_credits", path=ToolPath.HOT),
+        ]
+
+    async def certify_credits(
+        self, operator_id: str, amount_sats: int
+    ) -> dict[str, Any]:
+        return {"certified": True}
+
+    async def register_operator(self, npub: str) -> dict[str, Any]:
+        return {"npub": npub}
+
+    async def operator_status(self) -> dict[str, Any]:
+        return {"status": "active"}
+
+    async def check_balance(self) -> dict[str, Any]:
+        return {"balance": 1000}
+
+    async def account_statement(self) -> dict[str, Any]:
+        return {"transactions": []}
+
+    async def account_statement_infographic(self) -> dict[str, Any]:
+        return {"chart": "..."}
+
+    async def service_status(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+    async def report_upstream_purchase(
+        self, amount_sats: int
+    ) -> dict[str, Any]:
+        return {"reported": True}
+
+    async def purchase_credits(self, amount_sats: int) -> dict[str, Any]:
+        return {"invoice_id": "inv_123"}
+
+    async def check_payment(self, invoice_id: str) -> dict[str, Any]:
+        return {"settled": True}
+
+    async def check_dpyc_membership(self, npub: str) -> dict[str, Any]:
+        return {"member": True}
+
+
+class TestAuthorityProtocol:
+    """Protocol compliance tests."""
+
+    def test_stub_satisfies_protocol(self):
+        """StubAuthority satisfies the AuthorityProtocol."""
+        authority = StubAuthority()
+        assert isinstance(authority, AuthorityProtocol)
+
+    def test_dict_does_not_satisfy(self):
+        """A plain dict does NOT satisfy the protocol."""
+        assert not isinstance({}, AuthorityProtocol)

--- a/tests/test_operator_protocol.py
+++ b/tests/test_operator_protocol.py
@@ -1,0 +1,88 @@
+"""Tests for OperatorProtocol compliance."""
+
+from typing import Any
+
+from tollbooth.actor_types import ToolPath, ToolPathInfo
+from tollbooth.operator_protocol import OperatorProtocol
+
+
+class StubOperator:
+    """Minimal stub satisfying OperatorProtocol."""
+
+    @property
+    def slug(self) -> str:
+        return "brain"
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        return [
+            ToolPathInfo(tool_name="check_balance", path=ToolPath.HOT),
+        ]
+
+    async def check_balance(self, npub: str) -> dict[str, Any]:
+        return {"balance": 500}
+
+    async def account_statement(self, npub: str) -> dict[str, Any]:
+        return {"transactions": []}
+
+    async def account_statement_infographic(
+        self, npub: str
+    ) -> dict[str, Any]:
+        return {"chart": "..."}
+
+    async def restore_credits(
+        self, npub: str, invoice_id: str
+    ) -> dict[str, Any]:
+        return {"restored": True}
+
+    async def service_status(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+    async def purchase_credits(
+        self, npub: str, amount_sats: int, certificate: str
+    ) -> dict[str, Any]:
+        return {"invoice_id": "inv_456"}
+
+    async def check_payment(
+        self, npub: str, invoice_id: str
+    ) -> dict[str, Any]:
+        return {"settled": True}
+
+    async def certify_credits(
+        self, operator_id: str, amount_sats: int
+    ) -> dict[str, Any]:
+        return {"certified": True}
+
+    async def register_operator(self, npub: str) -> dict[str, Any]:
+        return {"npub": npub}
+
+    async def operator_status(self) -> dict[str, Any]:
+        return {"status": "active"}
+
+    async def lookup_member(self, npub: str) -> dict[str, Any] | str:
+        return {"npub": npub}
+
+    async def how_to_join(self) -> str:
+        return "Visit dpyc.org"
+
+    async def get_tax_rate(self) -> dict[str, Any]:
+        return {"rate": 2.0}
+
+    async def about(self) -> str:
+        return "DPYC ecosystem"
+
+    async def network_advisory(self) -> str:
+        return "No advisories"
+
+
+class TestOperatorProtocol:
+    """Protocol compliance tests."""
+
+    def test_stub_satisfies_protocol(self):
+        """StubOperator satisfies the OperatorProtocol."""
+        operator = StubOperator()
+        assert isinstance(operator, OperatorProtocol)
+
+    def test_dict_does_not_satisfy(self):
+        """A plain dict does NOT satisfy the protocol."""
+        assert not isinstance({}, OperatorProtocol)

--- a/tests/test_oracle_protocol.py
+++ b/tests/test_oracle_protocol.py
@@ -1,0 +1,70 @@
+"""Tests for OracleProtocol compliance."""
+
+from typing import Any
+
+from tollbooth.actor_types import ToolPath, ToolPathInfo
+from tollbooth.oracle_protocol import OracleProtocol
+
+
+class StubOracle:
+    """Minimal stub satisfying OracleProtocol."""
+
+    @property
+    def slug(self) -> str:
+        return "oracle"
+
+    @classmethod
+    def tool_catalog(cls) -> list[ToolPathInfo]:
+        return [
+            ToolPathInfo(tool_name="get_tax_rate", path=ToolPath.HOT),
+        ]
+
+    async def get_tax_rate(self) -> dict[str, Any]:
+        return {"rate": 2.0}
+
+    async def how_to_join(self) -> str:
+        return "Visit dpyc.org"
+
+    async def service_status(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+    async def request_citizenship(
+        self, npub: str, display_name: str
+    ) -> dict[str, Any]:
+        return {"npub": npub}
+
+    async def about(self) -> str:
+        return "DPYC ecosystem"
+
+    async def lookup_member(self, npub: str) -> dict[str, Any] | str:
+        return {"npub": npub}
+
+    async def get_rulebook(self) -> str:
+        return "Rules"
+
+    async def who_is_first_curator(self) -> dict[str, Any] | str:
+        return {"curator": "npub1..."}
+
+    async def network_versions(self) -> dict[str, Any]:
+        return {"version": "1.0"}
+
+    async def network_advisory(self) -> str:
+        return "No advisories"
+
+    async def confirm_citizenship(
+        self, npub: str, challenge_id: str, signed_event_json: str
+    ) -> dict[str, Any]:
+        return {"confirmed": True}
+
+
+class TestOracleProtocol:
+    """Protocol compliance tests."""
+
+    def test_stub_satisfies_protocol(self):
+        """StubOracle satisfies the OracleProtocol."""
+        oracle = StubOracle()
+        assert isinstance(oracle, OracleProtocol)
+
+    def test_dict_does_not_satisfy(self):
+        """A plain dict does NOT satisfy the protocol."""
+        assert not isinstance({}, OracleProtocol)


### PR DESCRIPTION
## Summary

- Add `ActorRole` enum (operator/authority/oracle), `ToolPath` enum (hot/cold/delegation), and `ToolPathInfo` frozen dataclass to `actor_types.py`
- Add `OracleProtocol` — free community concierge tools (hot: tax rate, onboarding; cold: GitHub registry)
- Add `AuthorityProtocol` — certification, operator ledger, BTCPay (hot: certify/register/balance; cold: purchase/payment/membership)
- Add `OperatorProtocol` — patron ledger + delegation to Authority & Oracle (hot: balance/statement; cold: BTCPay + delegation)
- Export all new types from `tollbooth.__init__`
- Bump version 0.1.62 → 0.1.63

## Design

Follows the existing `VaultBackend` pattern: `@runtime_checkable` Protocol classes with `...` method bodies, `from __future__ import annotations`, pure stdlib typing (no FastMCP dependency). Methods annotated with `(hot)`/`(cold)` section comments and docstrings.

Brain task: `b88f423b`

## Test plan

- [x] `test_actor_types.py` — enum values, frozen immutability
- [x] `test_oracle_protocol.py` — stub compliance, isinstance checks
- [x] `test_authority_protocol.py` — stub compliance, isinstance checks
- [x] `test_operator_protocol.py` — stub compliance, isinstance checks
- [x] Full suite: 1035 tests pass
- [x] Import verification: `from tollbooth import OperatorProtocol, AuthorityProtocol, OracleProtocol`

🤖 Generated with [Claude Code](https://claude.com/claude-code)