### PR TITLE
fix: harden npub validation against pynostr TypeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.63"
+version = "0.1.64"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -190,7 +190,19 @@ def _npub_to_hex(npub: str) -> str:
     """Convert npub bech32 to 32-byte hex pubkey."""
     if not _HAS_PYNOSTR:
         raise RuntimeError("pynostr required for npub conversion")
-    return PublicKey.from_npub(npub).hex()
+    if not npub or not npub.startswith("npub1"):
+        raise ValueError(
+            f"Expected an npub (npub1...), got: {npub!r}"
+        )
+    try:
+        return PublicKey.from_npub(npub).hex()
+    except TypeError:
+        # pynostr raises TypeError when bech32 checksum fails
+        # (bech32_decode returns None, which convertbits iterates)
+        raise ValueError(
+            f"Invalid npub — bech32 checksum failed for "
+            f"'{npub[:16]}...'. Verify the npub is correct."
+        )
 
 
 def _hex_to_npub(hex_pubkey: str) -> str:

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1890,3 +1890,43 @@ class TestNip17TimestampHardening:
 
         results = ex._find_dm_candidates(sender.public_key.hex())
         assert len(results) == 0
+
+
+# ── _npub_to_hex validation ──────────────────────────────────────────
+
+
+class TestNpubToHex:
+    """Tests for _npub_to_hex hardening against pynostr TypeError."""
+
+    def test_valid_npub(self):
+        from tollbooth.nostr_credentials import _npub_to_hex
+
+        pk = PrivateKey()
+        npub = pk.public_key.bech32()
+        result = _npub_to_hex(npub)
+        assert result == pk.public_key.hex()
+
+    def test_empty_string_raises_valueerror(self):
+        from tollbooth.nostr_credentials import _npub_to_hex
+
+        with pytest.raises(ValueError, match="Expected an npub"):
+            _npub_to_hex("")
+
+    def test_non_npub_prefix_raises_valueerror(self):
+        from tollbooth.nostr_credentials import _npub_to_hex
+
+        with pytest.raises(ValueError, match="Expected an npub"):
+            _npub_to_hex("nsec1abc123")
+
+    def test_bad_checksum_raises_valueerror(self):
+        from tollbooth.nostr_credentials import _npub_to_hex
+
+        # Valid format but corrupted checksum (last char changed)
+        pk = PrivateKey()
+        npub = pk.public_key.bech32()
+        # Flip the last character to corrupt checksum
+        last = npub[-1]
+        flipped = "q" if last != "q" else "p"
+        bad_npub = npub[:-1] + flipped
+        with pytest.raises(ValueError, match="bech32 checksum failed"):
+            _npub_to_hex(bad_npub)


### PR DESCRIPTION
## Summary
- `_npub_to_hex` now catches `TypeError` from pynostr's `bech32_decode` returning `(None, None, None)` on bad checksums
- Validates `npub1` prefix upfront with a clear error
- 4 new tests: valid npub, empty string, wrong prefix, bad checksum

## Root cause
pynostr 0.7.0's `PublicKey.from_npub()` calls `convertbits(data, 5, 8)` where `data` is `None` when the bech32 checksum fails, producing `TypeError: 'NoneType' object is not iterable`. This propagates through `CourierValidationError` as an unhelpful error message.

## Test plan
- [x] `pytest tests/test_nostr_credentials.py::TestNpubToHex -v` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)