### PR TITLE
feat: add make_slug_tool() for slug-prefixed MCP tool names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.64"
+version = "0.1.65"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -15,6 +15,7 @@ from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
 from tollbooth.credential_vault_backend import CredentialVaultBackend
 from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
+from tollbooth.slug_tools import make_slug_tool
 from tollbooth.operator_protocol import OperatorProtocol
 from tollbooth.authority_protocol import AuthorityProtocol
 from tollbooth.oracle_protocol import OracleProtocol
@@ -157,6 +158,7 @@ __all__ = [
     "OperatorProtocol",
     "AuthorityProtocol",
     "OracleProtocol",
+    "make_slug_tool",
     "LedgerCache",
     "TheBrainVault",
     "NeonVault",

--- a/src/tollbooth/slug_tools.py
+++ b/src/tollbooth/slug_tools.py
@@ -1,0 +1,29 @@
+"""Utility for slug-prefixed MCP tool registration."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def make_slug_tool(mcp_server: Any, slug: str) -> Callable[[F], F]:
+    """Return a decorator that registers MCP tools with a slug prefix.
+
+    Usage in server.py::
+
+        from tollbooth.slug_tools import make_slug_tool
+        mcp = FastMCP("my-server")
+        tool = make_slug_tool(mcp, "myslug")
+
+        @tool
+        async def check_balance():
+            ...
+        # Registered as "myslug_check_balance"
+    """
+
+    def decorator(func: F) -> F:
+        prefixed = f"{slug}_{func.__name__}"
+        return mcp_server.tool(name=prefixed)(func)
+
+    return decorator  # type: ignore[return-value]

--- a/tests/test_slug_tools.py
+++ b/tests/test_slug_tools.py
@@ -1,0 +1,80 @@
+"""Tests for slug-prefixed MCP tool registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from tollbooth.slug_tools import make_slug_tool
+
+
+class _FakeToolManager:
+    """Minimal stand-in for FastMCP tool registration."""
+
+    def __init__(self) -> None:
+        self.registered: dict[str, object] = {}
+
+    def tool(self, *, name: str):
+        def decorator(func):
+            self.registered[name] = func
+            return func
+        return decorator
+
+
+class TestMakeSlugTool:
+    def test_prefixes_function_name(self) -> None:
+        fake = _FakeToolManager()
+        tool = make_slug_tool(fake, "brain")
+
+        @tool
+        def check_balance():
+            return "ok"
+
+        assert "brain_check_balance" in fake.registered
+        assert fake.registered["brain_check_balance"] is check_balance
+
+    def test_different_slug(self) -> None:
+        fake = _FakeToolManager()
+        tool = make_slug_tool(fake, "authority")
+
+        @tool
+        def certify_credits():
+            return "cert"
+
+        assert "authority_certify_credits" in fake.registered
+
+    def test_async_function(self) -> None:
+        fake = _FakeToolManager()
+        tool = make_slug_tool(fake, "excalibur")
+
+        @tool
+        async def post_tweet():
+            return "posted"
+
+        assert "excalibur_post_tweet" in fake.registered
+
+    def test_preserves_original_function(self) -> None:
+        fake = _FakeToolManager()
+        tool = make_slug_tool(fake, "brain")
+
+        @tool
+        def search_thoughts():
+            return "found"
+
+        # The decorated function should still be callable
+        assert search_thoughts() == "found"
+
+    def test_multiple_tools_same_slug(self) -> None:
+        fake = _FakeToolManager()
+        tool = make_slug_tool(fake, "brain")
+
+        @tool
+        def tool_a():
+            return "a"
+
+        @tool
+        def tool_b():
+            return "b"
+
+        assert "brain_tool_a" in fake.registered
+        assert "brain_tool_b" in fake.registered
+        assert len(fake.registered) == 2


### PR DESCRIPTION
## Summary
- Adds `make_slug_tool()` factory in `src/tollbooth/slug_tools.py` that wraps `mcp.tool()` with automatic slug prefixing
- Exported from `tollbooth.__init__` for use by all DPYC servers
- Eliminates tool name collisions when multiple servers are composed in one MCP session
- Version bump: 0.1.64 → 0.1.65

## Test plan
- [x] 5 unit tests in `tests/test_slug_tools.py` — all passing
- [ ] Merge this before the downstream server PRs (thebrain-mcp, tollbooth-authority, excalibur-mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)