### PR TITLE
feat: AuthorityCertifier for server-to-server auto-certification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.65"
+version = "0.1.66"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import version as _meta_version
 __version__ = _meta_version("tollbooth-dpyc")
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
-from tollbooth.registry import DPYCRegistry, RegistryError, resolve_authority_npub, DEFAULT_REGISTRY_URL
+from tollbooth.registry import DPYCRegistry, RegistryError, resolve_authority_npub, resolve_authority_service, DEFAULT_REGISTRY_URL
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -25,6 +25,12 @@ from tollbooth.pricing import ToolPricing
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
 from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
+
+try:
+    from tollbooth.authority_client import AuthorityCertifier, AuthorityCertifyError
+except ImportError:
+    AuthorityCertifier = None  # type: ignore[assignment,misc]
+    AuthorityCertifyError = None  # type: ignore[assignment,misc]
 
 try:
     from tollbooth.nostr_audit import NostrAuditPublisher, AuditedVault
@@ -175,7 +181,11 @@ __all__ = [
     "DPYCRegistry",
     "RegistryError",
     "resolve_authority_npub",
+    "resolve_authority_service",
     "DEFAULT_REGISTRY_URL",
+    # Authority Client
+    "AuthorityCertifier",
+    "AuthorityCertifyError",
     "NostrAuditPublisher",
     "AuditedVault",
     "MerkleTree",

--- a/src/tollbooth/authority_client.py
+++ b/src/tollbooth/authority_client.py
@@ -1,0 +1,110 @@
+"""Server-to-server MCP client for obtaining Authority certificates.
+
+Used by operator servers (thebrain-mcp, excalibur-mcp) to auto-certify
+credit purchases without requiring the AI agent to call the Authority directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from fastmcp import Client  # type: ignore[import-untyped]
+except ImportError:
+    Client = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+
+class AuthorityCertifyError(Exception):
+    """Raised when Authority certification fails."""
+
+
+class AuthorityCertifier:
+    """Server-to-server MCP client for obtaining Authority certificates.
+
+    Opens a short-lived ``fastmcp.Client`` SSE connection with Horizon OAuth
+    auto-negotiation. One connection per ``certify()`` call (credit-critical
+    path — correctness over connection pooling).
+    """
+
+    def __init__(
+        self,
+        authority_url: str,
+        operator_npub: str,
+        certify_tool_name: str = "authority_certify_credits",
+    ) -> None:
+        self._authority_url = authority_url
+        self._operator_npub = operator_npub
+        self._certify_tool_name = certify_tool_name
+
+    async def certify(self, amount_sats: int) -> dict[str, Any]:
+        """Call the Authority's certify_credits tool and return the certificate dict.
+
+        Returns dict with keys: certificate, jti, amount_sats, fee_sats,
+        net_sats, expires_at (as returned by the Authority).
+
+        Raises ``AuthorityCertifyError`` on any failure (connection, auth, tool error).
+        """
+        if Client is None:
+            raise AuthorityCertifyError(
+                "fastmcp package required for auto-certification. "
+                "Install with: pip install fastmcp"
+            )
+
+        try:
+            async with Client(self._authority_url, auth="oauth") as client:
+                result = await client.call_tool(
+                    self._certify_tool_name,
+                    {
+                        "operator_id": self._operator_npub,
+                        "amount_sats": amount_sats,
+                    },
+                )
+        except AuthorityCertifyError:
+            raise
+        except Exception as e:
+            raise AuthorityCertifyError(
+                f"Failed to connect to Authority at {self._authority_url}: {e}"
+            ) from e
+
+        return self._parse_result(result)
+
+    def _parse_result(self, result: Any) -> dict[str, Any]:
+        """Extract the certificate dict from the MCP tool result."""
+        # fastmcp.Client.call_tool returns a list of content blocks
+        if isinstance(result, list):
+            for block in result:
+                # TextContent has .text attribute
+                if hasattr(block, "text"):
+                    import json
+
+                    try:
+                        data = json.loads(block.text)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if isinstance(data, dict):
+                        if data.get("success") is False:
+                            raise AuthorityCertifyError(
+                                f"Authority refused certification: "
+                                f"{data.get('error', 'unknown error')}"
+                            )
+                        if "certificate" in data:
+                            return data
+            raise AuthorityCertifyError(
+                f"Authority returned unexpected response format: {result}"
+            )
+
+        if isinstance(result, dict):
+            if result.get("success") is False:
+                raise AuthorityCertifyError(
+                    f"Authority refused certification: "
+                    f"{result.get('error', 'unknown error')}"
+                )
+            if "certificate" in result:
+                return result
+
+        raise AuthorityCertifyError(
+            f"Authority returned unexpected response format: {result}"
+        )

--- a/src/tollbooth/registry.py
+++ b/src/tollbooth/registry.py
@@ -63,6 +63,28 @@ class DPYCRegistry:
             )
         return upstream
 
+    async def resolve_authority_service(self, operator_npub: str) -> dict[str, str]:
+        """Look up *operator_npub*'s upstream authority and return its service URL.
+
+        Returns ``{"npub": authority_npub, "url": service_url, "name": service_name}``.
+        Raises ``RegistryError`` if the authority has no services registered.
+        """
+        authority_npub = await self.resolve_authority_npub(operator_npub)
+        authority_member = await self.check_membership(authority_npub)
+
+        services = authority_member.get("services") or []
+        if not services:
+            raise RegistryError(
+                f"Authority {authority_npub} has no services registered in the registry."
+            )
+
+        svc = services[0]
+        return {
+            "npub": authority_npub,
+            "url": svc["url"],
+            "name": svc.get("name", "unknown"),
+        }
+
     async def _fetch(self) -> list[dict[str, Any]]:
         """Return the cached member list, refreshing if stale."""
         now = time.monotonic()
@@ -117,5 +139,22 @@ async def resolve_authority_npub(
     registry = DPYCRegistry(url=registry_url, cache_ttl_seconds=cache_ttl_seconds)
     try:
         return await registry.resolve_authority_npub(operator_npub)
+    finally:
+        await registry.close()
+
+
+async def resolve_authority_service(
+    operator_npub: str,
+    registry_url: str = DEFAULT_REGISTRY_URL,
+    cache_ttl_seconds: int = 300,
+) -> dict[str, str]:
+    """Convenience function: resolve an operator's upstream authority service.
+
+    Returns ``{"npub": authority_npub, "url": service_url, "name": service_name}``.
+    Creates a one-shot ``DPYCRegistry``, performs the lookup, and closes.
+    """
+    registry = DPYCRegistry(url=registry_url, cache_ttl_seconds=cache_ttl_seconds)
+    try:
+        return await registry.resolve_authority_service(operator_npub)
     finally:
         await registry.close()

--- a/tests/test_authority_client.py
+++ b/tests/test_authority_client.py
@@ -1,0 +1,305 @@
+"""Tests for tollbooth.authority_client — AuthorityCertifier."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tollbooth.authority_client import AuthorityCertifier, AuthorityCertifyError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_block(data: dict) -> MagicMock:
+    """Create a mock TextContent block with .text = JSON string."""
+    block = MagicMock()
+    block.text = json.dumps(data)
+    return block
+
+
+# ---------------------------------------------------------------------------
+# certify() — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_certify_success():
+    """certify() returns parsed certificate dict on success."""
+    cert_response = {
+        "success": True,
+        "certificate": "eyJhbGciOi...",
+        "jti": "abc-123",
+        "amount_sats": 100,
+        "fee_sats": 10,
+        "net_sats": 90,
+        "expires_at": "2026-03-03T12:00:00Z",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(cert_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.authority_client.Client", return_value=mock_client):
+        certifier = AuthorityCertifier(
+            authority_url="https://authority.example.com/mcp",
+            operator_npub="npub1operator",
+        )
+        result = await certifier.certify(100)
+
+    assert result["certificate"] == "eyJhbGciOi..."
+    assert result["net_sats"] == 90
+    mock_client.call_tool.assert_awaited_once_with(
+        "authority_certify_credits",
+        {"operator_id": "npub1operator", "amount_sats": 100},
+    )
+
+
+# ---------------------------------------------------------------------------
+# certify() — Authority refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_certify_authority_refuses():
+    """certify() raises AuthorityCertifyError when Authority returns error."""
+    error_response = {
+        "success": False,
+        "error": "Insufficient credit balance",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(error_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.authority_client.Client", return_value=mock_client):
+        certifier = AuthorityCertifier(
+            authority_url="https://authority.example.com/mcp",
+            operator_npub="npub1operator",
+        )
+        with pytest.raises(AuthorityCertifyError, match="Insufficient credit balance"):
+            await certifier.certify(100)
+
+
+# ---------------------------------------------------------------------------
+# certify() — connection failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_certify_connection_failure():
+    """certify() wraps connection errors in AuthorityCertifyError."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(side_effect=ConnectionError("refused"))
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.authority_client.Client", return_value=mock_client):
+        certifier = AuthorityCertifier(
+            authority_url="https://authority.example.com/mcp",
+            operator_npub="npub1operator",
+        )
+        with pytest.raises(AuthorityCertifyError, match="Failed to connect"):
+            await certifier.certify(100)
+
+
+# ---------------------------------------------------------------------------
+# certify() — custom tool name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_certify_custom_tool_name():
+    """certify() uses the custom tool name when provided."""
+    cert_response = {
+        "success": True,
+        "certificate": "jwt...",
+        "jti": "x",
+        "amount_sats": 50,
+        "fee_sats": 5,
+        "net_sats": 45,
+        "expires_at": "2026-03-03T12:00:00Z",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(cert_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.authority_client.Client", return_value=mock_client):
+        certifier = AuthorityCertifier(
+            authority_url="https://authority.example.com/mcp",
+            operator_npub="npub1operator",
+            certify_tool_name="custom_certify",
+        )
+        await certifier.certify(50)
+
+    mock_client.call_tool.assert_awaited_once_with(
+        "custom_certify",
+        {"operator_id": "npub1operator", "amount_sats": 50},
+    )
+
+
+# ---------------------------------------------------------------------------
+# certify() — unexpected response format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_certify_unexpected_format():
+    """certify() raises on unexpected response (no certificate key)."""
+    bad_response = {"success": True, "message": "ok but no cert"}
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(bad_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.authority_client.Client", return_value=mock_client):
+        certifier = AuthorityCertifier(
+            authority_url="https://authority.example.com/mcp",
+            operator_npub="npub1operator",
+        )
+        with pytest.raises(AuthorityCertifyError, match="unexpected response"):
+            await certifier.certify(100)
+
+
+# ---------------------------------------------------------------------------
+# resolve_authority_service — registry integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_service_success():
+    """resolve_authority_service returns authority URL from registry."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import DPYCRegistry, RegistryError
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1authority",
+        },
+        {
+            "npub": "npub1authority",
+            "role": "authority",
+            "status": "active",
+            "services": [
+                {
+                    "name": "tollbooth-authority",
+                    "url": "https://authority.fastmcp.app/mcp",
+                    "description": "Authority service",
+                }
+            ],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(return_value=resp)
+
+    result = await registry.resolve_authority_service("npub1operator")
+    assert result["npub"] == "npub1authority"
+    assert result["url"] == "https://authority.fastmcp.app/mcp"
+    assert result["name"] == "tollbooth-authority"
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_service_no_services():
+    """resolve_authority_service raises when authority has no services."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import DPYCRegistry, RegistryError
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1authority",
+        },
+        {
+            "npub": "npub1authority",
+            "role": "authority",
+            "status": "active",
+            "services": [],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(return_value=resp)
+
+    with pytest.raises(RegistryError, match="no services"):
+        await registry.resolve_authority_service("npub1operator")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_authority_service_convenience():
+    """Module-level resolve_authority_service() creates a one-shot registry."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import resolve_authority_service
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1authority",
+        },
+        {
+            "npub": "npub1authority",
+            "role": "authority",
+            "status": "active",
+            "services": [
+                {
+                    "name": "tollbooth-authority",
+                    "url": "https://authority.fastmcp.app/mcp",
+                }
+            ],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    with patch("tollbooth.registry.httpx.AsyncClient") as MockClient:
+        instance = AsyncMock()
+        instance.get = AsyncMock(return_value=resp)
+        MockClient.return_value = instance
+
+        result = await resolve_authority_service(
+            "npub1operator",
+            registry_url="https://example.com/members.json",
+        )
+        assert result["url"] == "https://authority.fastmcp.app/mcp"
+        instance.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Adds `resolve_authority_service()` to `DPYCRegistry` — resolves operator npub → authority service URL via community registry
- Adds `AuthorityCertifier` class (`authority_client.py`) — uses `fastmcp.Client` with Horizon OAuth for transparent certificate acquisition
- Version bump 0.1.65 → 0.1.66
- 8 new tests, full suite passes (1052 tests)

## Test plan
- [x] `test_certify_success` — happy path returns parsed certificate
- [x] `test_certify_authority_refuses` — error response raises `AuthorityCertifyError`
- [x] `test_certify_connection_failure` — connection errors wrapped properly
- [x] `test_certify_custom_tool_name` — non-default tool name works
- [x] `test_certify_unexpected_format` — missing certificate key raises
- [x] `test_resolve_authority_service_success` — registry returns service URL
- [x] `test_resolve_authority_service_no_services` — empty services raises
- [x] `test_resolve_authority_service_convenience` — module-level function works

🤖 Generated with [Claude Code](https://claude.com/claude-code)