### PR TITLE
feat: add OracleClient and resolve_oracle_service()

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ The `tollbooth.tools` package provides functions your MCP server wraps as tools.
 | `AuthorityCertifier` | Server-to-server MCP client for auto-certifying credit purchases. Opens a short-lived `fastmcp.Client` SSE connection with Horizon OAuth auto-negotiation. |
 | `AuthorityCertifyError` | Raised when Authority certification fails (connection, auth, or tool error). |
 
+### Oracle Client
+
+| Module | Purpose |
+|--------|---------|
+| `OracleClient` | Server-to-server MCP client for delegating Oracle tool calls. Opens a short-lived `fastmcp.Client` SSE connection per call. Oracle tools are free and unauthenticated. |
+| `OracleClientError` | Raised when an Oracle delegation call fails (connection or parse error). |
+
 ### DPYC Registry
 
 | Module | Purpose |
@@ -111,6 +118,7 @@ The `tollbooth.tools` package provides functions your MCP server wraps as tools.
 | `DPYCRegistry` | Cached HTTPS fetch of the [dpyc-community](https://github.com/lonniev/dpyc-community) `members.json` registry. Resolves membership, upstream authorities, and service URLs. |
 | `resolve_authority_service` | Convenience: finds an operator's upstream Authority service URL in one call. |
 | `resolve_authority_npub` | Finds an operator's upstream Authority npub from the registry. |
+| `resolve_oracle_service` | Walks the authority chain to the Prime Authority and returns the Oracle service URL. |
 
 ### Vault Backends
 
@@ -249,6 +257,7 @@ Tollbooth is a three-party ecosystem built on the [DPYC Honor Chain](https://git
 | [tollbooth-authority](https://github.com/lonniev/tollbooth-authority) | The institution — tax collection, Schnorr signing, purchase order certification |
 | **tollbooth-dpyc** (this package) | The booth — operator-side credit ledger, BTCPay client, tool gating, auto-certification |
 | [dpyc-community](https://github.com/lonniev/dpyc-community) | The registry — membership, governance, and service discovery |
+| [dpyc-oracle](https://github.com/lonniev/dpyc-oracle) | The concierge — community onboarding, tax rates, membership lookup |
 | [thebrain-mcp](https://github.com/lonniev/thebrain-mcp) | Reference operator — PersonalBrain knowledge graph, 40+ metered tools |
 | [excalibur-mcp](https://github.com/lonniev/excalibur-mcp) | Reference operator — social media posting via Tollbooth credits |
 
@@ -287,6 +296,23 @@ from tollbooth import resolve_authority_service
 
 service = await resolve_authority_service("npub1operator...")
 # service["url"] → "https://authority.fastmcp.app/mcp"
+```
+
+## Oracle Delegation
+
+`OracleClient` lets operator servers delegate community queries to the DPYC Oracle — no separate MCP connection from the AI agent needed. Oracle tools are free and unauthenticated.
+
+```python
+from tollbooth import OracleClient, resolve_oracle_service
+
+# Resolve Oracle URL via registry (walks authority chain to Prime Authority)
+service = await resolve_oracle_service("npub1operator...")
+# service["url"] → "https://dpyc-oracle.fastmcp.app/mcp"
+
+# Call any Oracle tool
+client = OracleClient(service["url"])
+result = await client.call_tool("get_tax_rate")
+# result → {"rate_percent": 2, "min_sats": 10, ...}
 ```
 
 ## Constraint Engine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.67"
+version = "0.1.68"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import version as _meta_version
 __version__ = _meta_version("tollbooth-dpyc")
 
 from tollbooth.certificate import CertificateError, verify_certificate_auto, UNDERSTOOD_PROTOCOLS
-from tollbooth.registry import DPYCRegistry, RegistryError, resolve_authority_npub, resolve_authority_service, DEFAULT_REGISTRY_URL
+from tollbooth.registry import DPYCRegistry, RegistryError, resolve_authority_npub, resolve_authority_service, resolve_oracle_service, DEFAULT_REGISTRY_URL
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
@@ -31,6 +31,12 @@ try:
 except ImportError:
     AuthorityCertifier = None  # type: ignore[assignment,misc]
     AuthorityCertifyError = None  # type: ignore[assignment,misc]
+
+try:
+    from tollbooth.oracle_client import OracleClient, OracleClientError
+except ImportError:
+    OracleClient = None  # type: ignore[assignment,misc]
+    OracleClientError = None  # type: ignore[assignment,misc]
 
 try:
     from tollbooth.nostr_audit import NostrAuditPublisher, AuditedVault
@@ -182,10 +188,14 @@ __all__ = [
     "RegistryError",
     "resolve_authority_npub",
     "resolve_authority_service",
+    "resolve_oracle_service",
     "DEFAULT_REGISTRY_URL",
     # Authority Client
     "AuthorityCertifier",
     "AuthorityCertifyError",
+    # Oracle Client
+    "OracleClient",
+    "OracleClientError",
     "NostrAuditPublisher",
     "AuditedVault",
     "MerkleTree",

--- a/src/tollbooth/oracle_client.py
+++ b/src/tollbooth/oracle_client.py
@@ -1,0 +1,99 @@
+"""Server-to-server MCP client for Oracle delegation.
+
+Used by operator servers (thebrain-mcp, excalibur-mcp) to delegate
+community queries to the DPYC Oracle without requiring a separate
+MCP connection from the AI agent.
+
+Oracle tools are free and unauthenticated — no credits required.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+try:
+    from fastmcp import Client  # type: ignore[import-untyped]
+except ImportError:
+    Client = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+
+class OracleClientError(Exception):
+    """Raised when an Oracle delegation call fails."""
+
+
+class OracleClient:
+    """Server-to-server MCP client for Oracle tool calls.
+
+    Opens a short-lived ``fastmcp.Client`` SSE connection per
+    ``call_tool()`` invocation. Oracle tools are free and
+    unauthenticated, so no credits or certificates are needed.
+    """
+
+    def __init__(self, oracle_url: str) -> None:
+        self._oracle_url = oracle_url
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Call an Oracle tool by name and return the parsed result dict.
+
+        Raises ``OracleClientError`` on any failure (connection, parse, tool error).
+        """
+        if Client is None:
+            raise OracleClientError(
+                "fastmcp package required for Oracle delegation. "
+                "Install with: pip install fastmcp"
+            )
+
+        try:
+            async with Client(self._oracle_url, auth="oauth") as client:
+                result = await client.call_tool(tool_name, arguments or {})
+        except OracleClientError:
+            raise
+        except Exception as e:
+            raise OracleClientError(
+                f"Failed to connect to Oracle at {self._oracle_url}: {e}"
+            ) from e
+
+        return self._parse_result(result)
+
+    def _parse_result(self, result: Any) -> dict[str, Any]:
+        """Extract a dict from the MCP tool result.
+
+        Duck-types CallToolResult unwrapping (same pattern as
+        ``AuthorityCertifier._parse_result``).
+        """
+        # Unwrap CallToolResult with .data dict (structured output)
+        if hasattr(result, "data") and isinstance(getattr(result, "data"), dict):
+            return result.data
+
+        # Unwrap CallToolResult with .content list (text blocks)
+        if hasattr(result, "content") and isinstance(
+            getattr(result, "content"), list
+        ):
+            result = result.content
+
+        # Parse list of text content blocks
+        if isinstance(result, list):
+            for block in result:
+                if hasattr(block, "text"):
+                    try:
+                        data = json.loads(block.text)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if isinstance(data, dict):
+                        return data
+            raise OracleClientError(
+                f"Oracle returned unexpected response format: {result}"
+            )
+
+        if isinstance(result, dict):
+            return result
+
+        raise OracleClientError(
+            f"Oracle returned unexpected response format: {result}"
+        )

--- a/src/tollbooth/registry.py
+++ b/src/tollbooth/registry.py
@@ -63,6 +63,38 @@ class DPYCRegistry:
             )
         return upstream
 
+    async def resolve_oracle_service(self, operator_npub: str) -> dict[str, str]:
+        """Walk *operator_npub*'s authority chain to Prime Authority and return Oracle service.
+
+        The Oracle is a community service operated by the Prime Authority.
+        Resolution: operator → upstream authority → ... → Prime Authority (no
+        ``upstream_authority_npub``) → find service named ``dpyc-oracle``.
+
+        Returns ``{"npub": prime_npub, "url": service_url, "name": service_name}``.
+        Raises ``RegistryError`` if no Oracle service is found.
+        """
+        # Walk upstream to Prime Authority
+        current_npub = operator_npub
+        for _ in range(10):  # guard against cycles
+            member = await self.check_membership(current_npub)
+            upstream = member.get("upstream_authority_npub")
+            if not upstream:
+                # This is the Prime Authority — look for Oracle service
+                services = member.get("services") or []
+                for svc in services:
+                    if svc.get("name") == "dpyc-oracle":
+                        return {
+                            "npub": current_npub,
+                            "url": svc["url"],
+                            "name": svc.get("name", "dpyc-oracle"),
+                        }
+                raise RegistryError(
+                    f"Prime Authority {current_npub} has no dpyc-oracle service registered."
+                )
+            current_npub = upstream
+
+        raise RegistryError("Authority chain too deep (possible cycle).")
+
     async def resolve_authority_service(self, operator_npub: str) -> dict[str, str]:
         """Look up *operator_npub*'s upstream authority and return its service URL.
 
@@ -156,5 +188,22 @@ async def resolve_authority_service(
     registry = DPYCRegistry(url=registry_url, cache_ttl_seconds=cache_ttl_seconds)
     try:
         return await registry.resolve_authority_service(operator_npub)
+    finally:
+        await registry.close()
+
+
+async def resolve_oracle_service(
+    operator_npub: str,
+    registry_url: str = DEFAULT_REGISTRY_URL,
+    cache_ttl_seconds: int = 300,
+) -> dict[str, str]:
+    """Convenience function: resolve the Oracle service via authority chain.
+
+    Returns ``{"npub": prime_npub, "url": service_url, "name": service_name}``.
+    Creates a one-shot ``DPYCRegistry``, performs the lookup, and closes.
+    """
+    registry = DPYCRegistry(url=registry_url, cache_ttl_seconds=cache_ttl_seconds)
+    try:
+        return await registry.resolve_oracle_service(operator_npub)
     finally:
         await registry.close()

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -1,0 +1,318 @@
+"""Tests for tollbooth.oracle_client — OracleClient."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tollbooth.oracle_client import OracleClient, OracleClientError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_block(data: dict) -> MagicMock:
+    """Create a mock TextContent block with .text = JSON string."""
+    block = MagicMock()
+    block.text = json.dumps(data)
+    return block
+
+
+# ---------------------------------------------------------------------------
+# call_tool() — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_success():
+    """call_tool() returns parsed dict on success."""
+    oracle_response = {
+        "success": True,
+        "rate_percent": 2,
+        "min_sats": 10,
+    }
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(oracle_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("get_tax_rate")
+
+    assert result["rate_percent"] == 2
+    assert result["min_sats"] == 10
+    mock_client.call_tool.assert_awaited_once_with("get_tax_rate", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_with_arguments():
+    """call_tool() passes arguments to the Oracle tool."""
+    oracle_response = {
+        "npub": "npub1abc...",
+        "role": "citizen",
+        "status": "active",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[_text_block(oracle_response)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("lookup_member", {"npub": "npub1abc..."})
+
+    assert result["role"] == "citizen"
+    mock_client.call_tool.assert_awaited_once_with(
+        "lookup_member", {"npub": "npub1abc..."}
+    )
+
+
+# ---------------------------------------------------------------------------
+# call_tool() — connection failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_connection_failure():
+    """call_tool() wraps connection errors in OracleClientError."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(side_effect=ConnectionError("refused"))
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        with pytest.raises(OracleClientError, match="Failed to connect"):
+            await client.call_tool("get_tax_rate")
+
+
+# ---------------------------------------------------------------------------
+# call_tool() — CallToolResult unwrapping (structured data path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_calltoolresult_data():
+    """call_tool() unwraps CallToolResult-like objects with .data dict."""
+    oracle_response = {
+        "rate_percent": 2,
+        "min_sats": 10,
+    }
+
+    call_tool_result = MagicMock()
+    call_tool_result.data = oracle_response
+    call_tool_result.content = None  # data takes priority
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=call_tool_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("get_tax_rate")
+
+    assert result["rate_percent"] == 2
+    assert result["min_sats"] == 10
+
+
+@pytest.mark.asyncio
+async def test_call_tool_calltoolresult_content():
+    """call_tool() unwraps CallToolResult-like objects with .content list."""
+    oracle_response = {
+        "rate_percent": 2,
+        "min_sats": 10,
+    }
+
+    call_tool_result = MagicMock(spec=[])  # no .data attribute
+    call_tool_result.content = [_text_block(oracle_response)]
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=call_tool_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("get_tax_rate")
+
+    assert result["rate_percent"] == 2
+
+
+# ---------------------------------------------------------------------------
+# call_tool() — unexpected response format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unexpected_format():
+    """call_tool() raises on unexpected response (no parseable dict)."""
+    bad_block = MagicMock()
+    bad_block.text = "not json"
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[bad_block])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        with pytest.raises(OracleClientError, match="unexpected response"):
+            await client.call_tool("get_tax_rate")
+
+
+# ---------------------------------------------------------------------------
+# resolve_oracle_service — registry integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_oracle_service_success():
+    """resolve_oracle_service walks authority chain to Prime Authority Oracle."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import DPYCRegistry
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1authority",
+        },
+        {
+            "npub": "npub1authority",
+            "role": "authority",
+            "status": "active",
+            "upstream_authority_npub": "npub1prime",
+            "services": [
+                {
+                    "name": "tollbooth-authority",
+                    "url": "https://authority.fastmcp.app/mcp",
+                }
+            ],
+        },
+        {
+            "npub": "npub1prime",
+            "role": "prime_authority",
+            "status": "active",
+            "upstream_authority_npub": None,
+            "services": [
+                {
+                    "name": "dpyc-oracle",
+                    "url": "https://dpyc-oracle.fastmcp.app/mcp",
+                    "description": "DPYC Oracle",
+                }
+            ],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(return_value=resp)
+
+    result = await registry.resolve_oracle_service("npub1operator")
+    assert result["npub"] == "npub1prime"
+    assert result["url"] == "https://dpyc-oracle.fastmcp.app/mcp"
+    assert result["name"] == "dpyc-oracle"
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_oracle_service_no_oracle():
+    """resolve_oracle_service raises when Prime Authority has no Oracle service."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import DPYCRegistry, RegistryError
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1prime",
+        },
+        {
+            "npub": "npub1prime",
+            "role": "prime_authority",
+            "status": "active",
+            "upstream_authority_npub": None,
+            "services": [],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    registry = DPYCRegistry(url="https://example.com/members.json")
+    registry._client = AsyncMock()
+    registry._client.get = AsyncMock(return_value=resp)
+
+    with pytest.raises(RegistryError, match="no dpyc-oracle service"):
+        await registry.resolve_oracle_service("npub1operator")
+    await registry.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_oracle_service_convenience():
+    """Module-level resolve_oracle_service() creates a one-shot registry."""
+    from unittest.mock import MagicMock as SyncMock
+
+    import httpx
+
+    from tollbooth.registry import resolve_oracle_service
+
+    members = [
+        {
+            "npub": "npub1operator",
+            "role": "operator",
+            "status": "active",
+            "upstream_authority_npub": "npub1prime",
+        },
+        {
+            "npub": "npub1prime",
+            "role": "prime_authority",
+            "status": "active",
+            "upstream_authority_npub": None,
+            "services": [
+                {
+                    "name": "dpyc-oracle",
+                    "url": "https://dpyc-oracle.fastmcp.app/mcp",
+                }
+            ],
+        },
+    ]
+
+    resp = SyncMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {"members": members}
+    resp.raise_for_status = SyncMock()
+
+    with patch("tollbooth.registry.httpx.AsyncClient") as MockClient:
+        instance = AsyncMock()
+        instance.get = AsyncMock(return_value=resp)
+        MockClient.return_value = instance
+
+        result = await resolve_oracle_service(
+            "npub1operator",
+            registry_url="https://example.com/members.json",
+        )
+        assert result["url"] == "https://dpyc-oracle.fastmcp.app/mcp"
+        instance.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
- New `OracleClient` class in `oracle_client.py` — generic MCP-to-MCP delegate for Oracle calls (mirrors `AuthorityCertifier` pattern)
- New `resolve_oracle_service()` in `DPYCRegistry` — walks authority chain to Prime Authority to find the `dpyc-oracle` service
- Module-level convenience function `resolve_oracle_service()` and exports in `__init__.py`
- Version bump: 0.1.67 → 0.1.68

## Test plan
- [x] 9 new tests in `test_oracle_client.py` — all pass
- [x] 10 existing authority client tests — no regressions
- [ ] Downstream: thebrain-mcp wires 5 Oracle delegation tools using `OracleClient`

**Depends on**: lonniev/dpyc-community#42 (Oracle registry entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)