### PR TITLE
feat: auto-restore DPYC session from vault on cold start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.69"
+version = "0.1.70"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -13,7 +13,7 @@ from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger, ToolUsage, InvoiceRecord, Tranche
 from tollbooth.btcpay_client import BTCPayClient, BTCPayError, BTCPayAuthError
 from tollbooth.vault_backend import VaultBackend
-from tollbooth.credential_vault_backend import CredentialVaultBackend
+from tollbooth.credential_vault_backend import CredentialVaultBackend, SessionBindingBackend
 from tollbooth.actor_types import ActorRole, ToolPath, ToolPathInfo
 from tollbooth.slug_tools import make_slug_tool
 from tollbooth.operator_protocol import OperatorProtocol, OPERATOR_BASE_CATALOG
@@ -163,6 +163,7 @@ __all__ = [
     "BTCPayAuthError",
     "VaultBackend",
     "CredentialVaultBackend",
+    "SessionBindingBackend",
     # Actor Protocols
     "ActorRole",
     "ToolPath",

--- a/src/tollbooth/credential_vault_backend.py
+++ b/src/tollbooth/credential_vault_backend.py
@@ -48,3 +48,34 @@ class CredentialVaultBackend(Protocol):
         no credentials existed for this pair.
         """
         ...
+
+
+@runtime_checkable
+class SessionBindingBackend(Protocol):
+    """Async persistence for caller_id → npub session bindings.
+
+    Allows silent session restoration on serverless cold starts.
+    The binding maps a transport-layer caller ID (e.g. Horizon user_id)
+    to the DPYC npub that was last used for credential receipt.
+
+    Separate from CredentialVaultBackend so existing vault implementations
+    remain compatible without changes.
+    """
+
+    async def store_session_binding(
+        self, caller_id: str, service: str, npub: str,
+    ) -> None:
+        """Persist a session binding (upserts on conflict)."""
+        ...
+
+    async def fetch_session_binding(
+        self, caller_id: str, service: str,
+    ) -> str | None:
+        """Look up the npub for a caller+service pair.  Returns None if missing."""
+        ...
+
+    async def delete_session_binding(
+        self, caller_id: str, service: str,
+    ) -> bool:
+        """Remove a session binding.  Returns True if found and deleted."""
+        ...

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -36,7 +36,10 @@ logger = logging.getLogger(__name__)
 # Optional imports — graceful degradation mirrors nostr_credentials.py
 try:
     from tollbooth.credential_templates import CredentialTemplate
-    from tollbooth.credential_vault_backend import CredentialVaultBackend
+    from tollbooth.credential_vault_backend import (
+        CredentialVaultBackend,
+        SessionBindingBackend,
+    )
     from tollbooth.nostr_credentials import (
         CourierError,
         CourierNotReady,
@@ -183,17 +186,25 @@ class SecureCourierService:
         self,
         sender_npub: str,
         service: str = "x",
+        *,
+        caller_id: str | None = None,
     ) -> dict[str, Any]:
         """Receive credentials from Secure Courier.
 
         1. Delegates to the exchange for relay polling / vault lookup.
         2. On success, calls ``on_credentials_received`` if set.
         3. Merges callback result into the response.
-        4. **Always** strips credential values before returning.
+        4. If *caller_id* provided, persists a session binding for cold-start
+           restoration.
+        5. **Always** strips credential values before returning.
 
         Args:
             sender_npub: Patron's npub (bech32).
             service: Credential template service name.
+            caller_id: Optional transport-layer caller ID (e.g. Horizon
+                user_id).  When provided and the vault supports session
+                bindings, the ``(caller_id, service) → npub`` mapping is
+                persisted for silent cold-start restoration.
 
         Returns:
             Dict with success, service, field count, and any callback-added
@@ -218,6 +229,10 @@ class SecureCourierService:
                         "on_credentials_received callback failed: %s", exc,
                     )
                     result["callback_error"] = str(exc)
+
+            # Persist session binding for cold-start restoration
+            if caller_id is not None:
+                await self._store_binding(caller_id, matched_service, sender_npub)
 
             # Generate credential card for scan-and-paste reuse
             if _HAS_CREDENTIAL_CARD:
@@ -251,17 +266,94 @@ class SecureCourierService:
         self,
         sender_npub: str,
         service: str = "x",
+        *,
+        caller_id: str | None = None,
     ) -> dict[str, Any]:
         """Delete vaulted credentials for key rotation.
 
         Args:
             sender_npub: Patron's npub (bech32).
             service: Service name whose credentials to forget.
+            caller_id: Optional transport-layer caller ID.  When provided,
+                also deletes the session binding so cold-start restoration
+                won't revive a forgotten identity.
 
         Returns:
             Dict with success and whether credentials were found.
         """
-        return await self._exchange.forget(sender_npub, service=service)
+        result = await self._exchange.forget(sender_npub, service=service)
+
+        if caller_id is not None:
+            await self._delete_binding(caller_id, service)
+
+        return result
+
+    async def restore_session(
+        self,
+        caller_id: str,
+        service: str = "x",
+    ) -> str | None:
+        """Attempt silent session restoration from a persisted binding.
+
+        On serverless cold starts the in-memory session dict is lost.
+        This method:
+
+        1. Looks up the persisted ``(caller_id, service) → npub`` binding.
+        2. Calls ``self.receive(npub, service, caller_id=caller_id)`` which
+           hits the vault-first fast path (no relay I/O).
+        3. The ``on_credentials_received`` callback fires, repopulating
+           the in-memory session.
+
+        Returns:
+            The restored npub on success, ``None`` on any failure.
+        """
+        vault = self._exchange._credential_vault
+        if vault is None or not isinstance(vault, SessionBindingBackend):
+            return None
+
+        try:
+            npub = await vault.fetch_session_binding(caller_id, service)
+        except Exception as exc:
+            logger.debug("Session binding lookup failed: %s", exc)
+            return None
+
+        if npub is None:
+            return None
+
+        try:
+            result = await self.receive(npub, service, caller_id=caller_id)
+            if result.get("success"):
+                return npub
+        except Exception as exc:
+            logger.debug("Session restoration failed: %s", exc)
+
+        return None
+
+    # -- Private helpers -----------------------------------------------------
+
+    async def _store_binding(
+        self, caller_id: str, service: str, npub: str,
+    ) -> None:
+        """Persist a session binding if the vault supports it."""
+        vault = self._exchange._credential_vault
+        if vault is not None and isinstance(vault, SessionBindingBackend):
+            try:
+                await vault.store_session_binding(caller_id, service, npub)
+            except Exception as exc:
+                logger.warning("Failed to store session binding: %s", exc)
+
+    async def _delete_binding(
+        self, caller_id: str, service: str,
+    ) -> None:
+        """Delete a session binding if the vault supports it."""
+        vault = self._exchange._credential_vault
+        if vault is not None and isinstance(vault, SessionBindingBackend):
+            try:
+                await vault.delete_session_binding(caller_id, service)
+            except Exception as exc:
+                logger.warning("Failed to delete session binding: %s", exc)
+
+    # -- Credential card -----------------------------------------------------
 
     def generate_credential_card(
         self,

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -119,6 +119,7 @@ class SecureCourierService:
 
         self._operator_nsec = operator_nsec
         self._send_card_dm = send_card_dm
+        self._sessions: dict[str, str] = {}  # caller_id → npub (in-memory)
 
         self._exchange = NostrCredentialExchange(
             nsec=operator_nsec,
@@ -232,6 +233,7 @@ class SecureCourierService:
 
             # Persist session binding for cold-start restoration
             if caller_id is not None:
+                self._sessions[caller_id] = sender_npub
                 await self._store_binding(caller_id, matched_service, sender_npub)
 
             # Generate credential card for scan-and-paste reuse
@@ -284,6 +286,7 @@ class SecureCourierService:
         result = await self._exchange.forget(sender_npub, service=service)
 
         if caller_id is not None:
+            self._sessions.pop(caller_id, None)
             await self._delete_binding(caller_id, service)
 
         return result
@@ -328,6 +331,41 @@ class SecureCourierService:
             logger.debug("Session restoration failed: %s", exc)
 
         return None
+
+    async def ensure_identity(
+        self,
+        caller_id: str,
+        service: str = "x",
+    ) -> str:
+        """Return the npub for *caller_id*, auto-restoring on cold start.
+
+        Every operator MCP server should call this instead of maintaining
+        its own in-memory session dict.
+
+        Fast path: in-memory ``_sessions`` cache hit → return immediately.
+        Cold-start path: ``restore_session()`` → vault binding lookup →
+        vault-first ``receive()`` → ``on_credentials_received`` callback →
+        operator session re-established.
+
+        Raises:
+            ValueError: No identity could be established (first-time user
+                or credentials were forgotten).
+        """
+        npub = self._sessions.get(caller_id)
+        if npub:
+            return npub
+
+        restored = await self.restore_session(caller_id, service)
+        if restored:
+            return restored
+
+        raise ValueError(
+            "No DPYC identity active. Credit operations require an npub. "
+            "Follow the Secure Courier onboarding flow: call "
+            "request_credential_channel(recipient_npub=<npub>), reply via Nostr DM, "
+            "then call receive_credentials(sender_npub=<npub>). "
+            "Get your npub from the dpyc-oracle's how_to_join() tool."
+        )
 
     # -- Private helpers -----------------------------------------------------
 

--- a/src/tollbooth/vaults/neon.py
+++ b/src/tollbooth/vaults/neon.py
@@ -392,7 +392,7 @@ class NeonCredentialVault:
         self._neon = neon_vault
 
     async def ensure_schema(self) -> None:
-        """Create the ``credentials`` table if it doesn't exist."""
+        """Create the ``credentials`` and ``session_bindings`` tables if they don't exist."""
         await self._neon._execute(
             "CREATE TABLE IF NOT EXISTS credentials ("
             "    service TEXT NOT NULL,"
@@ -402,6 +402,7 @@ class NeonCredentialVault:
             "    PRIMARY KEY (service, npub)"
             ")"
         )
+        await self.ensure_session_bindings_schema()
 
     async def store_credentials(
         self, service: str, npub: str, encrypted_blob: str,
@@ -435,5 +436,55 @@ class NeonCredentialVault:
         result = await self._neon._execute(
             "DELETE FROM credentials WHERE service = $1 AND npub = $2",
             [service, npub],
+        )
+        return (result.get("rowCount", 0) or 0) > 0
+
+    # -- SessionBindingBackend implementation --------------------------------
+
+    async def ensure_session_bindings_schema(self) -> None:
+        """Create the ``session_bindings`` table if it doesn't exist."""
+        await self._neon._execute(
+            "CREATE TABLE IF NOT EXISTS session_bindings ("
+            "    caller_id TEXT NOT NULL,"
+            "    service TEXT NOT NULL,"
+            "    npub TEXT NOT NULL,"
+            "    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+            "    PRIMARY KEY (caller_id, service)"
+            ")"
+        )
+
+    async def store_session_binding(
+        self, caller_id: str, service: str, npub: str,
+    ) -> None:
+        """Persist a session binding (upserts on conflict)."""
+        await self._neon._execute(
+            "INSERT INTO session_bindings (caller_id, service, npub, updated_at) "
+            "VALUES ($1, $2, $3, now()) "
+            "ON CONFLICT (caller_id, service) DO UPDATE "
+            "SET npub = EXCLUDED.npub, "
+            "    updated_at = now()",
+            [caller_id, service, npub],
+        )
+
+    async def fetch_session_binding(
+        self, caller_id: str, service: str,
+    ) -> str | None:
+        """Look up the npub for a caller+service pair."""
+        result = await self._neon._execute(
+            "SELECT npub FROM session_bindings "
+            "WHERE caller_id = $1 AND service = $2",
+            [caller_id, service],
+        )
+        rows = result.get("rows", [])
+        return rows[0]["npub"] if rows else None
+
+    async def delete_session_binding(
+        self, caller_id: str, service: str,
+    ) -> bool:
+        """Remove a session binding. Returns True if found and deleted."""
+        result = await self._neon._execute(
+            "DELETE FROM session_bindings "
+            "WHERE caller_id = $1 AND service = $2",
+            [caller_id, service],
         )
         return (result.get("rowCount", 0) or 0) > 0

--- a/tests/test_auto_restore.py
+++ b/tests/test_auto_restore.py
@@ -138,6 +138,7 @@ def _make_courier_service(
     svc = object.__new__(SecureCourierService)
     svc._operator_nsec = "nsec1fake"
     svc._send_card_dm = False
+    svc._sessions = {}
     svc._on_received = on_received
 
     exchange = MagicMock()
@@ -269,3 +270,76 @@ class TestBindingOnReceiveForget:
         await svc.forget("npub1abc", "thebrain")
 
         vault.delete_session_binding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_populates_in_memory_sessions(self):
+        """receive() with caller_id populates _sessions dict."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.store_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        assert "user_01" not in svc._sessions
+        await svc.receive("npub1abc", "thebrain", caller_id="user_01")
+        assert svc._sessions["user_01"] == "npub1abc"
+
+    @pytest.mark.asyncio
+    async def test_forget_clears_in_memory_sessions(self):
+        """forget() with caller_id clears _sessions dict."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.delete_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        svc._sessions["user_01"] = "npub1abc"
+        await svc.forget("npub1abc", "thebrain", caller_id="user_01")
+        assert "user_01" not in svc._sessions
+
+
+# ---------------------------------------------------------------------------
+# SecureCourierService — ensure_identity (operator-facing API)
+# ---------------------------------------------------------------------------
+
+class TestEnsureIdentity:
+
+    @pytest.mark.asyncio
+    async def test_fast_path_from_memory(self):
+        """In-memory _sessions hit → returns npub immediately, no vault I/O."""
+        svc, exchange = _make_courier_service(vault=None)
+        svc._sessions["user_01"] = "npub1abc"
+
+        result = await svc.ensure_identity("user_01", service="thebrain")
+        assert result == "npub1abc"
+        exchange.receive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cold_start_restore(self):
+        """No in-memory session → vault restore → returns npub."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.fetch_session_binding = AsyncMock(return_value="npub1abc")
+        vault.store_session_binding = AsyncMock()
+
+        callback = AsyncMock(return_value={"session": "active"})
+        svc, exchange = _make_courier_service(vault=vault, on_received=callback)
+
+        result = await svc.ensure_identity("user_01", service="thebrain")
+        assert result == "npub1abc"
+        # _sessions populated by receive() via restore_session()
+        assert svc._sessions["user_01"] == "npub1abc"
+
+    @pytest.mark.asyncio
+    async def test_no_binding_raises(self):
+        """No binding and no in-memory session → ValueError."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.fetch_session_binding = AsyncMock(return_value=None)
+
+        svc, _ = _make_courier_service(vault=vault)
+
+        with pytest.raises(ValueError, match="No DPYC identity active"):
+            await svc.ensure_identity("user_01", service="thebrain")
+
+    @pytest.mark.asyncio
+    async def test_no_vault_raises(self):
+        """No vault at all → ValueError."""
+        svc, _ = _make_courier_service(vault=None)
+
+        with pytest.raises(ValueError, match="No DPYC identity active"):
+            await svc.ensure_identity("user_01", service="thebrain")

--- a/tests/test_auto_restore.py
+++ b/tests/test_auto_restore.py
@@ -1,0 +1,271 @@
+"""Tests for auto-restore session binding (cold-start resilience)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tollbooth.credential_vault_backend import (
+    CredentialVaultBackend,
+    SessionBindingBackend,
+)
+from tollbooth.vaults.neon import NeonCredentialVault
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_neon_vault_mock(execute_return=None):
+    """Create a mock NeonVault with a controllable _execute."""
+    neon = MagicMock()
+    neon._execute = AsyncMock(return_value=execute_return or {})
+    return neon
+
+
+def _make_credential_vault(execute_return=None):
+    """Create a NeonCredentialVault wrapping a mocked NeonVault."""
+    neon = _make_neon_vault_mock(execute_return)
+    vault = NeonCredentialVault(neon_vault=neon)
+    return vault, neon
+
+
+# ---------------------------------------------------------------------------
+# NeonCredentialVault — SessionBindingBackend SQL operations
+# ---------------------------------------------------------------------------
+
+class TestSessionBindingSQL:
+    """Verify SQL round-trips via mocked _execute."""
+
+    @pytest.mark.asyncio
+    async def test_store_and_fetch_binding(self):
+        """Store a binding then fetch it back."""
+        vault, neon = _make_credential_vault()
+
+        # Store
+        await vault.store_session_binding("user_01", "thebrain", "npub1abc")
+        neon._execute.assert_called_once()
+        call_args = neon._execute.call_args
+        assert "INSERT INTO session_bindings" in call_args[0][0]
+        assert call_args[0][1] == ["user_01", "thebrain", "npub1abc"]
+
+        # Fetch
+        neon._execute.reset_mock()
+        neon._execute.return_value = {"rows": [{"npub": "npub1abc"}]}
+        result = await vault.fetch_session_binding("user_01", "thebrain")
+        assert result == "npub1abc"
+        assert "SELECT npub FROM session_bindings" in neon._execute.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_returns_none(self):
+        """Empty rows → None."""
+        vault, neon = _make_credential_vault({"rows": []})
+        result = await vault.fetch_session_binding("user_01", "thebrain")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_overwrites_npub(self):
+        """ON CONFLICT UPDATE behavior — SQL contains ON CONFLICT."""
+        vault, neon = _make_credential_vault()
+        await vault.store_session_binding("user_01", "thebrain", "npub1new")
+        sql = neon._execute.call_args[0][0]
+        assert "ON CONFLICT" in sql
+        assert "DO UPDATE" in sql
+
+    @pytest.mark.asyncio
+    async def test_delete_binding_found(self):
+        """rowCount > 0 → True."""
+        vault, neon = _make_credential_vault({"rowCount": 1})
+        result = await vault.delete_session_binding("user_01", "thebrain")
+        assert result is True
+        assert "DELETE FROM session_bindings" in neon._execute.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_delete_binding_not_found(self):
+        """rowCount == 0 → False."""
+        vault, neon = _make_credential_vault({"rowCount": 0})
+        result = await vault.delete_session_binding("user_01", "thebrain")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_ensure_schema_creates_session_bindings(self):
+        """ensure_schema() creates both credentials and session_bindings tables."""
+        vault, neon = _make_credential_vault()
+        await vault.ensure_schema()
+        # Should have been called twice: credentials + session_bindings
+        assert neon._execute.call_count == 2
+        sqls = [call[0][0] for call in neon._execute.call_args_list]
+        assert any("credentials" in s for s in sqls)
+        assert any("session_bindings" in s for s in sqls)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestProtocolConformance:
+
+    def test_neon_credential_vault_is_session_binding_backend(self):
+        """NeonCredentialVault satisfies the SessionBindingBackend protocol."""
+        vault, _ = _make_credential_vault()
+        assert isinstance(vault, SessionBindingBackend)
+
+    def test_neon_credential_vault_still_is_credential_vault_backend(self):
+        """NeonCredentialVault still satisfies CredentialVaultBackend."""
+        vault, _ = _make_credential_vault()
+        assert isinstance(vault, CredentialVaultBackend)
+
+    def test_plain_dict_is_not_session_binding_backend(self):
+        """A plain dict does NOT satisfy the protocol."""
+        assert not isinstance({}, SessionBindingBackend)
+
+
+# ---------------------------------------------------------------------------
+# SecureCourierService — restore_session flow
+# ---------------------------------------------------------------------------
+
+def _make_courier_service(
+    *,
+    vault=None,
+    on_received=None,
+):
+    """Create a SecureCourierService with mocked internals."""
+    from tollbooth.secure_courier import SecureCourierService
+
+    # We can't easily construct a real SecureCourierService without nostr deps,
+    # so we build one with mocked exchange.
+    svc = object.__new__(SecureCourierService)
+    svc._operator_nsec = "nsec1fake"
+    svc._send_card_dm = False
+    svc._on_received = on_received
+
+    exchange = MagicMock()
+    exchange._credential_vault = vault
+    exchange.receive = AsyncMock(return_value={
+        "success": True,
+        "service": "thebrain",
+        "credentials": {"api_key": "k", "brain_id": "b"},
+        "encryption": "vault",
+    })
+    exchange.forget = AsyncMock(return_value={"success": True, "deleted": True})
+    svc._exchange = exchange
+
+    return svc, exchange
+
+
+class TestRestoreSession:
+
+    @pytest.mark.asyncio
+    async def test_restore_calls_receive(self):
+        """restore_session() calls receive() with the stored npub."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.fetch_session_binding = AsyncMock(return_value="npub1abc")
+        vault.store_session_binding = AsyncMock()
+
+        callback = AsyncMock(return_value={"session": "active"})
+        svc, exchange = _make_courier_service(vault=vault, on_received=callback)
+
+        result = await svc.restore_session("user_01", service="thebrain")
+        assert result == "npub1abc"
+
+        # receive() was called on the exchange
+        exchange.receive.assert_called_once_with("npub1abc", service="thebrain")
+        # Callback fired
+        callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restore_no_binding_returns_none(self):
+        """No binding in vault → None, no receive() call."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.fetch_session_binding = AsyncMock(return_value=None)
+
+        svc, exchange = _make_courier_service(vault=vault)
+        result = await svc.restore_session("user_01", service="thebrain")
+        assert result is None
+        exchange.receive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_no_vault_returns_none(self):
+        """No vault at all → None."""
+        svc, exchange = _make_courier_service(vault=None)
+        result = await svc.restore_session("user_01", service="thebrain")
+        assert result is None
+        exchange.receive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_vault_without_binding_support(self):
+        """Vault doesn't implement SessionBindingBackend → None."""
+        # A plain CredentialVaultBackend without session binding methods
+        vault = MagicMock(spec=CredentialVaultBackend)
+        svc, exchange = _make_courier_service(vault=vault)
+        result = await svc.restore_session("user_01", service="thebrain")
+        assert result is None
+        exchange.receive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_receive_failure_returns_none(self):
+        """If receive() raises, restore returns None."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.fetch_session_binding = AsyncMock(return_value="npub1abc")
+
+        svc, exchange = _make_courier_service(vault=vault)
+        exchange.receive = AsyncMock(side_effect=RuntimeError("relay down"))
+
+        result = await svc.restore_session("user_01", service="thebrain")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# SecureCourierService — binding stored/deleted on receive/forget
+# ---------------------------------------------------------------------------
+
+class TestBindingOnReceiveForget:
+
+    @pytest.mark.asyncio
+    async def test_binding_stored_on_receive(self):
+        """caller_id param → store_session_binding called."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.store_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        await svc.receive("npub1abc", "thebrain", caller_id="user_01")
+
+        vault.store_session_binding.assert_called_once_with(
+            "user_01", "thebrain", "npub1abc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_binding_not_stored_without_caller_id(self):
+        """No caller_id → store_session_binding NOT called."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.store_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        await svc.receive("npub1abc", "thebrain")
+
+        vault.store_session_binding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_binding_deleted_on_forget(self):
+        """caller_id param → delete_session_binding called."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.delete_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        await svc.forget("npub1abc", "thebrain", caller_id="user_01")
+
+        vault.delete_session_binding.assert_called_once_with(
+            "user_01", "thebrain",
+        )
+
+    @pytest.mark.asyncio
+    async def test_binding_not_deleted_without_caller_id(self):
+        """No caller_id → delete_session_binding NOT called."""
+        vault = MagicMock(spec=SessionBindingBackend)
+        vault.delete_session_binding = AsyncMock()
+
+        svc, _ = _make_courier_service(vault=vault)
+        await svc.forget("npub1abc", "thebrain")
+
+        vault.delete_session_binding.assert_not_called()

--- a/tests/test_neon_credential_vault.py
+++ b/tests/test_neon_credential_vault.py
@@ -61,12 +61,13 @@ class TestEnsureSchema:
         )
         vault = _cred_vault(neon)
         await vault.ensure_schema()
-        neon._client.post.assert_called_once()
-        body = neon._client.post.call_args.kwargs.get(
-            "json", neon._client.post.call_args[1] if len(neon._client.post.call_args.args) > 1 else None
-        )
-        assert "credentials" in body["query"]
-        assert "IF NOT EXISTS" in body["query"]
+        # ensure_schema creates both credentials and session_bindings tables
+        assert neon._client.post.call_count == 2
+        first_body = neon._client.post.call_args_list[0].kwargs.get("json")
+        assert "credentials" in first_body["query"]
+        assert "IF NOT EXISTS" in first_body["query"]
+        second_body = neon._client.post.call_args_list[1].kwargs.get("json")
+        assert "session_bindings" in second_body["query"]
 
     @pytest.mark.asyncio
     async def test_schema_idempotent(self) -> None:
@@ -78,7 +79,8 @@ class TestEnsureSchema:
         vault = _cred_vault(neon)
         await vault.ensure_schema()
         await vault.ensure_schema()
-        assert neon._client.post.call_count == 2
+        # 2 tables per call × 2 calls = 4
+        assert neon._client.post.call_count == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `SessionBindingBackend` protocol to `credential_vault_backend.py` for persisting `(caller_id, service) → npub` session bindings
- Implements in `NeonCredentialVault` with a new `session_bindings` table (UPSERT/SELECT/DELETE)
- `SecureCourierService.receive()` and `forget()` gain `caller_id` keyword param for binding lifecycle
- New `restore_session(caller_id, service)` method: looks up persisted binding, calls vault-first `receive()` path, triggers `on_credentials_received` callback — zero relay I/O
- Bumps version to 0.1.70

Eliminates repeated identity drops on serverless cold starts (7 observed in a single session on 2026-03-04).

## Test plan
- [x] 18 new tests in `tests/test_auto_restore.py` covering SQL round-trips, protocol conformance, restore flow, binding lifecycle
- [x] Full suite green (1086 passed)
- [ ] After deploy: paid tool call after cold start should succeed without explicit `receive_credentials`
- [ ] `forget_credentials` + cold start → onboarding error (binding cleaned up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)