### PR TITLE
fix: handle plain-text Oracle responses in OracleClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.70"
+version = "0.1.71"
 description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/oracle_client.py
+++ b/src/tollbooth/oracle_client.py
@@ -84,9 +84,12 @@ class OracleClient:
                     try:
                         data = json.loads(block.text)
                     except (json.JSONDecodeError, TypeError):
-                        continue
+                        # Plain text response (e.g. markdown from how_to_join, about)
+                        return {"text": block.text}
                     if isinstance(data, dict):
                         return data
+                    # JSON-parsed but not a dict (e.g. a list or scalar)
+                    return {"text": block.text}
             raise OracleClientError(
                 f"Oracle returned unexpected response format: {result}"
             )

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -146,18 +146,83 @@ async def test_call_tool_calltoolresult_content():
 
 
 # ---------------------------------------------------------------------------
-# call_tool() — unexpected response format
+# call_tool() — plain text responses (non-JSON)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_plain_text():
+    """call_tool() wraps plain-text responses in {"text": ...}."""
+    markdown = "## How to Join\n\nStep 1: Generate a Nostr keypair..."
+
+    text_block = MagicMock()
+    text_block.text = markdown
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[text_block])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("how_to_join")
+
+    assert result == {"text": markdown}
+
+
+@pytest.mark.asyncio
+async def test_call_tool_plain_text_calltoolresult():
+    """call_tool() handles TextContent inside CallToolResult for plain text."""
+    markdown = "# DPYC\n\nDon't Pester Your Customer..."
+
+    text_block = MagicMock()
+    text_block.text = markdown
+
+    call_tool_result = MagicMock(spec=[])  # no .data attribute
+    call_tool_result.content = [text_block]
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=call_tool_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("about")
+
+    assert result == {"text": markdown}
+
+
+@pytest.mark.asyncio
+async def test_call_tool_json_non_dict():
+    """call_tool() wraps JSON arrays/scalars as {"text": ...}."""
+    text_block = MagicMock()
+    text_block.text = '["item1", "item2"]'
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=[text_block])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.oracle_client.Client", return_value=mock_client):
+        client = OracleClient(oracle_url="https://oracle.example.com/mcp")
+        result = await client.call_tool("some_tool")
+
+    assert result == {"text": '["item1", "item2"]'}
+
+
+# ---------------------------------------------------------------------------
+# call_tool() — unexpected response format (no text blocks at all)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_call_tool_unexpected_format():
-    """call_tool() raises on unexpected response (no parseable dict)."""
-    bad_block = MagicMock()
-    bad_block.text = "not json"
+    """call_tool() raises on empty list with no text blocks."""
+    empty_block = MagicMock(spec=[])  # no .text attribute
 
     mock_client = AsyncMock()
-    mock_client.call_tool = AsyncMock(return_value=[bad_block])
+    mock_client.call_tool = AsyncMock(return_value=[empty_block])
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Summary

- `OracleClient._parse_result()` only handled JSON-dict responses, but 4 of 5 Oracle tools return plain markdown strings
- `how_to_join`, `about`, `network_advisory`, and `lookup_member` (not-found case) all returned `TextContent(text="markdown...")` which failed `json.loads()` and raised `OracleClientError`
- Fix: non-JSON text blocks are now wrapped as `{"text": block.text}` — type-compatible with the existing `dict[str, Any]` return type
- Also handles JSON-parsed non-dict values (arrays, scalars) the same way
- Bumps version to 0.1.71

## Test plan

- [x] `test_call_tool_plain_text` — markdown string via raw list
- [x] `test_call_tool_plain_text_calltoolresult` — markdown string via CallToolResult.content
- [x] `test_call_tool_json_non_dict` — JSON array wrapped as text
- [x] `test_call_tool_unexpected_format` — blocks without `.text` still raise
- [x] Full suite: 1095 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)