### PR TITLE
feat: QR upload to nostr.build + trademark notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tollbooth DPYC
+# Tollbooth DPYC™
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI version](https://img.shields.io/pypi/v/tollbooth-dpyc)](https://pypi.org/project/tollbooth-dpyc/)
@@ -8,7 +8,7 @@
   <img src="https://raw.githubusercontent.com/lonniev/tollbooth-dpyc/main/docs/tollbooth-hero.png" alt="Milo drives the Lightning Turnpike — Don't Pester Your Customer" width="800">
 </p>
 
-**Don't Pester Your Customer** — Bitcoin Lightning micropayments for MCP servers.
+**Don't Pester Your Customer™** — Bitcoin Lightning micropayments for MCP servers.
 
 > *The metaphors in this project are drawn with admiration from* The Phantom Tollbooth *by Norton Juster, illustrated by Jules Feiffer (1961). Milo, Tock, the Tollbooth, Dictionopolis, and Digitopolis are creations of Mr. Juster's extraordinary imagination. We just built the payment infrastructure.*
 
@@ -396,6 +396,10 @@ pytest tests/ -q
 ## Further Reading
 
 [The Phantom Tollbooth on the Lightning Turnpike](https://stablecoin.myshopify.com/blogs/our-value/the-phantom-tollbooth-on-the-lightning-turnpike) — the full story of how we're monetizing the monetization of AI APIs, and then fading to the background.
+
+## Trademarks
+
+DPYC, Tollbooth DPYC, and Don't Pester Your Customer are trademarks of Lonnie VanZandt. See the [TRADEMARKS.md](https://github.com/lonniev/dpyc-community/blob/main/TRADEMARKS.md) in the dpyc-community repository for usage guidelines.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.71"
-description = "Don't Pester Your Customer — Bitcoin Lightning micropayments for MCP servers"
+version = "0.1.72"
+description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/src/tollbooth/media_upload.py
+++ b/src/tollbooth/media_upload.py
@@ -1,0 +1,75 @@
+"""NIP-96 media upload for Nostr-compatible image hosting.
+
+Uploads PNG images to nostr.build for inclusion in Nostr DMs.
+Used by SecureCourierService to send credential card QR codes
+as inline images rather than raw text strings.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+NOSTR_BUILD_UPLOAD_URL = "https://nostr.build/api/v2/upload/files"
+
+
+class MediaUploadError(Exception):
+    """Raised when a media upload fails."""
+
+
+async def upload_to_nostr_build(
+    png_bytes: bytes,
+    *,
+    alt: str = "DPYC credential card QR",
+    timeout: float = 15.0,
+) -> str:
+    """Upload PNG to nostr.build NIP-96 API. Returns the image URL.
+
+    Args:
+        png_bytes: Raw PNG image bytes.
+        alt: Alt-text for the uploaded image.
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        The public URL of the uploaded image.
+
+    Raises:
+        MediaUploadError: On HTTP errors, timeouts, or unexpected responses.
+    """
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.post(
+                NOSTR_BUILD_UPLOAD_URL,
+                files={"file": ("credential_card.png", png_bytes, "image/png")},
+                data={"alt": alt},
+            )
+        except httpx.TimeoutException as exc:
+            raise MediaUploadError(f"Upload timed out: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise MediaUploadError(f"Upload failed: {exc}") from exc
+
+    if resp.status_code != 200:
+        raise MediaUploadError(
+            f"Upload returned HTTP {resp.status_code}: {resp.text[:200]}"
+        )
+
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise MediaUploadError(f"Invalid JSON response: {exc}") from exc
+
+    # nostr.build returns {"status": "success", "data": [{"url": "..."}]}
+    try:
+        url = data["data"][0]["url"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise MediaUploadError(
+            f"Unexpected response structure: {exc}"
+        ) from exc
+
+    if not isinstance(url, str) or not url.startswith("http"):
+        raise MediaUploadError(f"Invalid URL in response: {url!r}")
+
+    return url

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -253,7 +253,9 @@ class SecureCourierService:
                     # Send credential card via Nostr DM on fresh relay receipt
                     is_vault_restore = result.get("encryption") == "vault"
                     if self._send_card_dm and not is_vault_restore:
-                        self._deliver_card_dm(sender_npub, matched_service, ncred)
+                        await self._deliver_card_dm(
+                            sender_npub, matched_service, ncred, qr_png=qr_png,
+                        )
                         result["credential_card_dm_sent"] = True
 
                 except Exception as exc:
@@ -428,34 +430,57 @@ class SecureCourierService:
 
         return ncred, qr_png
 
-    def _deliver_card_dm(
+    async def _deliver_card_dm(
         self,
         recipient_npub: str,
         service: str,
         ncred: str,
+        *,
+        qr_png: bytes | None = None,
     ) -> None:
         """Send the credential card string to the patron via Nostr DM.
 
         Runs in a fire-and-forget manner — DM delivery failures are
         logged but never propagated to the caller.
 
-        The DM contains the ``ncred1...`` string and brief usage
-        instructions.  QR rendering happens client-side when the patron
-        scans from their saved image; the DM provides the text fallback
-        for copy-paste.
+        When *qr_png* is provided, the QR image is uploaded to
+        nostr.build (NIP-96) and the resulting URL is included in the
+        DM so Nostr clients auto-render the image inline.
 
         Args:
             recipient_npub: Patron's npub (bech32).
             service: Service name (for the human-readable header).
             ncred: The ``ncred1...`` credential card string.
+            qr_png: Optional PNG bytes of the credential card QR code.
         """
-        dm_text = (
-            f"Your credential card for {service}:\n\n"
-            f"{ncred}\n\n"
-            "Save this string. To reactivate your session later, "
-            "paste it into the credential_card parameter — "
-            "no Courier exchange needed."
-        )
+        image_url: str | None = None
+        if qr_png is not None:
+            try:
+                from tollbooth.media_upload import upload_to_nostr_build
+
+                image_url = await upload_to_nostr_build(qr_png)
+            except Exception as exc:
+                logger.warning(
+                    "QR upload to nostr.build failed (non-fatal): %s", exc,
+                )
+
+        if image_url:
+            dm_text = (
+                f"Your credential card for {service}:\n\n"
+                f"{image_url}\n\n"
+                f"{ncred}\n\n"
+                "Save this string. To reactivate your session later, "
+                "paste it into the credential_card parameter — "
+                "no Courier exchange needed."
+            )
+        else:
+            dm_text = (
+                f"Your credential card for {service}:\n\n"
+                f"{ncred}\n\n"
+                "Save this string. To reactivate your session later, "
+                "paste it into the credential_card parameter — "
+                "no Courier exchange needed."
+            )
 
         try:
             self._exchange.send_dm(recipient_npub, dm_text)

--- a/tests/test_media_upload.py
+++ b/tests/test_media_upload.py
@@ -1,0 +1,170 @@
+"""Tests for media_upload.py — NIP-96 image upload to nostr.build."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from tollbooth.media_upload import MediaUploadError, upload_to_nostr_build
+
+
+# ---------------------------------------------------------------------------
+# upload_to_nostr_build tests
+# ---------------------------------------------------------------------------
+
+FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100  # minimal PNG-ish bytes
+FAKE_URL = "https://image.nostr.build/abc123.png"
+
+
+def _mock_response(*, status_code: int = 200, json_data: dict | None = None) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = '{"status":"success"}'
+    if json_data is not None:
+        resp.json.return_value = json_data
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_upload_success():
+    """Happy path: mock httpx returns URL."""
+    resp = _mock_response(json_data={"status": "success", "data": [{"url": FAKE_URL}]})
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.media_upload.httpx.AsyncClient", return_value=mock_client):
+        url = await upload_to_nostr_build(FAKE_PNG)
+
+    assert url == FAKE_URL
+    mock_client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_server_error():
+    """HTTP 500 raises MediaUploadError."""
+    resp = _mock_response(status_code=500)
+    resp.text = "Internal Server Error"
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.media_upload.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(MediaUploadError, match="HTTP 500"):
+            await upload_to_nostr_build(FAKE_PNG)
+
+
+@pytest.mark.asyncio
+async def test_upload_timeout():
+    """Timeout raises MediaUploadError."""
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.ReadTimeout("timed out")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.media_upload.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(MediaUploadError, match="timed out"):
+            await upload_to_nostr_build(FAKE_PNG)
+
+
+@pytest.mark.asyncio
+async def test_upload_bad_response():
+    """Missing URL in response raises MediaUploadError."""
+    resp = _mock_response(json_data={"status": "success", "data": []})
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tollbooth.media_upload.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(MediaUploadError, match="Unexpected response"):
+            await upload_to_nostr_build(FAKE_PNG)
+
+
+# ---------------------------------------------------------------------------
+# _deliver_card_dm integration tests (via SecureCourierService)
+# ---------------------------------------------------------------------------
+
+# These tests verify the DM text formatting with and without QR upload.
+# They mock the courier internals to avoid real Nostr connections.
+
+
+def _make_courier_service():
+    """Build a minimal SecureCourierService with mocked internals."""
+    # We can't construct SecureCourierService without nostr deps, so we
+    # test _deliver_card_dm as a standalone coroutine by building a
+    # minimal mock that has the method bound.
+    from tollbooth.secure_courier import SecureCourierService
+
+    svc = object.__new__(SecureCourierService)
+    svc._operator_nsec = "nsec1fake"
+    svc._send_card_dm = True
+    svc._sessions = {}
+
+    # Mock the exchange
+    svc._exchange = MagicMock()
+    svc._exchange.send_dm = MagicMock()
+    svc._on_received = None
+
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_dm_with_qr_includes_url():
+    """DM text contains image URL when upload succeeds."""
+    svc = _make_courier_service()
+
+    with patch(
+        "tollbooth.media_upload.upload_to_nostr_build",
+        new_callable=AsyncMock,
+        return_value=FAKE_URL,
+    ):
+        await svc._deliver_card_dm(
+            "npub1test", "mybrain", "ncred1abc123", qr_png=FAKE_PNG,
+        )
+
+    dm_text = svc._exchange.send_dm.call_args[0][1]
+    assert FAKE_URL in dm_text
+    assert "ncred1abc123" in dm_text
+
+
+@pytest.mark.asyncio
+async def test_dm_without_qr_no_url():
+    """DM text unchanged when qr_png=None."""
+    svc = _make_courier_service()
+
+    await svc._deliver_card_dm("npub1test", "mybrain", "ncred1abc123")
+
+    dm_text = svc._exchange.send_dm.call_args[0][1]
+    assert "nostr.build" not in dm_text
+    assert "ncred1abc123" in dm_text
+
+
+@pytest.mark.asyncio
+async def test_dm_upload_failure_still_sends():
+    """Upload fails but DM is still sent without URL (non-fatal)."""
+    svc = _make_courier_service()
+
+    with patch(
+        "tollbooth.media_upload.upload_to_nostr_build",
+        new_callable=AsyncMock,
+        side_effect=Exception("upload boom"),
+    ):
+        await svc._deliver_card_dm(
+            "npub1test", "mybrain", "ncred1abc123", qr_png=FAKE_PNG,
+        )
+
+    # DM should still be sent
+    svc._exchange.send_dm.assert_called_once()
+    dm_text = svc._exchange.send_dm.call_args[0][1]
+    assert "ncred1abc123" in dm_text
+    # No URL since upload failed
+    assert "nostr.build" not in dm_text


### PR DESCRIPTION
## Summary
- New `media_upload.py` with `upload_to_nostr_build()` — uploads credential card QR PNG to nostr.build NIP-96 API
- `_deliver_card_dm()` is now async; uploads QR before sending DM so Nostr clients auto-render the image inline
- Upload failure is non-fatal — DM still sent with just the `ncred1...` string
- ™ marks on first prominent use of DPYC, Tollbooth DPYC, Don't Pester Your Customer in README and pyproject.toml description
- Trademarks section added above License in README
- Version bump to 0.1.72

## Test plan
- [x] `test_upload_success` — happy path mock returns URL
- [x] `test_upload_server_error` — HTTP 500 raises MediaUploadError
- [x] `test_upload_timeout` — timeout raises MediaUploadError
- [x] `test_upload_bad_response` — missing URL raises MediaUploadError
- [x] `test_dm_with_qr_includes_url` — DM text contains image URL
- [x] `test_dm_without_qr_no_url` — DM text unchanged without QR
- [x] `test_dm_upload_failure_still_sends` — upload fails, DM still sent
- [x] Full suite: 1102 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)