### PR TITLE
chore: ECOSYSTEM_LINKS constant + relay propagation delay hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.73"
+version = "0.1.74"
 description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -20,7 +20,7 @@ from tollbooth.operator_protocol import OperatorProtocol, OPERATOR_BASE_CATALOG,
 from tollbooth.authority_protocol import AuthorityProtocol, AUTHORITY_BASE_CATALOG
 from tollbooth.oracle_protocol import OracleProtocol
 from tollbooth.ledger_cache import LedgerCache
-from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS
+from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS, ECOSYSTEM_LINKS
 from tollbooth.pricing import ToolPricing
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
@@ -184,6 +184,7 @@ __all__ = [
     "ToolTier",
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",
+    "ECOSYSTEM_LINKS",
     "verify_certificate_auto",
     "verify_nostr_certificate",
     "NOSTR_CERT_KIND",

--- a/src/tollbooth/constants.py
+++ b/src/tollbooth/constants.py
@@ -6,6 +6,20 @@ from enum import IntEnum
 MAX_INVOICE_SATS = 1_000_000  # 0.01 BTC cap per invoice
 LOW_BALANCE_FLOOR_API_SATS = 100  # minimum warning threshold
 
+# Canonical links to DPYC ecosystem repos and live services.
+# Operators should include these in service_status responses so
+# AI agents can discover sibling services without web search.
+ECOSYSTEM_LINKS: dict[str, str] = {
+    "dpyc_community": "https://github.com/lonniev/dpyc-community",
+    "tollbooth_dpyc": "https://github.com/lonniev/tollbooth-dpyc",
+    "tollbooth_authority": "https://github.com/lonniev/tollbooth-authority",
+    "thebrain_mcp": "https://github.com/lonniev/thebrain-mcp",
+    "excalibur_mcp": "https://github.com/lonniev/excalibur-mcp",
+    "dpyc_oracle": "https://github.com/lonniev/dpyc-oracle",
+    "tollbooth_sample": "https://github.com/lonniev/tollbooth-sample",
+    "dpyc_oracle_mcp": "https://dpyc-oracle.fastmcp.app/mcp",
+}
+
 
 class ToolTier(IntEnum):
     """Cost tiers for tool-call metering (satoshis per call)."""

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -602,6 +602,11 @@ class NostrCredentialExchange:
                     f"They should reply with their credentials using the @@@ format shown. "
                     f"Then call receive_credentials with their npub."
                 )
+                result["relay_propagation_note"] = (
+                    "Nostr relay propagation may take 30-60 seconds. "
+                    "If the welcome DM doesn't appear immediately in "
+                    "Primal or your client, wait a moment and refresh."
+                )
             except Exception as exc:
                 logger.warning("Welcome DM failed, falling back to manual: %s", exc)
                 result["welcome_dm_sent"] = False
@@ -696,8 +701,10 @@ class NostrCredentialExchange:
             raise CourierTimeout(
                 f"No DM found from {sender_npub} within the "
                 f"{self._freshness_window}-second freshness window. "
-                f"Make sure you sent the DM from your Nostr client and "
-                f"try again."
+                f"If you just sent your reply, Nostr relay propagation "
+                f"may take 10-30 seconds — wait a moment and try again. "
+                f"Otherwise, make sure you sent the DM from your Nostr "
+                f"client to the correct npub."
             )
 
         # Resolve poison expectation up front


### PR DESCRIPTION
## Summary
- **ECOSYSTEM_LINKS** dict in `constants.py` — canonical URLs for all DPYC ecosystem repos and live services. Operators include this in `service_status` responses so AI agents can discover sibling services without web search.
- **Relay propagation delay hints** in Secure Courier: `open_channel` now returns a `relay_propagation_note` field, and `receive` timeout message explains relay delay instead of just "try again."

Addresses task board items `ee3e0276` (ecosystem discoverability) and `abae54b9` (relay delay UX).

## Test plan
- [ ] `ECOSYSTEM_LINKS` importable from `tollbooth`
- [ ] `open_channel` response includes `relay_propagation_note` key
- [ ] `CourierTimeout` message mentions relay propagation delay
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)