### PR TITLE
feat: DPYC identity credential + federated trust cold path

### DIFF
--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -25,6 +25,15 @@ from tollbooth.pricing import ToolPricing
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
 from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
+from tollbooth.identity_credential import (
+    sign_identity_credential,
+    verify_identity_credential,
+    verify_credential_chain,
+    IdentityCredentialError,
+    IDENTITY_CREDENTIAL_KIND,
+    IDENTITY_CREDENTIAL_TAG,
+    IDENTITY_CREDENTIAL_LABEL,
+)
 
 try:
     from tollbooth.authority_client import AuthorityCertifier, AuthorityCertifyError
@@ -191,6 +200,14 @@ __all__ = [
     "verify_nostr_certificate",
     "NOSTR_CERT_KIND",
     "UNDERSTOOD_PROTOCOLS",
+    # Identity Credential
+    "sign_identity_credential",
+    "verify_identity_credential",
+    "verify_credential_chain",
+    "IdentityCredentialError",
+    "IDENTITY_CREDENTIAL_KIND",
+    "IDENTITY_CREDENTIAL_TAG",
+    "IDENTITY_CREDENTIAL_LABEL",
     # Registry
     "DPYCRegistry",
     "RegistryError",

--- a/src/tollbooth/identity_credential.py
+++ b/src/tollbooth/identity_credential.py
@@ -1,0 +1,293 @@
+"""DPYC Identity Credential — Nostr kind 30080 Schnorr-signed identity attestation.
+
+Operators issue identity credentials to citizens during Secure Courier
+onboarding.  A credential proves that a citizen's npub was verified by a
+registered operator.  The hot path (tool calls) never contacts the Oracle;
+the cold path (purchases/top-ups) uses the credential for chain-walk
+verification and ban checks.
+
+Structure (Nostr event):
+    kind: 30080 (NIP-33 parameterized replaceable)
+    pubkey: operator hex pubkey (issuer)
+    content: JSON {"citizen_npub", "operator_npub", "issued_at"}
+    tags: [d: jti, p: citizen_hex, t: dpyc-identity, L: dpyc.identity, expiration: unix_ts]
+    sig: Schnorr/BIP-340
+
+Dependencies: ``pynostr`` — install with ``pip install tollbooth-dpyc[nostr]``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+IDENTITY_CREDENTIAL_KIND = 30080
+"""NIP-33 parameterized replaceable event kind for DPYC identity credentials."""
+
+IDENTITY_CREDENTIAL_TAG = "dpyc-identity"
+IDENTITY_CREDENTIAL_LABEL = "dpyc.identity"
+
+# Default credential TTL: 30 days
+DEFAULT_CREDENTIAL_TTL_SECONDS = 30 * 24 * 3600
+
+
+class IdentityCredentialError(Exception):
+    """Raised when an identity credential fails validation."""
+
+
+def _npub_to_hex(npub: str) -> str:
+    """Convert a bech32 npub to hex pubkey string."""
+    from pynostr.key import PublicKey  # type: ignore[import-untyped]
+
+    return PublicKey.from_npub(npub).hex()
+
+
+def _hex_to_npub(hex_pubkey: str) -> str:
+    """Convert a hex pubkey to bech32 npub string."""
+    from pynostr.key import PublicKey  # type: ignore[import-untyped]
+
+    return PublicKey(bytes.fromhex(hex_pubkey)).bech32()
+
+
+def sign_identity_credential(
+    citizen_npub: str,
+    operator_nsec: str,
+    *,
+    ttl_seconds: int = DEFAULT_CREDENTIAL_TTL_SECONDS,
+) -> str:
+    """Sign a kind 30080 identity credential for a citizen.
+
+    Args:
+        citizen_npub: Citizen's bech32 npub to attest.
+        operator_nsec: Operator's bech32 nsec for signing.
+        ttl_seconds: Credential validity in seconds.
+
+    Returns:
+        JSON string of the signed Nostr event.
+
+    Raises:
+        IdentityCredentialError: On signing failure.
+    """
+    try:
+        from pynostr.event import Event  # type: ignore[import-untyped]
+        from pynostr.key import PrivateKey  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise IdentityCredentialError(
+            f"Missing dependency for identity credential signing: {e}. "
+            "Install with: pip install tollbooth-dpyc[nostr]"
+        ) from e
+
+    try:
+        private_key = PrivateKey.from_nsec(operator_nsec)
+        operator_hex = private_key.public_key.hex()
+        operator_npub = private_key.public_key.bech32()
+    except Exception as e:
+        raise IdentityCredentialError(f"Invalid operator nsec: {e}") from e
+
+    try:
+        citizen_hex = _npub_to_hex(citizen_npub)
+    except Exception as e:
+        raise IdentityCredentialError(f"Invalid citizen npub: {e}") from e
+
+    now = int(time.time())
+    expiration = now + ttl_seconds
+    jti = str(uuid.uuid4())
+
+    content = json.dumps(
+        {
+            "citizen_npub": citizen_npub,
+            "operator_npub": operator_npub,
+            "issued_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+        },
+        separators=(",", ":"),
+    )
+
+    event = Event(
+        kind=IDENTITY_CREDENTIAL_KIND,
+        content=content,
+        tags=[
+            ["d", jti],
+            ["p", citizen_hex],
+            ["t", IDENTITY_CREDENTIAL_TAG],
+            ["L", IDENTITY_CREDENTIAL_LABEL],
+            ["expiration", str(expiration)],
+        ],
+        pubkey=operator_hex,
+        created_at=now,
+    )
+    event.sign(private_key.hex())
+
+    return json.dumps(event.to_dict())
+
+
+def _get_tag_value(tags: list[list[str]], key: str) -> str | None:
+    """Extract the first value for a given tag key."""
+    for tag in tags:
+        if len(tag) >= 2 and tag[0] == key:
+            return tag[1]
+    return None
+
+
+def verify_identity_credential(
+    event_json: str,
+    expected_citizen_npub: str | None = None,
+) -> dict[str, Any]:
+    """Verify a kind 30080 identity credential.
+
+    Checks:
+      1. Schnorr signature validity
+      2. Event kind == 30080
+      3. NIP-40 expiration not past
+      4. d-tag (JTI) present
+      5. Citizen npub matches expected (if provided)
+
+    Args:
+        event_json: JSON string of the signed Nostr event.
+        expected_citizen_npub: If provided, verify the credential is for
+            this specific citizen.
+
+    Returns:
+        Dict with claims: citizen_npub, operator_npub, operator_hex,
+        issued_at, jti, expiration.
+
+    Raises:
+        IdentityCredentialError: On any verification failure.
+    """
+    try:
+        from pynostr.event import Event  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise IdentityCredentialError(
+            f"Missing dependency for identity credential verification: {e}. "
+            "Install with: pip install tollbooth-dpyc[nostr]"
+        ) from e
+
+    # Parse event JSON
+    try:
+        event_dict = json.loads(event_json)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise IdentityCredentialError(
+            f"Credential is not valid JSON: {e}"
+        ) from e
+
+    # Construct Event
+    try:
+        event = Event.from_dict(event_dict)
+    except Exception as e:
+        raise IdentityCredentialError(
+            f"Invalid Nostr event structure: {e}"
+        ) from e
+
+    # 1. Verify Schnorr signature
+    try:
+        if not event.verify():
+            raise IdentityCredentialError(
+                "Credential signature invalid — possible tampering."
+            )
+    except IdentityCredentialError:
+        raise
+    except Exception as e:
+        raise IdentityCredentialError(
+            f"Signature verification failed: {e}"
+        ) from e
+
+    # 2. Verify event kind
+    if event.kind != IDENTITY_CREDENTIAL_KIND:
+        raise IdentityCredentialError(
+            f"Not an identity credential (kind {event.kind}, "
+            f"expected {IDENTITY_CREDENTIAL_KIND})."
+        )
+
+    # 3. Check expiration (NIP-40)
+    expiration_str = _get_tag_value(event.tags, "expiration")
+    if not expiration_str:
+        raise IdentityCredentialError("Credential missing expiration tag.")
+    try:
+        expiration = int(expiration_str)
+    except (ValueError, TypeError) as e:
+        raise IdentityCredentialError(
+            f"Invalid expiration tag: {e}"
+        ) from e
+    if expiration < time.time():
+        raise IdentityCredentialError("Credential has expired.")
+
+    # 4. Extract JTI from d-tag
+    jti = _get_tag_value(event.tags, "d")
+    if not jti:
+        raise IdentityCredentialError("Credential missing d-tag (JTI).")
+
+    # 5. Extract claims from content
+    try:
+        claims = json.loads(event.content)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise IdentityCredentialError(
+            f"Credential content is not valid JSON: {e}"
+        ) from e
+
+    citizen_npub = claims.get("citizen_npub", "")
+    operator_npub = claims.get("operator_npub", "")
+
+    # 6. Verify citizen matches expected
+    if expected_citizen_npub and citizen_npub != expected_citizen_npub:
+        raise IdentityCredentialError(
+            "Credential citizen_npub does not match expected npub."
+        )
+
+    # 7. Verify signer matches claimed operator
+    try:
+        operator_hex = _npub_to_hex(operator_npub)
+    except Exception:
+        operator_hex = ""
+    if operator_hex and event.pubkey != operator_hex:
+        raise IdentityCredentialError(
+            "Credential signer does not match claimed operator_npub."
+        )
+
+    return {
+        "citizen_npub": citizen_npub,
+        "operator_npub": operator_npub,
+        "operator_hex": event.pubkey,
+        "issued_at": claims.get("issued_at", ""),
+        "jti": jti,
+        "expiration": expiration,
+    }
+
+
+async def verify_credential_chain(
+    event_json: str,
+    citizen_npub: str,
+    registry: Any,
+) -> dict[str, Any]:
+    """Verify an identity credential and that its issuer is a registered operator.
+
+    Performs full verification:
+      1. ``verify_identity_credential()`` — sig, kind, expiration, citizen match
+      2. Registry chain walk — issuer (operator) is a registered DPYC member
+
+    Args:
+        event_json: JSON string of the signed credential event.
+        citizen_npub: Expected citizen npub to verify against.
+        registry: A ``DPYCRegistry`` instance for membership verification.
+
+    Returns:
+        Claims dict from ``verify_identity_credential()``.
+
+    Raises:
+        IdentityCredentialError: On credential or chain verification failure.
+    """
+    claims = verify_identity_credential(event_json, citizen_npub)
+
+    operator_npub = claims["operator_npub"]
+    try:
+        await registry.check_membership(operator_npub)
+    except Exception as e:
+        raise IdentityCredentialError(
+            f"Credential issuer {operator_npub} is not a registered "
+            f"DPYC member: {e}"
+        ) from e
+
+    return claims

--- a/src/tollbooth/oracle_client.py
+++ b/src/tollbooth/oracle_client.py
@@ -100,3 +100,11 @@ class OracleClient:
         raise OracleClientError(
             f"Oracle returned unexpected response format: {result}"
         )
+
+    async def check_ban_status(self, npub: str) -> dict[str, Any]:
+        """Check whether *npub* is banned via the Oracle.
+
+        Returns ``{"banned": bool, "reason": str | None}``.
+        Raises ``OracleClientError`` on connection/parse failure.
+        """
+        return await self.call_tool("check_ban_status", {"npub": npub})

--- a/src/tollbooth/secure_courier.py
+++ b/src/tollbooth/secure_courier.py
@@ -62,6 +62,13 @@ try:
 except ImportError:
     _HAS_CREDENTIAL_CARD = False
 
+try:
+    from tollbooth.identity_credential import sign_identity_credential
+
+    _HAS_IDENTITY_CREDENTIAL = True
+except ImportError:
+    _HAS_IDENTITY_CREDENTIAL = False
+
 
 class SecureCourierService:
     """Reusable Secure Courier -- operators import and wire 3 MCP tools.
@@ -90,6 +97,7 @@ class SecureCourierService:
             | None
         ) = None,
         send_card_dm: bool = True,
+        credential_ttl_seconds: int = 30 * 24 * 3600,
     ) -> None:
         """Initialise the Secure Courier Service.
 
@@ -110,6 +118,8 @@ class SecureCourierService:
                 The DM contains the ``ncred1...`` string so the patron can
                 save it for scan-and-paste reuse.  Only sent on fresh relay
                 delivery, not on vault restores.
+            credential_ttl_seconds: TTL for issued identity credentials
+                (default 30 days).
         """
         if not _HAS_COURIER:
             raise RuntimeError(
@@ -119,7 +129,9 @@ class SecureCourierService:
 
         self._operator_nsec = operator_nsec
         self._send_card_dm = send_card_dm
+        self._credential_ttl = credential_ttl_seconds
         self._sessions: dict[str, str] = {}  # caller_id → npub (in-memory)
+        self._credentials: dict[str, str] = {}  # npub → signed credential JSON
 
         self._exchange = NostrCredentialExchange(
             nsec=operator_nsec,
@@ -156,6 +168,10 @@ class SecureCourierService:
     def relays(self) -> list[str]:
         """Configured relay URLs."""
         return self._exchange.relays
+
+    def get_identity_credential(self, npub: str) -> str | None:
+        """Return the signed identity credential for *npub*, or None."""
+        return self._credentials.get(npub)
 
     # -- Tool-level methods -------------------------------------------------
 
@@ -230,6 +246,21 @@ class SecureCourierService:
                         "on_credentials_received callback failed: %s", exc,
                     )
                     result["callback_error"] = str(exc)
+
+            # Issue identity credential (kind 30080) for this citizen
+            if _HAS_IDENTITY_CREDENTIAL:
+                try:
+                    credential = sign_identity_credential(
+                        citizen_npub=sender_npub,
+                        operator_nsec=self._operator_nsec,
+                        ttl_seconds=self._credential_ttl,
+                    )
+                    self._credentials[sender_npub] = credential
+                    result["identity_credential_issued"] = True
+                except Exception as exc:
+                    logger.warning(
+                        "Identity credential issuance failed: %s", exc,
+                    )
 
             # Persist session binding for cold-start restoration
             if caller_id is not None:

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -238,13 +238,44 @@ async def purchase_credits_tool(
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
     default_credit_ttl_seconds: int | None = None,
+    ban_check_oracle_url: str | None = None,
 ) -> dict[str, Any]:
     """Create a BTCPay invoice after verifying an Authority certificate.
 
     For OPERATOR use: the certified purchase flow. Every credit purchase
     requires a valid Authority-signed Nostr event certificate.
     The certificate's net_sats (amount after certification fee) determines the invoice amount.
+
+    If *ban_check_oracle_url* is provided, checks the Oracle for ban status
+    before proceeding.  Fail-closed: if the Oracle is unreachable, the
+    purchase is denied — never grant free access.
     """
+    # Ban check (fail-closed — Oracle unreachable = deny purchase)
+    if ban_check_oracle_url:
+        try:
+            from tollbooth.oracle_client import OracleClient
+
+            oracle = OracleClient(ban_check_oracle_url)
+            ban_result = await oracle.check_ban_status(user_id)
+            if ban_result.get("banned"):
+                reason = ban_result.get("reason", "banned")
+                return {
+                    "success": False,
+                    "error": f"Account suspended: {reason}. "
+                    "Credit purchases are not available for banned members.",
+                }
+        except Exception as exc:
+            logger.warning(
+                "Ban check failed for %s — denying purchase (fail-closed): %s",
+                user_id,
+                exc,
+            )
+            return {
+                "success": False,
+                "error": "Unable to verify account standing — purchase denied. "
+                "The Oracle may be temporarily unavailable. Try again later.",
+            }
+
     # Trust gate — authority_npub must be configured
     if not authority_npub:
         return {

--- a/tests/test_identity_credential.py
+++ b/tests/test_identity_credential.py
@@ -1,0 +1,275 @@
+"""Tests for DPYC identity credential — kind 30080 sign/verify round-trip."""
+
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from pynostr.key import PrivateKey  # type: ignore[import-untyped]
+
+from tollbooth.identity_credential import (
+    IDENTITY_CREDENTIAL_KIND,
+    IDENTITY_CREDENTIAL_TAG,
+    IDENTITY_CREDENTIAL_LABEL,
+    IdentityCredentialError,
+    sign_identity_credential,
+    verify_identity_credential,
+    verify_credential_chain,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def operator_keys():
+    """Generate an operator Nostr keypair."""
+    pk = PrivateKey()
+    return pk, pk.public_key.bech32(), pk.public_key.hex()
+
+
+@pytest.fixture()
+def citizen_keys():
+    """Generate a citizen Nostr keypair."""
+    pk = PrivateKey()
+    return pk, pk.public_key.bech32(), pk.public_key.hex()
+
+
+# ---------------------------------------------------------------------------
+# sign + verify round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSignAndVerify:
+    def test_round_trip(self, operator_keys, citizen_keys):
+        """Sign and immediately verify — happy path."""
+        _, operator_nsec_bech32, _ = operator_keys
+        # Need nsec for signing
+        op_pk = operator_keys[0]
+        op_nsec = op_pk.bech32()  # nsec bech32
+
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_nsec,
+            ttl_seconds=3600,
+        )
+
+        claims = verify_identity_credential(credential_json, citizen_npub)
+        assert claims["citizen_npub"] == citizen_npub
+        assert claims["operator_npub"] == operator_keys[1]  # operator npub
+        assert claims["jti"]  # non-empty
+        assert claims["expiration"] > time.time()
+        assert claims["issued_at"]  # non-empty
+
+    def test_event_structure(self, operator_keys, citizen_keys):
+        """Verify the raw event has correct kind, tags, and content."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, citizen_hex = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        event_dict = json.loads(credential_json)
+        assert event_dict["kind"] == IDENTITY_CREDENTIAL_KIND
+        assert event_dict["pubkey"] == operator_keys[2]  # operator hex
+
+        # Check tags
+        tags = event_dict["tags"]
+        tag_keys = [t[0] for t in tags]
+        assert "d" in tag_keys
+        assert "p" in tag_keys
+        assert "t" in tag_keys
+        assert "L" in tag_keys
+        assert "expiration" in tag_keys
+
+        # p-tag should be citizen hex
+        p_tags = [t for t in tags if t[0] == "p"]
+        assert p_tags[0][1] == citizen_hex
+
+        # t-tag
+        t_tags = [t for t in tags if t[0] == "t"]
+        assert t_tags[0][1] == IDENTITY_CREDENTIAL_TAG
+
+        # L-tag
+        l_tags = [t for t in tags if t[0] == "L"]
+        assert l_tags[0][1] == IDENTITY_CREDENTIAL_LABEL
+
+        # Content is valid JSON with expected fields
+        content = json.loads(event_dict["content"])
+        assert content["citizen_npub"] == citizen_npub
+        assert content["operator_npub"] == operator_keys[1]
+
+    def test_verify_without_expected_citizen(self, operator_keys, citizen_keys):
+        """Verify works without specifying expected citizen."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        claims = verify_identity_credential(credential_json)
+        assert claims["citizen_npub"] == citizen_npub
+
+
+# ---------------------------------------------------------------------------
+# Verification failures
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyFailures:
+    def test_expired_credential(self, operator_keys, citizen_keys):
+        """Credential with TTL in the past is rejected."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+            ttl_seconds=-10,  # already expired
+        )
+
+        with pytest.raises(IdentityCredentialError, match="expired"):
+            verify_identity_credential(credential_json, citizen_npub)
+
+    def test_wrong_citizen_npub(self, operator_keys, citizen_keys):
+        """Credential for wrong citizen is rejected."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+        other_pk = PrivateKey()
+        other_npub = other_pk.public_key.bech32()
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        with pytest.raises(IdentityCredentialError, match="does not match"):
+            verify_identity_credential(credential_json, other_npub)
+
+    def test_tampered_content(self, operator_keys, citizen_keys):
+        """Tampered event content fails signature check."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        event_dict = json.loads(credential_json)
+        event_dict["content"] = '{"citizen_npub":"npub1fake","operator_npub":"npub1fake","issued_at":"2026-01-01"}'
+
+        with pytest.raises(IdentityCredentialError, match="invalid|tampering"):
+            verify_identity_credential(json.dumps(event_dict), citizen_npub)
+
+    def test_wrong_kind(self, operator_keys, citizen_keys):
+        """Event with wrong kind is rejected."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        event_dict = json.loads(credential_json)
+        event_dict["kind"] = 30079  # wrong kind
+        # Re-sign needed for valid sig, but the kind check happens after sig
+        # So this should still fail on kind mismatch (if sig passes) or sig (if sig fails)
+        with pytest.raises(IdentityCredentialError):
+            verify_identity_credential(json.dumps(event_dict), citizen_npub)
+
+    def test_invalid_json(self):
+        """Non-JSON input is rejected."""
+        with pytest.raises(IdentityCredentialError, match="not valid JSON"):
+            verify_identity_credential("not json at all")
+
+    def test_missing_expiration_tag(self, operator_keys, citizen_keys):
+        """Event without expiration tag is rejected."""
+        from pynostr.event import Event  # type: ignore[import-untyped]
+
+        op_pk = operator_keys[0]
+        _, citizen_npub, citizen_hex = citizen_keys
+
+        # Build event manually without expiration
+        event = Event(
+            kind=IDENTITY_CREDENTIAL_KIND,
+            content=json.dumps({"citizen_npub": citizen_npub, "operator_npub": operator_keys[1], "issued_at": "now"}),
+            tags=[["d", "test-jti"], ["p", citizen_hex], ["t", IDENTITY_CREDENTIAL_TAG]],
+            pubkey=operator_keys[2],
+            created_at=int(time.time()),
+        )
+        event.sign(op_pk.hex())
+
+        with pytest.raises(IdentityCredentialError, match="expiration"):
+            verify_identity_credential(json.dumps(event.to_dict()), citizen_npub)
+
+
+# ---------------------------------------------------------------------------
+# Chain verification
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCredentialChain:
+    @pytest.mark.asyncio
+    async def test_registered_operator_passes(self, operator_keys, citizen_keys):
+        """Credential signed by registered operator passes chain verification."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        registry = AsyncMock()
+        registry.check_membership = AsyncMock(return_value={
+            "npub": operator_keys[1],
+            "role": "operator",
+            "status": "active",
+        })
+
+        claims = await verify_credential_chain(credential_json, citizen_npub, registry)
+        assert claims["citizen_npub"] == citizen_npub
+        registry.check_membership.assert_called_once_with(operator_keys[1])
+
+    @pytest.mark.asyncio
+    async def test_unregistered_operator_fails(self, operator_keys, citizen_keys):
+        """Credential signed by unregistered operator fails chain verification."""
+        op_pk = operator_keys[0]
+        _, citizen_npub, _ = citizen_keys
+
+        credential_json = sign_identity_credential(
+            citizen_npub=citizen_npub,
+            operator_nsec=op_pk.bech32(),
+        )
+
+        registry = AsyncMock()
+        registry.check_membership = AsyncMock(
+            side_effect=Exception("Not found in registry")
+        )
+
+        with pytest.raises(IdentityCredentialError, match="not a registered"):
+            await verify_credential_chain(credential_json, citizen_npub, registry)
+
+
+# ---------------------------------------------------------------------------
+# Error class
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityCredentialError:
+    def test_is_exception(self):
+        assert issubclass(IdentityCredentialError, Exception)
+
+    def test_can_be_raised(self):
+        with pytest.raises(IdentityCredentialError, match="test"):
+            raise IdentityCredentialError("test")


### PR DESCRIPTION
## Summary
- New `identity_credential.py`: kind 30080 Nostr identity credentials — operators issue Schnorr-signed credentials to citizens during Secure Courier onboarding
- `SecureCourierService.receive()` auto-issues credential on successful receipt, exposes via `get_identity_credential(npub)`
- `OracleClient.check_ban_status()` convenience method for cold-path ban checks
- `purchase_credits_tool()` gains optional `ban_check_oracle_url` — fail-closed ban enforcement before invoice creation
- 13 new tests covering sign/verify round-trip, expiry, tampering, chain verification, and error cases

## Design Decisions
- **Kind 30080** (not 30078 — collides with NIP-78 audit events in `nostr_audit.py`)
- **Fail-closed ban check**: Oracle unreachable = deny purchase, never grant free access
- **No migration code**: greenfield implementation, no legacy support

## Test plan
- [x] `pytest tests/test_identity_credential.py` — 13/13 pass
- [x] Full suite: 887 passed, 3 pre-existing failures (segno not installed)
- [ ] Integration: deploy to FastMCP Cloud with Oracle running, verify ban check on purchase

🤖 Generated with [Claude Code](https://claude.com/claude-code)