### PR TITLE
feat: add authority_config table to NeonVault

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.76"
+version = "0.1.77"
 description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/vaults/neon.py
+++ b/src/tollbooth/vaults/neon.py
@@ -267,6 +267,14 @@ class NeonVault:
             "    PRIMARY KEY (tool_name, window_key)"
             ")"
         )
+        # -- Authority configuration (curator npub, onboarding state) --
+        await self._execute(
+            "CREATE TABLE IF NOT EXISTS authority_config ("
+            "    key TEXT PRIMARY KEY,"
+            "    value TEXT NOT NULL,"
+            "    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+            ")"
+        )
 
     # -- Global demand counters (surge pricing) --------------------------------
 
@@ -408,6 +416,32 @@ class NeonVault:
         await self._execute(
             "UPDATE anchors SET ots_receipts_json = $1 WHERE id = $2",
             [ots_receipts_json, int(anchor_id)],
+        )
+
+    # -- Authority configuration -----------------------------------------------
+
+    async def get_config(self, key: str) -> str | None:
+        """Read a value from the ``authority_config`` table.
+
+        Returns ``None`` if the key does not exist.
+        """
+        try:
+            result = await self._execute(
+                "SELECT value FROM authority_config WHERE key = $1",
+                [key],
+            )
+            rows = result.get("rows", [])
+            return rows[0]["value"] if rows else None
+        except Exception:
+            return None
+
+    async def set_config(self, key: str, value: str) -> None:
+        """Upsert a value into the ``authority_config`` table."""
+        await self._execute(
+            "INSERT INTO authority_config (key, value, updated_at) "
+            "VALUES ($1, $2, now()) "
+            "ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = now()",
+            [key, value],
         )
 
     # -- Helpers -------------------------------------------------------------

--- a/tests/test_neon_vault.py
+++ b/tests/test_neon_vault.py
@@ -319,7 +319,7 @@ class TestEnsureSchema:
             return_value=_response(200, _sql_result(rows=[], command="CREATE"))
         )
         await vault.ensure_schema()
-        assert vault._client.post.call_count == 8  # 4 tables + 4 indexes
+        assert vault._client.post.call_count == 9  # 5 tables + 4 indexes
 
     @pytest.mark.asyncio
     async def test_schema_statements_use_if_not_exists(self) -> None:


### PR DESCRIPTION
## Summary
- Adds `authority_config` key-value table to NeonVault `ensure_schema()` for persisting Authority curator npub and onboarding state
- Adds `get_config()` / `set_config()` convenience methods on NeonVault
- Bumps version to 0.1.77

## Test plan
- [x] Existing test updated (schema statement count 8 → 9)
- [x] All 1137 tests pass
- [ ] Verify `ensure_schema()` creates table on Neon instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)