### PR TITLE
fix: remove legacy royalty payout + fix tax incidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ The `tollbooth.tools` package provides functions your MCP server wraps as tools.
 |----------|---------|
 | `purchase_credits_tool` | Creates a BTCPay invoice, records it as pending, returns a checkout link. Validates Authority certificate when `authority_public_key` is configured. |
 | `direct_purchase_tool` | Invoice without certificate — for Authority self-purchases (trust anchor has no upstream). |
-| `check_payment_tool` | Polls an invoice, credits the balance on settlement, fires the royalty payout. Idempotent. |
+| `check_payment_tool` | Polls an invoice, credits the balance on settlement. Idempotent. |
 | `check_balance_tool` | Returns current balance, usage summary, tier info, and invoice history. Read-only. |
 | `restore_credits_tool` | Recovers credits from a paid invoice lost to cache/vault issues. Checks vault first, falls back to BTCPay. |
 | `account_statement_tool` | 30-day purchase and usage history for a user. |
-| `btcpay_status_tool` | Diagnostics: BTCPay connectivity, store name, API key permissions, royalty config. |
+| `btcpay_status_tool` | Diagnostics: BTCPay connectivity, store name, API key permissions. |
 | `compute_low_balance_warning` | Pure function — returns a warning dict if balance is below threshold, `None` if healthy. |
 | `anchor_ledger_tool` | Creates a Merkle tree of all ledgers and submits root hash to OTS calendar servers. |
 | `get_anchor_proof_tool` | Retrieves a Merkle inclusion proof for a specific user's ledger entry. |
@@ -194,7 +194,6 @@ config = TollboothConfig(
     btcpay_host="https://your-btcpay.example.com",
     btcpay_store_id="your-store-id",
     btcpay_api_key="your-api-key",
-    tollbooth_royalty_address="tollbooth@btcpay.digitalthread.link",
 )
 
 # Create a BTCPay client
@@ -216,39 +215,31 @@ async with BTCPayClient(config.btcpay_host, config.btcpay_api_key, config.btcpay
 | `btcpay_tier_config` | `str \| None` | `None` | JSON string mapping tier names to credit multipliers |
 | `btcpay_user_tiers` | `str \| None` | `None` | JSON string mapping user IDs to tier names |
 | `seed_balance_sats` | `int` | `0` | Free starter balance granted to new users (0 to disable) |
-| `tollbooth_royalty_address` | `str \| None` | `None` | Lightning Address for the 2% royalty payout to the Tollbooth originator |
-| `tollbooth_royalty_percent` | `float` | `0.02` | Royalty percentage (0.02 = 2%) |
-| `tollbooth_royalty_min_sats` | `int` | `10` | Minimum royalty payout in sats (below this, no payout fires) |
 | `authority_public_key` | `str \| None` | `None` | Authority's Nostr npub (Schnorr certificates) or Ed25519 public key (legacy JWT). Required for `purchase_credits`. |
 | `credit_ttl_seconds` | `int \| None` | `None` | Credit expiration in seconds. `None` = no expiration. |
 | `constraints_enabled` | `bool` | `False` | Enable constraint engine evaluation on tool calls. |
 | `constraints_config` | `str \| None` | `None` | JSON constraint configuration (see Constraint Engine section). |
 
-## The Three-Party Settlement
+## The Certification Fee Cascade
 
-Here's where the story takes a turn that even Milo wouldn't expect.
+We didn't build Tollbooth to sell. We built it to **give away** — like the Massachusetts Turnpike Authority. The Authority doesn't operate every toll plaza. Independent operators run the booths. What the Authority does is simpler: it certifies purchase orders and collects a small fee for each certification.
 
-We didn't build Tollbooth to sell. We built it to **give away** — like the Massachusetts Turnpike Authority. The Authority doesn't operate every toll plaza. Independent operators run the booths. What the Authority does is simpler: it collects a small percentage of every fare that flows through infrastructure it designed.
+When a user purchases credits, the settlement involves a certification cascade:
 
-When a user purchases credits, the settlement is three-party:
+1. **Milo** pays the operator's Lightning invoice for the full requested amount
+2. **The operator** holds a pre-funded cert-sat balance at their Authority
+3. **The Authority** deducts a 2% certification fee from the operator's reserve when signing the purchase certificate
+4. **Each Authority** is itself an operator of its upstream Authority — the same 2% fee cascades up through the chain to the Prime Authority
 
-1. **Milo** pays the operator's Lightning invoice
-2. **The operator's** BTCPay Server credits Milo's balance
-3. **Automatically, in the background** — BTCPay creates a small payout to the Tollbooth originator's Lightning Address
-
-A royalty. Two percent of the fare. The operator sees it transparently in their BTCPay dashboard. Milo never knows it happened.
-
-The enforcement is both technical and social. At startup, Tollbooth inspects the operator's BTCPay API key permissions. If the key lacks payout capability, **Tollbooth refuses to start**. Not a warning. A hard stop. The social contract, made executable.
+The certification fee is the operator's cost of doing business — Milo always receives exactly the credits they paid for. The operator pre-funds their Authority reserve and treats the fee as overhead, just like payment processing costs.
 
 ## The Economics
 
-**For Milo (the user):** Nothing changes. Buy credits, use tools, drive the turnpike.
+**For Milo (the user):** Nothing changes. Buy credits, use tools, drive the turnpike. The invoice is always for the full amount requested.
 
-**For the operator:** A free, production-tested monetization framework. No license fee. The 2% royalty is a rounding error compared to the revenue you couldn't collect before. The tollbooth pays for itself on the first transaction.
+**For the operator:** A free, production-tested monetization framework. No license fee. The 2% certification fee is a cost of doing business — pre-fund your Authority reserve and forget about it.
 
-**For the ecosystem:** Revenue scales with adoption, not effort. Every new MCP server that installs Tollbooth becomes a node in the Lightning economy. The infrastructure hums along — collecting its modest fare, maintaining the roads, and making sure the turnpike stays open for everyone.
-
-*It's the transition from mining fees to transaction fees. You stop competing on compute and start collecting on flow.*
+**For the ecosystem:** Revenue scales with adoption, not effort. Every new MCP server that installs Tollbooth becomes a node in the Lightning economy. The fee cascade flows naturally through the Authority chain — no direct payouts, no separate settlement channels.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.77"
+version = "0.1.78"
 description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -15,9 +15,6 @@ class TollboothConfig:
     btcpay_tier_config: str | None = None
     btcpay_user_tiers: str | None = None
     seed_balance_sats: int = 0
-    tollbooth_royalty_address: str | None = None
-    tollbooth_royalty_percent: float = 0.02
-    tollbooth_royalty_min_sats: int = 10
     authority_npub: str | None = None  # Nostr npub (Schnorr verification)
     credit_ttl_seconds: int | None = 604800  # 7 days default, None = never
     flush_batch_size: int = 10

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -14,92 +14,12 @@ from tollbooth.certificate import CertificateError, verify_certificate_auto
 from tollbooth.config import TollboothConfig
 from tollbooth.ledger import UserLedger
 from tollbooth.ledger_cache import LedgerCache
-from tollbooth.lnurl import LnurlResolutionError, resolve_lightning_address
 from tollbooth.constants import LOW_BALANCE_FLOOR_API_SATS, MAX_INVOICE_SATS
 
 logger = logging.getLogger(__name__)
 
 # Default credit multiplier for users not in tier config
 _DEFAULT_MULTIPLIER = 1
-
-# Sanity ceiling for royalty payouts (independent of sats_to_btc_string ceiling).
-# 2% of a 5M-sat purchase = 100,000 sats — anything above is suspect.
-ROYALTY_PAYOUT_MAX_SATS = 100_000
-
-
-async def _attempt_royalty_payout(
-    btcpay: BTCPayClient,
-    invoice_amount_sats: int,
-    royalty_address: str,
-    royalty_percent: float,
-    royalty_min_sats: int,
-) -> dict[str, Any] | None:
-    """Attempt a royalty payout to the originator's Lightning Address.
-
-    Returns a result dict on success or partial failure, None if below minimum.
-    Never raises — catches all BTCPayError exceptions.
-    """
-    royalty_sats = int(invoice_amount_sats * royalty_percent)
-    if royalty_sats < royalty_min_sats:
-        return None
-
-    if royalty_sats > ROYALTY_PAYOUT_MAX_SATS:
-        logger.error(
-            "Royalty payout %d sats exceeds ceiling of %d — refusing payout. "
-            "Check royalty_percent (%.4f) or invoice amount (%d).",
-            royalty_sats, ROYALTY_PAYOUT_MAX_SATS,
-            royalty_percent, invoice_amount_sats,
-        )
-        return {
-            "royalty_sats": royalty_sats,
-            "royalty_address": royalty_address,
-            "royalty_error": (
-                f"Royalty amount ({royalty_sats:,} sats) exceeds safety ceiling "
-                f"({ROYALTY_PAYOUT_MAX_SATS:,} sats). Payout refused."
-            ),
-        }
-
-    # Resolve Lightning address to BOLT11 invoice (skip if already BOLT11)
-    destination = royalty_address
-    if not royalty_address.startswith("lnbc"):
-        try:
-            destination = await resolve_lightning_address(
-                royalty_address, royalty_sats,
-            )
-            logger.info(
-                "Resolved %s to BOLT11 invoice (%s…) for %d sats.",
-                royalty_address, destination[:20], royalty_sats,
-            )
-        except LnurlResolutionError as e:
-            logger.warning("LNURL resolution failed for %s: %s", royalty_address, e)
-            return {
-                "royalty_sats": royalty_sats,
-                "royalty_address": royalty_address,
-                "royalty_error": f"Lightning address resolution failed: {e}",
-            }
-
-    try:
-        payout = await btcpay.create_payout(destination, royalty_sats)
-        result = {
-            "royalty_sats": royalty_sats,
-            "royalty_address": royalty_address,
-            "payout_destination": destination[:30] + "…" if len(destination) > 30 else destination,
-            "payout_id": payout.get("id", ""),
-            "payout_state": payout.get("state", "Unknown"),
-        }
-        if result["payout_state"] == "AwaitingApproval":
-            result["payout_hint"] = (
-                "Payout is awaiting approval. If payouts never settle, "
-                "check Store Settings > Payout Processors > Automated Lightning Sender."
-            )
-        return result
-    except BTCPayError as e:
-        logger.warning("Royalty payout failed: %s", e)
-        return {
-            "royalty_sats": royalty_sats,
-            "royalty_address": royalty_address,
-            "royalty_error": str(e),
-        }
 
 
 def _get_tier_info(
@@ -244,7 +164,9 @@ async def purchase_credits_tool(
 
     For OPERATOR use: the certified purchase flow. Every credit purchase
     requires a valid Authority-signed Nostr event certificate.
-    The certificate's net_sats (amount after certification fee) determines the invoice amount.
+    The invoice is for the full amount_sats the patron requested — the
+    certification fee is the operator's cost of doing business, not a
+    patron-visible deduction.
 
     If *ban_check_oracle_url* is provided, checks the Oracle for ban status
     before proceeding.  Fail-closed: if the Oracle is unreachable, the
@@ -298,11 +220,12 @@ async def purchase_credits_tool(
     except CertificateError as e:
         return {"success": False, "error": f"Certificate rejected: {e}"}
 
-    # Use net_sats from the certificate as the invoice amount
-    net_sats = cert_claims["net_sats"]
+    # Invoice the patron for the full amount they requested — the
+    # certification fee is absorbed by the operator, not the patron.
+    invoice_sats = cert_claims["amount_sats"]
 
     result = await _create_purchase_invoice(
-        btcpay, cache, user_id, net_sats,
+        btcpay, cache, user_id, invoice_sats,
         tier_config_json, user_tiers_json,
         extra_metadata={"certificate_jti": cert_claims["jti"]},
         default_credit_ttl_seconds=default_credit_ttl_seconds,
@@ -342,16 +265,12 @@ async def check_payment_tool(
     tier_config_json: str | None = None,
     user_tiers_json: str | None = None,
     default_credit_ttl_seconds: int | None = None,
-    royalty_address: str | None = None,
-    royalty_percent: float = 0.02,
-    royalty_min_sats: int = 10,
 ) -> dict[str, Any]:
     """Poll a BTCPay invoice and credit the user's balance on settlement.
 
     Call this after the user pays an invoice from purchase_credits_tool. Safe
     to call multiple times — credits are only granted once per invoice
-    (idempotent via credited_invoices). On settlement, also fires a royalty
-    payout to the Tollbooth originator if royalty_address is configured.
+    (idempotent via credited_invoices).
     """
     try:
         invoice = await btcpay.get_invoice(invoice_id)
@@ -406,15 +325,6 @@ async def check_payment_tool(
             result["credits_granted"] = credited
             result["multiplier"] = multiplier
             result["message"] = f"Payment settled! {credited:,} credits added to your balance."
-
-            # Attempt royalty payout (never blocks credit settlement)
-            if royalty_address:
-                royalty_result = await _attempt_royalty_payout(
-                    btcpay, amount_sats, royalty_address,
-                    royalty_percent, royalty_min_sats,
-                )
-                if royalty_result is not None:
-                    result["royalty_payout"] = royalty_result
 
     elif status == "Expired":
         if invoice_id in ledger.pending_invoices:
@@ -876,15 +786,6 @@ async def btcpay_status_tool(
         config.btcpay_host and config.btcpay_store_id and config.btcpay_api_key
     )
 
-    # Royalty config
-    royalty_enabled = bool(config.tollbooth_royalty_address)
-    result["royalty_config"] = {
-        "enabled": royalty_enabled,
-        "address": config.tollbooth_royalty_address,
-        "percent": config.tollbooth_royalty_percent,
-        "min_sats": config.tollbooth_royalty_min_sats,
-    }
-
     if connection_vars_present and btcpay is not None:
         # Health check
         try:
@@ -911,9 +812,6 @@ async def btcpay_status_tool(
             key_info = await btcpay.get_api_key_info()
             permissions = key_info.get("permissions", [])
             required = ["btcpay.store.cancreateinvoice", "btcpay.store.canviewinvoices"]
-            if royalty_enabled:
-                required.append("btcpay.store.cancreatenonapprovedpullpayments")
-                required.append("btcpay.store.canviewstoresettings")
             present = [p for p in required if p in permissions]
             missing = [p for p in required if p not in permissions]
             result["api_key_permissions"] = {
@@ -926,29 +824,6 @@ async def btcpay_status_tool(
             result["api_key_permissions"] = {"error": str(e)}
         except Exception as e:
             result["api_key_permissions"] = {"error": str(e)}
-
-        # Payout processor check (only if royalties enabled)
-        if royalty_enabled:
-            try:
-                processors = await btcpay.get_payout_processors()
-                lightning_processor = any(
-                    "Lightning" in p.get("name", "") or "Lightning" in p.get("friendlyName", "")
-                    for p in processors
-                )
-                result["payout_processor"] = {
-                    "configured_count": len(processors),
-                    "lightning_automated": lightning_processor,
-                }
-                if not lightning_processor:
-                    result["payout_processor"]["warning"] = (
-                        "No Lightning Payout Processor configured. "
-                        "Royalty payouts will be created but never settle automatically. "
-                        "Go to: Store Settings > Payout Processors > Automated Lightning Sender"
-                    )
-            except BTCPayError as e:
-                result["payout_processor"] = {"error": str(e)}
-            except Exception as e:
-                result["payout_processor"] = {"error": str(e)}
     else:
         result["server_reachable"] = None
         result["store_name"] = None

--- a/tests/test_config_compat.py
+++ b/tests/test_config_compat.py
@@ -35,9 +35,6 @@ class TestConfigBackwardsCompatibility:
         assert config.btcpay_tier_config is None
         assert config.btcpay_user_tiers is None
         assert config.seed_balance_sats == 0
-        assert config.tollbooth_royalty_address is None
-        assert config.tollbooth_royalty_percent == 0.02
-        assert config.tollbooth_royalty_min_sats == 10
         assert config.authority_npub is None
         assert config.credit_ttl_seconds == 604800
         assert config.flush_batch_size == 10
@@ -54,9 +51,6 @@ class TestConfigBackwardsCompatibility:
             btcpay_tier_config='{"tiers":{}}',
             btcpay_user_tiers='{"users":{}}',
             seed_balance_sats=500,
-            tollbooth_royalty_address="bc1q...",
-            tollbooth_royalty_percent=0.05,
-            tollbooth_royalty_min_sats=20,
             authority_npub="npub1xxx",
             credit_ttl_seconds=3600,
             flush_batch_size=5,
@@ -70,9 +64,6 @@ class TestConfigBackwardsCompatibility:
         assert config.btcpay_tier_config == '{"tiers":{}}'
         assert config.btcpay_user_tiers == '{"users":{}}'
         assert config.seed_balance_sats == 500
-        assert config.tollbooth_royalty_address == "bc1q..."
-        assert config.tollbooth_royalty_percent == 0.05
-        assert config.tollbooth_royalty_min_sats == 20
         assert config.authority_npub == "npub1xxx"
         assert config.credit_ttl_seconds == 3600
         assert config.flush_batch_size == 5

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -22,8 +22,6 @@ from tollbooth.ledger import ToolUsage, Tranche, UserLedger
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.nostr_certificate import NOSTR_CERT_KIND, NOSTR_CERT_TAG, NOSTR_CERT_LABEL
 from tollbooth.tools.credits import (
-    ROYALTY_PAYOUT_MAX_SATS,
-    _attempt_royalty_payout,
     _get_multiplier,
     _get_tier_info,
     account_statement_tool,
@@ -35,7 +33,6 @@ from tollbooth.tools.credits import (
     reconcile_pending_invoices,
 )
 from tollbooth.constants import MAX_INVOICE_SATS
-from tollbooth.lnurl import LnurlResolutionError
 
 
 # ---------------------------------------------------------------------------
@@ -166,9 +163,6 @@ def _make_config(**overrides) -> TollboothConfig:
         "btcpay_api_key": "key-abc",
         "btcpay_tier_config": TIER_CONFIG,
         "btcpay_user_tiers": USER_TIERS,
-        "tollbooth_royalty_address": None,
-        "tollbooth_royalty_percent": 0.02,
-        "tollbooth_royalty_min_sats": 10,
     }
     defaults.update(overrides)
     return TollboothConfig(**defaults)
@@ -288,7 +282,7 @@ class TestPurchaseCredits:
         cache = _mock_cache()
         result = await purchase_credits_tool(
             btcpay, cache, "user1", 0,
-            certificate=_test_certificate(net_sats=0),
+            certificate=_test_certificate(amount_sats=0, net_sats=0),
             authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
@@ -300,7 +294,7 @@ class TestPurchaseCredits:
         cache = _mock_cache()
         result = await purchase_credits_tool(
             btcpay, cache, "user1", -100,
-            certificate=_test_certificate(net_sats=-100),
+            certificate=_test_certificate(amount_sats=-100, net_sats=-100),
             authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
@@ -349,12 +343,13 @@ class TestPurchaseCredits:
         cache = _mock_cache()
         result = await purchase_credits_tool(
             btcpay, cache, "user-vip", 500,
-            certificate=_test_certificate(net_sats=500),
+            certificate=_test_certificate(amount_sats=500, net_sats=490),
             authority_npub=_TEST_AUTHORITY_NPUB,
             tier_config_json=TIER_CONFIG, user_tiers_json=USER_TIERS,
         )
         assert result["tier"] == "vip"
         assert result["multiplier"] == 100
+        # Invoice for full amount_sats (500), not net_sats — patron pays sticker price
         assert result["expected_credits"] == 50000
 
 
@@ -721,7 +716,7 @@ class TestPurchaseCap:
         cache = _mock_cache()
         result = await purchase_credits_tool(
             btcpay, cache, "user1", MAX_INVOICE_SATS,
-            certificate=_test_certificate(net_sats=MAX_INVOICE_SATS),
+            certificate=_test_certificate(amount_sats=MAX_INVOICE_SATS, net_sats=MAX_INVOICE_SATS - 20),
             authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is True
@@ -733,478 +728,12 @@ class TestPurchaseCap:
         cache = _mock_cache()
         result = await purchase_credits_tool(
             btcpay, cache, "user1", MAX_INVOICE_SATS + 1,
-            certificate=_test_certificate(net_sats=MAX_INVOICE_SATS + 1),
+            certificate=_test_certificate(amount_sats=MAX_INVOICE_SATS + 1, net_sats=MAX_INVOICE_SATS),
             authority_npub=_TEST_AUTHORITY_NPUB,
         )
         assert result["success"] is False
         assert "maximum" in result["error"]
         assert "1,000,000" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# _attempt_royalty_payout
-# ---------------------------------------------------------------------------
-
-
-class TestAttemptRoyaltyPayout:
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_success(self, mock_resolve: AsyncMock) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(
-            return_value={"id": "payout-1", "state": "AwaitingApproval"}
-        )
-        result = await _attempt_royalty_payout(btcpay, 1000, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert result["royalty_sats"] == 20
-        assert result["royalty_address"] == "addr@ln"
-        assert result["payout_id"] == "payout-1"
-        assert result["payout_state"] == "AwaitingApproval"
-        assert "payout_destination" in result
-        mock_resolve.assert_called_once_with("addr@ln", 20)
-        btcpay.create_payout.assert_called_once_with(_MOCK_BOLT11, 20)
-
-    @pytest.mark.asyncio
-    async def test_below_minimum_returns_none(self) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        result = await _attempt_royalty_payout(btcpay, 100, "addr@ln", 0.02, 10)
-        # 100 * 0.02 = 2, below min of 10
-        assert result is None
-        btcpay.create_payout.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_at_minimum(self, mock_resolve: AsyncMock) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p-2", "state": "OK"})
-        result = await _attempt_royalty_payout(btcpay, 500, "addr@ln", 0.02, 10)
-        # 500 * 0.02 = 10, exactly at min
-        assert result is not None
-        assert result["royalty_sats"] == 10
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_btcpay_error_returns_dict_never_raises(self, mock_resolve: AsyncMock) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(
-            side_effect=BTCPayServerError("500 oops", status_code=500)
-        )
-        result = await _attempt_royalty_payout(btcpay, 1000, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert result["royalty_sats"] == 20
-        assert "royalty_error" in result
-        assert "500 oops" in result["royalty_error"]
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_percentage_math(self, mock_resolve: AsyncMock) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p", "state": "OK"})
-        result = await _attempt_royalty_payout(btcpay, 5000, "a@b", 0.05, 10)
-        assert result is not None
-        assert result["royalty_sats"] == 250  # 5000 * 0.05
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_int_truncation_rounding(self, mock_resolve: AsyncMock) -> None:
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p", "state": "OK"})
-        # 999 * 0.02 = 19.98, int() truncates to 19
-        result = await _attempt_royalty_payout(btcpay, 999, "a@b", 0.02, 10)
-        assert result is not None
-        assert result["royalty_sats"] == 19
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock,
-           side_effect=LnurlResolutionError("DNS resolution failed"))
-    async def test_lnurl_failure_returns_error_dict(self, mock_resolve: AsyncMock) -> None:
-        """LNURL resolution failure returns error dict, never raises."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        result = await _attempt_royalty_payout(btcpay, 1000, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert result["royalty_sats"] == 20
-        assert result["royalty_address"] == "addr@ln"
-        assert "royalty_error" in result
-        assert "Lightning address resolution failed" in result["royalty_error"]
-        btcpay.create_payout.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_bolt11_destination_skips_resolution(self) -> None:
-        """BOLT11 invoice destinations skip LNURL resolution entirely."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p", "state": "OK"})
-        bolt11 = "lnbc200n1pjdirectinvoice"
-        with patch(_RESOLVE_PATCH) as mock_resolve:
-            result = await _attempt_royalty_payout(btcpay, 1000, bolt11, 0.02, 10)
-        mock_resolve.assert_not_called()
-        assert result is not None
-        btcpay.create_payout.assert_called_once_with(bolt11, 20)
-
-
-# ---------------------------------------------------------------------------
-# Royalty payout ceiling
-# ---------------------------------------------------------------------------
-
-
-class TestRoyaltyPayoutCeiling:
-    @pytest.mark.asyncio
-    async def test_above_ceiling_refused(self) -> None:
-        """Royalty exceeding ROYALTY_PAYOUT_MAX_SATS is refused without calling BTCPay."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        # 10M * 0.02 = 200,000 sats — above 100K ceiling
-        result = await _attempt_royalty_payout(btcpay, 10_000_000, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert "royalty_error" in result
-        assert "safety ceiling" in result["royalty_error"]
-        assert result["royalty_sats"] == 200_000
-        btcpay.create_payout.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_at_ceiling_allowed(self, mock_resolve: AsyncMock) -> None:
-        """Royalty exactly at ROYALTY_PAYOUT_MAX_SATS is allowed."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p-1", "state": "OK"})
-        # 5M * 0.02 = 100,000 sats — exactly at ceiling
-        result = await _attempt_royalty_payout(btcpay, 5_000_000, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert "royalty_error" not in result
-        assert result["royalty_sats"] == ROYALTY_PAYOUT_MAX_SATS
-        btcpay.create_payout.assert_called_once()
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_just_below_ceiling_allowed(self, mock_resolve: AsyncMock) -> None:
-        """Royalty just below ceiling is allowed."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.create_payout = AsyncMock(return_value={"id": "p-2", "state": "OK"})
-        # 4,999,999 * 0.02 = 99,999.98 -> int() = 99,999
-        result = await _attempt_royalty_payout(btcpay, 4_999_999, "addr@ln", 0.02, 10)
-        assert result is not None
-        assert "royalty_error" not in result
-        assert result["royalty_sats"] == 99_999
-
-    @pytest.mark.asyncio
-    async def test_ceiling_catches_bad_percentage(self) -> None:
-        """A mis-configured 100% royalty rate is caught by the ceiling."""
-        btcpay = AsyncMock(spec=BTCPayClient)
-        # 500,000 * 1.0 = 500,000 sats — way above ceiling
-        result = await _attempt_royalty_payout(btcpay, 500_000, "addr@ln", 1.0, 10)
-        assert result is not None
-        assert "royalty_error" in result
-        assert "safety ceiling" in result["royalty_error"]
-        btcpay.create_payout.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# check_payment with royalty
-# ---------------------------------------------------------------------------
-
-
-class TestCheckPaymentWithRoyalty:
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_settled_triggers_payout(self, mock_resolve: AsyncMock) -> None:
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        btcpay.create_payout = AsyncMock(
-            return_value={"id": "payout-1", "state": "AwaitingApproval"}
-        )
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        assert result["credits_granted"] == 1000
-        assert "royalty_payout" in result
-        assert result["royalty_payout"]["royalty_sats"] == 20
-        assert result["royalty_payout"]["payout_id"] == "payout-1"
-        btcpay.create_payout.assert_called_once_with(_MOCK_BOLT11, 20)
-
-    @pytest.mark.asyncio
-    async def test_no_payout_when_address_none(self) -> None:
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address=None,
-        )
-        assert result["credits_granted"] == 1000
-        assert "royalty_payout" not in result
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_payout_failure_doesnt_block_credits(self, mock_resolve: AsyncMock) -> None:
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        btcpay.create_payout = AsyncMock(
-            side_effect=BTCPayServerError("fail", status_code=500)
-        )
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        assert result["success"] is True
-        assert result["credits_granted"] == 1000
-        assert result["royalty_payout"]["royalty_error"] is not None
-
-    @pytest.mark.asyncio
-    async def test_idempotent_path_skips_payout(self) -> None:
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        btcpay.create_payout = AsyncMock()
-        ledger = _ledger_with_balance(1000, credited_invoices=["inv-1"])
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        assert result["credits_granted"] == 0
-        assert "royalty_payout" not in result
-        btcpay.create_payout.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_below_minimum_skips_payout(self) -> None:
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "100",
-        })
-        btcpay.create_payout = AsyncMock()
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        # 100 * 0.02 = 2, below min 10 -> no royalty_payout key
-        assert result["credits_granted"] == 100
-        assert "royalty_payout" not in result
-        btcpay.create_payout.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock, return_value=_MOCK_BOLT11)
-    async def test_payout_awaiting_approval_includes_hint(self, mock_resolve: AsyncMock) -> None:
-        """AwaitingApproval payout state includes a payout_hint for operators."""
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        btcpay.create_payout = AsyncMock(
-            return_value={"id": "payout-1", "state": "AwaitingApproval"}
-        )
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        assert result["credits_granted"] == 1000
-        rp = result["royalty_payout"]
-        assert rp["payout_state"] == "AwaitingApproval"
-        assert "payout_hint" in rp
-        assert "Payout Processors" in rp["payout_hint"]
-
-    @pytest.mark.asyncio
-    @patch(_RESOLVE_PATCH, new_callable=AsyncMock,
-           side_effect=LnurlResolutionError("DNS timeout"))
-    async def test_lnurl_failure_doesnt_block_credits(self, mock_resolve: AsyncMock) -> None:
-        """LNURL resolution failure returns error but never blocks credit settlement."""
-        btcpay = _mock_btcpay({
-            "id": "inv-1", "status": "Settled", "amount": "1000",
-        })
-        ledger = UserLedger()
-        cache = _mock_cache(ledger)
-        result = await check_payment_tool(
-            btcpay, cache, "user1", "inv-1",
-            royalty_address="addr@ln", royalty_percent=0.02, royalty_min_sats=10,
-        )
-        assert result["success"] is True
-        assert result["credits_granted"] == 1000
-        rp = result["royalty_payout"]
-        assert "royalty_error" in rp
-        assert "Lightning address resolution failed" in rp["royalty_error"]
-        btcpay.create_payout.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# btcpay_status with royalty (uses TollboothConfig)
-# ---------------------------------------------------------------------------
-
-
-class TestBTCPayStatusRoyalty:
-    @pytest.mark.asyncio
-    async def test_royalty_config_shown(self) -> None:
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={
-            "permissions": [
-                "btcpay.store.cancreateinvoice",
-                "btcpay.store.canviewinvoices",
-                "btcpay.store.cancreatenonapprovedpullpayments",
-            ]
-        })
-
-        result = await btcpay_status_tool(config, btcpay)
-        assert result["royalty_config"]["enabled"] is True
-        assert result["royalty_config"]["address"] == "toll@ln"
-        assert result["royalty_config"]["percent"] == 0.02
-        assert result["royalty_config"]["min_sats"] == 10
-
-    @pytest.mark.asyncio
-    async def test_royalty_disabled_shown(self) -> None:
-        config = _make_config(
-            btcpay_host=None, btcpay_store_id=None, btcpay_api_key=None,
-            btcpay_tier_config=None, btcpay_user_tiers=None,
-        )
-        result = await btcpay_status_tool(config, None)
-        assert result["royalty_config"]["enabled"] is False
-        assert result["royalty_config"]["address"] is None
-
-    @pytest.mark.asyncio
-    async def test_permissions_success(self) -> None:
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={
-            "permissions": [
-                "btcpay.store.cancreateinvoice",
-                "btcpay.store.canviewinvoices",
-                "btcpay.store.cancreatenonapprovedpullpayments",
-                "btcpay.store.canviewstoresettings",
-            ]
-        })
-        btcpay.get_payout_processors = AsyncMock(return_value=[])
-
-        result = await btcpay_status_tool(config, btcpay)
-        perms = result["api_key_permissions"]
-        assert perms["missing"] == []
-        assert len(perms["present"]) == 4
-
-    @pytest.mark.asyncio
-    async def test_missing_payout_perm(self) -> None:
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={
-            "permissions": [
-                "btcpay.store.cancreateinvoice",
-                "btcpay.store.canviewinvoices",
-            ]
-        })
-
-        result = await btcpay_status_tool(config, btcpay)
-        perms = result["api_key_permissions"]
-        assert "btcpay.store.cancreatenonapprovedpullpayments" in perms["missing"]
-
-    @pytest.mark.asyncio
-    async def test_api_key_info_error(self) -> None:
-        config = _make_config()
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(
-            side_effect=BTCPayAuthError("unauthorized", status_code=401)
-        )
-
-        result = await btcpay_status_tool(config, btcpay)
-        assert "error" in result["api_key_permissions"]
-
-    @pytest.mark.asyncio
-    async def test_payout_processor_present(self) -> None:
-        """Lightning payout processor configured -> lightning_automated True, no warning."""
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
-        btcpay.get_payout_processors = AsyncMock(return_value=[
-            {"name": "AutomatedPayoutBlob", "friendlyName": "Automated Lightning Sender"},
-        ])
-
-        result = await btcpay_status_tool(config, btcpay)
-        pp = result["payout_processor"]
-        assert pp["configured_count"] == 1
-        assert pp["lightning_automated"] is True
-        assert "warning" not in pp
-
-    @pytest.mark.asyncio
-    async def test_payout_processor_missing(self) -> None:
-        """No payout processors -> lightning_automated False, warning present."""
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
-        btcpay.get_payout_processors = AsyncMock(return_value=[])
-
-        result = await btcpay_status_tool(config, btcpay)
-        pp = result["payout_processor"]
-        assert pp["configured_count"] == 0
-        assert pp["lightning_automated"] is False
-        assert "warning" in pp
-        assert "Payout Processors" in pp["warning"]
-
-    @pytest.mark.asyncio
-    async def test_payout_processor_error(self) -> None:
-        """get_payout_processors fails -> error captured, no crash."""
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
-        btcpay.get_payout_processors = AsyncMock(
-            side_effect=BTCPayError("forbidden", status_code=403)
-        )
-
-        result = await btcpay_status_tool(config, btcpay)
-        pp = result["payout_processor"]
-        assert "error" in pp
-
-    @pytest.mark.asyncio
-    async def test_payout_processor_skipped_no_royalty(self) -> None:
-        """Royalty disabled -> payout_processor not in result."""
-        config = _make_config(tollbooth_royalty_address=None)
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
-
-        result = await btcpay_status_tool(config, btcpay)
-        assert "payout_processor" not in result
-
-    @pytest.mark.asyncio
-    async def test_required_perms_include_viewstoresettings_when_royalty(self) -> None:
-        """When royalty is enabled, canviewstoresettings is in required permissions."""
-        config = _make_config(tollbooth_royalty_address="toll@ln")
-
-        btcpay = AsyncMock(spec=BTCPayClient)
-        btcpay.health_check = AsyncMock(return_value={"synchronized": True})
-        btcpay.get_store = AsyncMock(return_value={"name": "Store"})
-        btcpay.get_api_key_info = AsyncMock(return_value={"permissions": []})
-        btcpay.get_payout_processors = AsyncMock(return_value=[])
-
-        result = await btcpay_status_tool(config, btcpay)
-        perms = result["api_key_permissions"]
-        assert "btcpay.store.canviewstoresettings" in perms["required"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nostr_certificate.py
+++ b/tests/test_nostr_certificate.py
@@ -316,7 +316,7 @@ class TestPurchaseWithNostrCertificate:
             authority_npub=npub,
         )
         assert result["success"] is True
-        assert result["amount_sats"] == 980  # from certificate net_sats
+        assert result["amount_sats"] == 1000  # full amount_sats, not net_sats
 
     @pytest.mark.asyncio
     async def test_npub_only_config_works(self, nostr_keypair):
@@ -332,7 +332,7 @@ class TestPurchaseWithNostrCertificate:
             authority_npub=npub,
         )
         assert result["success"] is True
-        assert result["amount_sats"] == 500
+        assert result["amount_sats"] == 1000  # full amount_sats, not net_sats
 
     @pytest.mark.asyncio
     async def test_invalid_nostr_certificate_rejected(self, nostr_keypair):


### PR DESCRIPTION
## Summary
- **Tax incidence fix**: `purchase_credits` now invoices for the full `amount_sats` the patron requested. The certification fee is the operator's cost of doing business — patrons receive exactly the credits they paid for.
- **Royalty removal**: Remove `_attempt_royalty_payout()`, `ROYALTY_PAYOUT_MAX_SATS`, royalty fields from `TollboothConfig`, royalty params from `check_payment_tool` and `btcpay_status_tool`.
- **README update**: Rewrite economics section to describe the certification fee cascade instead of royalty payouts.

## Test plan
- [x] All 1108 tests pass
- [ ] Verify downstream MCPs (thebrain-mcp, excalibur-mcp, tollbooth-authority) work with this version

🤖 Generated with [Claude Code](https://claude.com/claude-code)