### PR TITLE
feat: welcome DM provenance + invoice DM callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.1.78"
+version = "0.1.79"
 description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/credential_templates.py
+++ b/src/tollbooth/credential_templates.py
@@ -87,6 +87,20 @@ def validate_payload(
     return payload_fields
 
 
+def render_credential_payload_lines(template: CredentialTemplate) -> list[str]:
+    """Return only the ``key = @@@placeholder@@@`` lines for a template.
+
+    Used by the welcome DM builder to embed the payload section inside a
+    larger structured message without duplicating the Service/Description
+    header that :func:`render_delimited_instructions` includes.
+    """
+    lines: list[str] = []
+    for name in template.fields:
+        placeholder = f"PASTE_YOUR_{name.upper()}_HERE"
+        lines.append(f"  {name} = @@@{placeholder}@@@")
+    return lines
+
+
 def render_delimited_instructions(template: CredentialTemplate) -> str:
     """Render a credential template using @@@ delimiters (mobile-friendly).
 

--- a/src/tollbooth/nostr_credentials.py
+++ b/src/tollbooth/nostr_credentials.py
@@ -562,14 +562,21 @@ class NostrCredentialExchange:
         # Build the welcome message for the patron
         from datetime import datetime, timezone
         from tollbooth import __version__ as _tb_version
+        from tollbooth.credential_templates import render_credential_payload_lines
 
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        payload_lines = render_credential_payload_lines(template)
         welcome_text = (
             f"{greeting}\n\n"
-            f"{instructions}\n"
+            f"--- Credential Payload ---\n"
+            + "\n".join(payload_lines) + "\n"
             f"  poison = @@@{poison}@@@\n\n"
             f"IMPORTANT: include the anti-replay token exactly as shown.\n\n"
-            f"— tollbooth-dpyc v{_tb_version} | {timestamp}\n\n"
+            f"--- Message Provenance ---\n"
+            f"Service: {template.description or template.service}\n"
+            f"Operator: {self._npub}\n"
+            f"Sent: {timestamp}\n"
+            f"Protocol: DPYC Secure Courier v{_tb_version}\n\n"
             f"Your reply is end-to-end encrypted — "
             f"only this service can read it.\n"
             f"If you didn't request this, simply ignore this message."

--- a/src/tollbooth/tools/credits.py
+++ b/src/tollbooth/tools/credits.py
@@ -7,6 +7,7 @@ import json
 import logging
 import platform
 from datetime import date, datetime, timedelta, timezone
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from tollbooth.btcpay_client import BTCPayClient, BTCPayAuthError, BTCPayError
@@ -74,6 +75,7 @@ async def _create_purchase_invoice(
     user_tiers_json: str | None,
     extra_metadata: dict[str, Any] | None = None,
     default_credit_ttl_seconds: int | None = None,
+    invoice_dm_callback: Callable[[str], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Shared logic: validate amount, create BTCPay invoice, record in ledger.
 
@@ -145,6 +147,23 @@ async def _create_purchase_invoice(
     }
     if ttl is not None:
         result["credit_ttl_seconds"] = ttl
+
+    # Fire-and-forget invoice DM — failure never blocks the purchase
+    if invoice_dm_callback is not None:
+        dm_text = (
+            f"Lightning Invoice -- {amount_sats:,} sats\n\n"
+            f"Pay here: {checkout_link}\n\n"
+            f"Invoice: {invoice_id}\n"
+            f"Expires: {expiry}\n\n"
+            f"After paying, your credits appear automatically."
+        )
+        try:
+            await invoice_dm_callback(dm_text)
+            result["invoice_dm_sent"] = True
+        except Exception:
+            logger.warning("Invoice DM delivery failed for %s.", user_id)
+            result["invoice_dm_sent"] = False
+
     return result
 
 
@@ -159,6 +178,7 @@ async def purchase_credits_tool(
     user_tiers_json: str | None = None,
     default_credit_ttl_seconds: int | None = None,
     ban_check_oracle_url: str | None = None,
+    invoice_dm_callback: Callable[[str], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Create a BTCPay invoice after verifying an Authority certificate.
 
@@ -229,6 +249,7 @@ async def purchase_credits_tool(
         tier_config_json, user_tiers_json,
         extra_metadata={"certificate_jti": cert_claims["jti"]},
         default_credit_ttl_seconds=default_credit_ttl_seconds,
+        invoice_dm_callback=invoice_dm_callback,
     )
     if result.get("success"):
         result["certificate_jti"] = cert_claims["jti"]

--- a/tests/test_credit_tools.py
+++ b/tests/test_credit_tools.py
@@ -353,6 +353,69 @@ class TestPurchaseCredits:
         assert result["expected_credits"] == 50000
 
 
+class TestInvoiceDmCallback:
+    """Tests for the invoice_dm_callback parameter on purchase_credits_tool."""
+
+    @pytest.mark.asyncio
+    async def test_dm_callback_fires_on_success(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-dm-1",
+            "checkoutLink": "https://pay.example.com/inv-dm-1",
+            "expirationTime": "2026-03-08T00:00:00Z",
+        })
+        cache = _mock_cache()
+        dm_cb = AsyncMock()
+
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", 1000,
+            certificate=_test_certificate(net_sats=1000),
+            authority_npub=_TEST_AUTHORITY_NPUB,
+            invoice_dm_callback=dm_cb,
+        )
+        assert result["success"] is True
+        assert result["invoice_dm_sent"] is True
+        dm_cb.assert_awaited_once()
+        dm_text = dm_cb.call_args[0][0]
+        assert "1,000 sats" in dm_text
+        assert "https://pay.example.com/inv-dm-1" in dm_text
+
+    @pytest.mark.asyncio
+    async def test_dm_callback_failure_does_not_block_purchase(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-dm-2",
+            "checkoutLink": "https://pay.example.com/inv-dm-2",
+            "expirationTime": "2026-03-08T00:00:00Z",
+        })
+        cache = _mock_cache()
+        dm_cb = AsyncMock(side_effect=Exception("relay down"))
+
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", 1000,
+            certificate=_test_certificate(net_sats=1000),
+            authority_npub=_TEST_AUTHORITY_NPUB,
+            invoice_dm_callback=dm_cb,
+        )
+        assert result["success"] is True
+        assert result["invoice_dm_sent"] is False
+        assert result["invoice_id"] == "inv-dm-2"
+
+    @pytest.mark.asyncio
+    async def test_no_callback_means_no_dm_key(self) -> None:
+        btcpay = _mock_btcpay({
+            "id": "inv-dm-3",
+            "checkoutLink": "https://pay.example.com/inv-dm-3",
+        })
+        cache = _mock_cache()
+
+        result = await purchase_credits_tool(
+            btcpay, cache, "user1", 1000,
+            certificate=_test_certificate(net_sats=1000),
+            authority_npub=_TEST_AUTHORITY_NPUB,
+        )
+        assert result["success"] is True
+        assert "invoice_dm_sent" not in result
+
+
 # ---------------------------------------------------------------------------
 # check_payment
 # ---------------------------------------------------------------------------

--- a/tests/test_nostr_credentials.py
+++ b/tests/test_nostr_credentials.py
@@ -1458,8 +1458,10 @@ class TestConversationalDmFlow:
         mock_send.assert_called_once()
         welcome_text = mock_send.call_args[0][1]
         assert greeting in welcome_text
+        assert "--- Credential Payload ---" in welcome_text
+        assert "--- Message Provenance ---" in welcome_text
+        assert "DPYC Secure Courier v" in welcome_text
         assert "If you didn't request this" in welcome_text
-        assert "tollbooth-dpyc v" in welcome_text
 
     @pytest.mark.asyncio
     async def test_success_dm_sent_after_receive(self):


### PR DESCRIPTION
## Summary
- Add structured section headers (`--- Credential Payload ---`, `--- Message Provenance ---`) to Secure Courier welcome DM with service name, operator npub, timestamp, and protocol version
- Add `render_credential_payload_lines()` helper to `credential_templates.py` for reusable payload-only line rendering
- Add `invoice_dm_callback` parameter to `_create_purchase_invoice()` and `purchase_credits_tool()` — fire-and-forget Nostr DM with checkout link after invoice creation; DM failure never blocks the purchase
- Bump version to 0.1.79

## Test plan
- [x] `test_welcome_dm_is_conversational` updated for new section headers
- [x] `TestInvoiceDmCallback::test_dm_callback_fires_on_success` — callback fires, `invoice_dm_sent: True`
- [x] `TestInvoiceDmCallback::test_dm_callback_failure_does_not_block_purchase` — callback raises, purchase succeeds, `invoice_dm_sent: False`
- [x] `TestInvoiceDmCallback::test_no_callback_means_no_dm_key` — backward compat, no `invoice_dm_sent` key
- [x] Full test suite: 159 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)