### PR TITLE
Update DEFAULT_REGISTRY_URL for lookup cache rename

### DIFF
--- a/src/tollbooth/registry.py
+++ b/src/tollbooth/registry.py
@@ -11,7 +11,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 DEFAULT_REGISTRY_URL = (
-    "https://raw.githubusercontent.com/lonniev/dpyc-community/main/members.json"
+    "https://raw.githubusercontent.com/lonniev/dpyc-community/main/members/read-only-lookup-cache.json"
 )
 
 
@@ -22,7 +22,7 @@ class RegistryError(Exception):
 class DPYCRegistry:
     """Cached DPYC community membership lookup via HTTP.
 
-    Fetches the community members.json from the registry URL and caches it
+    Fetches the community lookup cache from the registry URL and caches it
     with a monotonic-clock TTL. Any HTTP, parse, or structure error raises
     ``RegistryError`` (fail closed — no silent pass-through).
     """

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -227,4 +227,4 @@ async def test_convenience_function():
 def test_default_registry_url():
     """DEFAULT_REGISTRY_URL points to dpyc-community on GitHub."""
     assert "dpyc-community" in DEFAULT_REGISTRY_URL
-    assert "members.json" in DEFAULT_REGISTRY_URL
+    assert "read-only-lookup-cache.json" in DEFAULT_REGISTRY_URL


### PR DESCRIPTION
## Summary
- Update `DEFAULT_REGISTRY_URL` to point to `members/read-only-lookup-cache.json`
- Update test assertion for the new URL

## Context
dpyc-community [PR #49](https://github.com/lonniev/dpyc-community/pull/49) moved the generated lookup cache into `members/` and renamed it to clarify its role as a generated artifact.

## Merge order
1. dpyc-community PR #49 (so the file exists at the new path)
2. **This PR** (tollbooth-dpyc — updates the canonical default URL)
3. Then downstream PRs (thebrain-mcp, excalibur-mcp, tollbooth-authority, dpyc-oracle)

## Test plan
- [x] 1111/1111 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)