### PR TITLE
feat: runtime-configurable pricing models

### DIFF
--- a/src/tollbooth/__init__.py
+++ b/src/tollbooth/__init__.py
@@ -22,6 +22,7 @@ from tollbooth.oracle_protocol import OracleProtocol
 from tollbooth.ledger_cache import LedgerCache
 from tollbooth.constants import ToolTier, MAX_INVOICE_SATS, LOW_BALANCE_FLOOR_API_SATS, ECOSYSTEM_LINKS
 from tollbooth.pricing import ToolPricing
+from tollbooth.pricing_model import PricingModel, ToolPrice, PipelineStep
 from tollbooth.vaults import TheBrainVault, NeonVault, NeonQueryError
 from tollbooth.ots import MerkleTree, InclusionProof, OTSCalendarClient
 from tollbooth.nostr_certificate import verify_nostr_certificate, NOSTR_CERT_KIND
@@ -46,6 +47,16 @@ try:
 except ImportError:
     OracleClient = None  # type: ignore[assignment,misc]
     OracleClientError = None  # type: ignore[assignment,misc]
+
+try:
+    from tollbooth.pricing_store import PricingModelStore
+except ImportError:
+    PricingModelStore = None  # type: ignore[assignment,misc]
+
+try:
+    from tollbooth.pricing_resolver import PricingResolver
+except ImportError:
+    PricingResolver = None  # type: ignore[assignment,misc]
 
 try:
     from tollbooth.nostr_audit import NostrAuditPublisher, AuditedVault
@@ -192,6 +203,11 @@ __all__ = [
     "NeonVault",
     "NeonQueryError",
     "ToolPricing",
+    "PricingModel",
+    "ToolPrice",
+    "PipelineStep",
+    "PricingModelStore",
+    "PricingResolver",
     "ToolTier",
     "MAX_INVOICE_SATS",
     "LOW_BALANCE_FLOOR_API_SATS",

--- a/src/tollbooth/config.py
+++ b/src/tollbooth/config.py
@@ -25,3 +25,5 @@ class TollboothConfig:
     # Constraint Engine (opt-in)
     constraints_enabled: bool = False
     constraints_config: str | None = None  # JSON string of constraint config
+    # Pricing Model cache TTL (PricingResolver)
+    pricing_cache_ttl_seconds: float = 300.0

--- a/src/tollbooth/constraints/gate.py
+++ b/src/tollbooth/constraints/gate.py
@@ -56,6 +56,7 @@ class ConstraintGate:
     def __init__(self, config: TollboothConfig) -> None:
         self._enabled = config.constraints_enabled
         self._engine: ConstraintEngine | None = None
+        self._resolver: Any | None = None  # PricingResolver (avoid circular import)
 
         if self._enabled and config.constraints_config:
             try:
@@ -64,6 +65,14 @@ class ConstraintGate:
             except (json.JSONDecodeError, ConfigError) as e:
                 logger.error("Failed to load constraint config: %s", e)
                 self._enabled = False
+
+    def attach_resolver(self, resolver: Any) -> None:
+        """Wire a :class:`PricingResolver` as a dynamic engine source.
+
+        When attached, :meth:`check_async` will prefer the resolver's
+        engine over the static one loaded from config.
+        """
+        self._resolver = resolver
 
     @property
     def enabled(self) -> bool:
@@ -131,6 +140,83 @@ class ConstraintGate:
             return error, 0
 
         # Apply price modifier if present
+        effective_cost = base_cost
+        if result.price_modifier:
+            effective_cost = result.price_modifier.apply_to(base_cost)
+
+        return None, effective_cost
+
+    async def check_async(
+        self,
+        tool_name: str,
+        base_cost: int,
+        ledger: Any,
+        npub: str = "",
+        membership_tier: str = "default",
+        invocation_count: int = 0,
+        global_demand: dict[str, int] | None = None,
+    ) -> tuple[dict[str, Any] | None, int]:
+        """Async version of :meth:`check` that prefers the resolver's engine.
+
+        If a :class:`PricingResolver` is attached via :meth:`attach_resolver`,
+        its dynamically-loaded engine takes precedence over the static one.
+        Falls back to the static engine (or passthrough) on resolver failure.
+        """
+        engine = self._engine  # static default
+
+        if self._resolver is not None:
+            try:
+                dynamic_engine = await self._resolver.get_constraint_engine()
+                if dynamic_engine is not None:
+                    engine = dynamic_engine
+            except Exception:
+                logger.warning(
+                    "PricingResolver.get_constraint_engine() failed; "
+                    "falling back to static engine",
+                    exc_info=True,
+                )
+
+        if engine is None and not self._enabled:
+            return None, base_cost
+
+        if engine is None:
+            return None, base_cost
+
+        context = ConstraintContext(
+            ledger=LedgerSnapshot(
+                balance_api_sats=ledger.balance_api_sats,
+                total_deposited_api_sats=ledger.total_deposited_api_sats,
+                total_consumed_api_sats=ledger.total_consumed_api_sats,
+                total_expired_api_sats=ledger.total_expired_api_sats,
+            ),
+            patron=PatronIdentity(
+                npub=npub,
+                membership_tier=membership_tier,
+            ),
+            env=EnvironmentSnapshot(
+                utc_now=datetime.now(timezone.utc),
+                tool_name=tool_name,
+                invocation_count=invocation_count,
+                global_demand=tuple(
+                    (global_demand or {}).items()
+                ),
+            ),
+        )
+
+        result = engine.evaluate(tool_name, context)
+
+        if not result.allowed:
+            error: dict[str, Any] = {
+                "success": False,
+                "error": result.message or f"Constraint denied: {result.reason}",
+                "constraint_reason": result.reason,
+            }
+            if result.retry_after:
+                error["retry_after"] = result.retry_after.isoformat()
+            if result.metadata:
+                error["constraint_metadata"] = result.metadata
+            return error, 0
+
         effective_cost = base_cost
         if result.price_modifier:
             effective_cost = result.price_modifier.apply_to(base_cost)

--- a/src/tollbooth/neon_schema.sql
+++ b/src/tollbooth/neon_schema.sql
@@ -34,3 +34,18 @@ CREATE TABLE IF NOT EXISTS tool_demand (
     count INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (tool_name, window_key)
 );
+
+-- Operator pricing models (runtime-configurable tool pricing)
+CREATE TABLE IF NOT EXISTS operator_pricing_models (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    operator TEXT NOT NULL,
+    name TEXT NOT NULL,
+    model_json JSONB NOT NULL,        -- {name, tools: [...], pipeline: [...]}
+    is_active BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS one_active_per_operator
+    ON operator_pricing_models (operator) WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_pricing_models_operator
+    ON operator_pricing_models (operator);

--- a/src/tollbooth/pricing_model.py
+++ b/src/tollbooth/pricing_model.py
@@ -1,0 +1,144 @@
+"""Pricing model dataclasses for runtime-configurable tool pricing.
+
+A PricingModel is a named bundle of per-tool prices and an optional
+constraint pipeline that an operator can activate at runtime via the
+Pricing Studio.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolPrice:
+    """Per-tool price entry within a pricing model."""
+
+    tool_name: str
+    price_sats: int
+    category: str = ""
+    intent: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "tool_name": self.tool_name,
+            "price_sats": self.price_sats,
+        }
+        if self.category:
+            d["category"] = self.category
+        if self.intent:
+            d["intent"] = self.intent
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolPrice:
+        return cls(
+            tool_name=data["tool_name"],
+            price_sats=int(data["price_sats"]),
+            category=data.get("category", ""),
+            intent=data.get("intent", ""),
+        )
+
+
+@dataclass
+class PipelineStep:
+    """A single step in the constraint pipeline."""
+
+    id: str
+    type: str  # must match a key in CONSTRAINT_REGISTRY
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"id": self.id, "type": self.type}
+        if self.params:
+            d["params"] = self.params
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PipelineStep:
+        return cls(
+            id=data["id"],
+            type=data["type"],
+            params=dict(data.get("params", {})),
+        )
+
+
+@dataclass
+class PricingModel:
+    """A named pricing model — tool costs + optional constraint pipeline."""
+
+    model_id: str = ""
+    operator: str = ""
+    name: str = ""
+    is_active: bool = False
+    tools: list[ToolPrice] = field(default_factory=list)
+    pipeline: list[PipelineStep] = field(default_factory=list)
+
+    def tool_cost_map(self) -> dict[str, int]:
+        """Return a flat {tool_name: price_sats} lookup dict."""
+        return {tp.tool_name: tp.price_sats for tp in self.tools}
+
+    def to_constraint_config(self) -> dict[str, Any] | None:
+        """Convert pipeline to the format ``load_constraints()`` expects.
+
+        Returns ``None`` if the pipeline is empty.
+
+        The pipeline steps are applied as wildcard (``"*"``) constraints
+        so they affect all tools uniformly.  Each step's ``type`` and
+        ``params`` are merged into a single constraint dict.
+        """
+        if not self.pipeline:
+            return None
+
+        constraints: list[dict[str, Any]] = []
+        for step in self.pipeline:
+            entry: dict[str, Any] = {"type": step.type}
+            entry.update(step.params)
+            constraints.append(entry)
+
+        return {
+            "tool_constraints": {
+                "*": {
+                    "constraints": constraints,
+                },
+            },
+        }
+
+    def to_json(self) -> str:
+        """Serialize to a JSON string (for ``model_json`` column)."""
+        return json.dumps(self._to_model_dict())
+
+    def _to_model_dict(self) -> dict[str, Any]:
+        """Internal dict for the ``model_json`` JSONB column."""
+        return {
+            "name": self.name,
+            "tools": [tp.to_dict() for tp in self.tools],
+            "pipeline": [ps.to_dict() for ps in self.pipeline],
+        }
+
+    @classmethod
+    def from_json(cls, raw: str, *, model_id: str = "", operator: str = "", is_active: bool = False) -> PricingModel:
+        """Deserialize from a JSON string (``model_json`` column)."""
+        data = json.loads(raw)
+        return cls(
+            model_id=model_id,
+            operator=operator,
+            name=data.get("name", ""),
+            is_active=is_active,
+            tools=[ToolPrice.from_dict(t) for t in data.get("tools", [])],
+            pipeline=[PipelineStep.from_dict(p) for p in data.get("pipeline", [])],
+        )
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> PricingModel:
+        """Build from a Neon result row (``operator_pricing_models`` table)."""
+        model_json = row["model_json"]
+        raw = model_json if isinstance(model_json, str) else json.dumps(model_json)
+        return cls.from_json(
+            raw,
+            model_id=str(row["id"]),
+            operator=row["operator"],
+            is_active=bool(row.get("is_active", False)),
+        )

--- a/src/tollbooth/pricing_resolver.py
+++ b/src/tollbooth/pricing_resolver.py
@@ -1,0 +1,110 @@
+"""Pricing resolver — runtime cost lookup with TTL cache and graceful fallback.
+
+The resolver is the integration point MCP servers use to get dynamic tool
+pricing.  It checks the active pricing model from Neon, caches it in
+memory, and falls back to a static dict on cache miss or Neon failure.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from tollbooth.constraints.config import load_constraints
+from tollbooth.constraints.engine import ConstraintEngine
+from tollbooth.pricing_model import PricingModel
+
+logger = logging.getLogger(__name__)
+
+
+class PricingResolver:
+    """Runtime resolver for tool costs and constraint engines.
+
+    Parameters
+    ----------
+    store:
+        A ``PricingModelStore`` instance (or anything with
+        ``fetch_active_model(operator) -> PricingModel | None``).
+    operator:
+        The operator identifier (npub) whose active model to resolve.
+    fallback_costs:
+        Static ``{tool_name: cost}`` dict used when no active model
+        exists or Neon is unreachable.
+    cache_ttl:
+        Time-to-live in seconds for the in-memory cache (default 300).
+    """
+
+    def __init__(
+        self,
+        *,
+        store: Any,
+        operator: str,
+        fallback_costs: dict[str, int] | None = None,
+        cache_ttl: float = 300.0,
+    ) -> None:
+        self._store = store
+        self._operator = operator
+        self._fallback_costs = fallback_costs or {}
+        self._cache_ttl = cache_ttl
+
+        self._cached_model: PricingModel | None = None
+        self._cached_cost_map: dict[str, int] | None = None
+        self._cached_engine: ConstraintEngine | None = None
+        self._cache_ts: float = 0.0
+
+    def _is_stale(self) -> bool:
+        return (time.monotonic() - self._cache_ts) > self._cache_ttl
+
+    async def _ensure_fresh(self) -> None:
+        """Refresh the cache if stale.  Neon failure degrades gracefully."""
+        if not self._is_stale():
+            return
+
+        try:
+            model = await self._store.fetch_active_model(self._operator)
+            self._cached_model = model
+            if model is not None:
+                self._cached_cost_map = model.tool_cost_map()
+                constraint_cfg = model.to_constraint_config()
+                if constraint_cfg is not None:
+                    self._cached_engine = load_constraints(constraint_cfg)
+                else:
+                    self._cached_engine = None
+            else:
+                self._cached_cost_map = None
+                self._cached_engine = None
+            self._cache_ts = time.monotonic()
+        except Exception:
+            logger.warning(
+                "Failed to refresh pricing model for %s; using cached/fallback",
+                self._operator,
+                exc_info=True,
+            )
+            # Keep existing cache (stale > nothing)
+            if self._cache_ts == 0.0:
+                # First call ever failed — mark as attempted so we don't
+                # hammer Neon on every request
+                self._cache_ts = time.monotonic()
+
+    async def get_cost(self, tool_name: str) -> int:
+        """Return the cost for *tool_name*.
+
+        Resolution order: active model → fallback static dict → 0.
+        """
+        await self._ensure_fresh()
+        if self._cached_cost_map is not None and tool_name in self._cached_cost_map:
+            return self._cached_cost_map[tool_name]
+        return self._fallback_costs.get(tool_name, 0)
+
+    async def get_constraint_engine(self) -> ConstraintEngine | None:
+        """Return the constraint engine from the active model's pipeline.
+
+        Returns ``None`` if no active model or no pipeline defined.
+        """
+        await self._ensure_fresh()
+        return self._cached_engine
+
+    def refresh(self) -> None:
+        """Force cache reset — call after Pricing Studio activates a model."""
+        self._cache_ts = 0.0

--- a/src/tollbooth/pricing_store.py
+++ b/src/tollbooth/pricing_store.py
@@ -1,0 +1,144 @@
+"""Pricing model store — CRUD for operator pricing models in Neon Postgres.
+
+Follows the NeonCredentialVault composition pattern: wraps a NeonVault
+and shares its ``_execute()`` helper.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from tollbooth.pricing_model import PricingModel
+
+logger = logging.getLogger(__name__)
+
+
+class PricingModelStore:
+    """CRUD for ``operator_pricing_models`` table via Neon HTTP API.
+
+    Usage::
+
+        store = PricingModelStore(neon_vault=vault)
+        await store.ensure_schema()
+
+        model = PricingModel(operator="npub1abc", name="Launch Pricing", ...)
+        model_id = await store.create_model(model)
+        await store.activate_model(model_id, operator="npub1abc")
+    """
+
+    def __init__(self, *, neon_vault: Any) -> None:
+        self._neon = neon_vault
+
+    async def ensure_schema(self) -> None:
+        """Create the ``operator_pricing_models`` table and indexes."""
+        await self._neon._execute(
+            "CREATE TABLE IF NOT EXISTS operator_pricing_models ("
+            "    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),"
+            "    operator TEXT NOT NULL,"
+            "    name TEXT NOT NULL,"
+            "    model_json JSONB NOT NULL,"
+            "    is_active BOOLEAN DEFAULT false,"
+            "    created_at TIMESTAMPTZ DEFAULT now(),"
+            "    updated_at TIMESTAMPTZ DEFAULT now()"
+            ")"
+        )
+        await self._neon._execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS one_active_per_operator "
+            "ON operator_pricing_models (operator) WHERE is_active = true"
+        )
+        await self._neon._execute(
+            "CREATE INDEX IF NOT EXISTS idx_pricing_models_operator "
+            "ON operator_pricing_models (operator)"
+        )
+
+    async def fetch_active_model(self, operator: str) -> PricingModel | None:
+        """Return the active pricing model for an operator, or ``None``."""
+        result = await self._neon._execute(
+            "SELECT id, operator, name, model_json, is_active "
+            "FROM operator_pricing_models "
+            "WHERE operator = $1 AND is_active = true "
+            "LIMIT 1",
+            [operator],
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            return None
+        return PricingModel.from_row(rows[0])
+
+    async def list_models(self, operator: str) -> list[PricingModel]:
+        """List all pricing models for an operator (newest first)."""
+        result = await self._neon._execute(
+            "SELECT id, operator, name, model_json, is_active "
+            "FROM operator_pricing_models "
+            "WHERE operator = $1 "
+            "ORDER BY created_at DESC",
+            [operator],
+        )
+        rows = result.get("rows", [])
+        return [PricingModel.from_row(row) for row in rows]
+
+    async def create_model(self, model: PricingModel) -> str:
+        """Insert a new pricing model. Returns the UUID as a string."""
+        result = await self._neon._execute(
+            "INSERT INTO operator_pricing_models "
+            "(operator, name, model_json, is_active) "
+            "VALUES ($1, $2, $3::jsonb, false) "
+            "RETURNING id",
+            [model.operator, model.name, model.to_json()],
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise RuntimeError("INSERT pricing model returned no rows")
+        return str(rows[0]["id"])
+
+    async def update_model(self, model_id: str, model_json: str) -> None:
+        """Replace the ``model_json`` blob for an existing model."""
+        await self._neon._execute(
+            "UPDATE operator_pricing_models "
+            "SET model_json = $1::jsonb, updated_at = now() "
+            "WHERE id = $2::uuid",
+            [model_json, model_id],
+        )
+
+    async def activate_model(self, model_id: str, operator: str) -> None:
+        """Deactivate the current active model and activate the given one.
+
+        Two UPDATEs: deactivate all for operator, then activate the target.
+        """
+        await self._neon._execute(
+            "UPDATE operator_pricing_models "
+            "SET is_active = false, updated_at = now() "
+            "WHERE operator = $1 AND is_active = true",
+            [operator],
+        )
+        await self._neon._execute(
+            "UPDATE operator_pricing_models "
+            "SET is_active = true, updated_at = now() "
+            "WHERE id = $1::uuid AND operator = $2",
+            [model_id, operator],
+        )
+
+    async def delete_model(self, model_id: str) -> bool:
+        """Delete a pricing model. Refuses to delete an active model.
+
+        Returns ``True`` if deleted, ``False`` if not found or active.
+        """
+        # Check if active first
+        check = await self._neon._execute(
+            "SELECT is_active FROM operator_pricing_models WHERE id = $1::uuid",
+            [model_id],
+        )
+        rows = check.get("rows", [])
+        if not rows:
+            return False
+        if rows[0].get("is_active"):
+            logger.warning("Refusing to delete active pricing model %s", model_id)
+            return False
+
+        result = await self._neon._execute(
+            "DELETE FROM operator_pricing_models WHERE id = $1::uuid",
+            [model_id],
+        )
+        return (result.get("rowCount", 0) or 0) > 0

--- a/src/tollbooth/vaults/neon.py
+++ b/src/tollbooth/vaults/neon.py
@@ -275,6 +275,26 @@ class NeonVault:
             "    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()"
             ")"
         )
+        # -- Operator pricing models (runtime-configurable tool pricing) --
+        await self._execute(
+            "CREATE TABLE IF NOT EXISTS operator_pricing_models ("
+            "    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),"
+            "    operator TEXT NOT NULL,"
+            "    name TEXT NOT NULL,"
+            "    model_json JSONB NOT NULL,"
+            "    is_active BOOLEAN DEFAULT false,"
+            "    created_at TIMESTAMPTZ DEFAULT now(),"
+            "    updated_at TIMESTAMPTZ DEFAULT now()"
+            ")"
+        )
+        await self._execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS one_active_per_operator "
+            "ON operator_pricing_models (operator) WHERE is_active = true"
+        )
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_pricing_models_operator "
+            "ON operator_pricing_models (operator)"
+        )
 
     # -- Global demand counters (surge pricing) --------------------------------
 

--- a/tests/test_constraints/test_gate.py
+++ b/tests/test_constraints/test_gate.py
@@ -412,3 +412,135 @@ class TestWildcardConstraintsApplied:
         )
         assert denial2 is None
         assert cost2 == 0
+
+
+# ---------------------------------------------------------------------------
+# attach_resolver + check_async
+# ---------------------------------------------------------------------------
+
+
+class _MockResolver:
+    """Minimal mock PricingResolver for gate tests."""
+
+    def __init__(self, engine: Any = None, *, fail: bool = False):
+        self._engine = engine
+        self._fail = fail
+
+    async def get_constraint_engine(self) -> Any:
+        if self._fail:
+            raise RuntimeError("resolver failed")
+        return self._engine
+
+
+class TestAttachResolver:
+    def test_attach_sets_resolver(self):
+        config = TollboothConfig()
+        gate = ConstraintGate(config)
+        resolver = _MockResolver()
+        gate.attach_resolver(resolver)
+        assert gate._resolver is resolver
+
+
+class TestCheckAsyncNoResolver:
+    @pytest.mark.asyncio
+    async def test_passthrough_when_disabled(self):
+        """check_async returns (None, base_cost) when gate is disabled."""
+        config = TollboothConfig()
+        gate = ConstraintGate(config)
+
+        denial, cost = await gate.check_async(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+        )
+        assert denial is None
+        assert cost == 100
+
+    @pytest.mark.asyncio
+    async def test_uses_static_engine(self):
+        """check_async uses static engine when no resolver attached."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        denial, cost = await gate.check_async(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,
+        )
+        assert denial is None
+        assert cost == 0  # free trial
+
+
+class TestCheckAsyncWithResolver:
+    @pytest.mark.asyncio
+    async def test_prefers_resolver_engine(self):
+        """check_async uses dynamic engine from resolver over static one."""
+        from tollbooth.constraints.config import load_constraints
+
+        # Static engine: free trial (makes cost 0)
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        # Dynamic engine: 50% coupon (makes cost 50)
+        dynamic_cfg = json.loads(_coupon_config(discount_percent=50.0))
+        dynamic_engine = load_constraints(dynamic_cfg)
+        resolver = _MockResolver(engine=dynamic_engine)
+        gate.attach_resolver(resolver)
+
+        denial, cost = await gate.check_async(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,
+        )
+        assert denial is None
+        assert cost == 50  # coupon from resolver, not free trial from static
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_static_on_resolver_failure(self):
+        """check_async falls back to static engine when resolver fails."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        resolver = _MockResolver(fail=True)
+        gate.attach_resolver(resolver)
+
+        denial, cost = await gate.check_async(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,
+        )
+        assert denial is None
+        assert cost == 0  # free trial from static engine
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_static_when_resolver_returns_none(self):
+        """check_async uses static engine when resolver returns None engine."""
+        config = TollboothConfig(
+            constraints_enabled=True,
+            constraints_config=_free_trial_config(first_n_free=3),
+        )
+        gate = ConstraintGate(config)
+
+        resolver = _MockResolver(engine=None)
+        gate.attach_resolver(resolver)
+
+        denial, cost = await gate.check_async(
+            tool_name="search",
+            base_cost=100,
+            ledger=_StubLedger(),
+            invocation_count=0,
+        )
+        assert denial is None
+        assert cost == 0  # free trial from static engine

--- a/tests/test_neon_vault.py
+++ b/tests/test_neon_vault.py
@@ -319,7 +319,7 @@ class TestEnsureSchema:
             return_value=_response(200, _sql_result(rows=[], command="CREATE"))
         )
         await vault.ensure_schema()
-        assert vault._client.post.call_count == 9  # 5 tables + 4 indexes
+        assert vault._client.post.call_count == 12  # 6 tables + 6 indexes
 
     @pytest.mark.asyncio
     async def test_schema_statements_use_if_not_exists(self) -> None:

--- a/tests/test_pricing_model.py
+++ b/tests/test_pricing_model.py
@@ -1,0 +1,165 @@
+"""Tests for PricingModel, ToolPrice, and PipelineStep dataclasses."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tollbooth.pricing_model import PipelineStep, PricingModel, ToolPrice
+
+
+# ---------------------------------------------------------------------------
+# ToolPrice
+# ---------------------------------------------------------------------------
+
+
+class TestToolPrice:
+    def test_round_trip(self) -> None:
+        tp = ToolPrice(tool_name="search", price_sats=5, category="read", intent="query")
+        d = tp.to_dict()
+        restored = ToolPrice.from_dict(d)
+        assert restored.tool_name == "search"
+        assert restored.price_sats == 5
+        assert restored.category == "read"
+        assert restored.intent == "query"
+
+    def test_optional_fields_omitted(self) -> None:
+        tp = ToolPrice(tool_name="search", price_sats=5)
+        d = tp.to_dict()
+        assert "category" not in d
+        assert "intent" not in d
+
+    def test_from_dict_defaults(self) -> None:
+        tp = ToolPrice.from_dict({"tool_name": "x", "price_sats": 1})
+        assert tp.category == ""
+        assert tp.intent == ""
+
+
+# ---------------------------------------------------------------------------
+# PipelineStep
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStep:
+    def test_round_trip(self) -> None:
+        ps = PipelineStep(id="s1", type="free_trial", params={"first_n_free": 3})
+        d = ps.to_dict()
+        restored = PipelineStep.from_dict(d)
+        assert restored.id == "s1"
+        assert restored.type == "free_trial"
+        assert restored.params == {"first_n_free": 3}
+
+    def test_empty_params_omitted(self) -> None:
+        ps = PipelineStep(id="s1", type="coupon")
+        d = ps.to_dict()
+        assert "params" not in d
+
+    def test_from_dict_defaults(self) -> None:
+        ps = PipelineStep.from_dict({"id": "s1", "type": "coupon"})
+        assert ps.params == {}
+
+
+# ---------------------------------------------------------------------------
+# PricingModel
+# ---------------------------------------------------------------------------
+
+
+class TestPricingModel:
+    def _sample_model(self) -> PricingModel:
+        return PricingModel(
+            model_id="abc-123",
+            operator="npub1test",
+            name="Launch Pricing",
+            is_active=True,
+            tools=[
+                ToolPrice(tool_name="search", price_sats=5),
+                ToolPrice(tool_name="create", price_sats=10),
+            ],
+            pipeline=[
+                PipelineStep(id="s1", type="free_trial", params={"first_n_free": 3}),
+            ],
+        )
+
+    def test_tool_cost_map(self) -> None:
+        model = self._sample_model()
+        costs = model.tool_cost_map()
+        assert costs == {"search": 5, "create": 10}
+
+    def test_tool_cost_map_empty(self) -> None:
+        model = PricingModel()
+        assert model.tool_cost_map() == {}
+
+    def test_to_constraint_config(self) -> None:
+        model = self._sample_model()
+        cfg = model.to_constraint_config()
+        assert cfg is not None
+        assert "*" in cfg["tool_constraints"]
+        constraints = cfg["tool_constraints"]["*"]["constraints"]
+        assert len(constraints) == 1
+        assert constraints[0]["type"] == "free_trial"
+        assert constraints[0]["first_n_free"] == 3
+
+    def test_to_constraint_config_empty_pipeline(self) -> None:
+        model = PricingModel()
+        assert model.to_constraint_config() is None
+
+    def test_to_constraint_config_feeds_load_constraints(self) -> None:
+        """Verify the output can be consumed by load_constraints()."""
+        from tollbooth.constraints.config import load_constraints
+
+        model = self._sample_model()
+        cfg = model.to_constraint_config()
+        assert cfg is not None
+        engine = load_constraints(cfg)
+        assert engine is not None
+
+    def test_json_round_trip(self) -> None:
+        model = self._sample_model()
+        raw = model.to_json()
+        restored = PricingModel.from_json(
+            raw,
+            model_id="abc-123",
+            operator="npub1test",
+            is_active=True,
+        )
+        assert restored.name == "Launch Pricing"
+        assert len(restored.tools) == 2
+        assert restored.tools[0].tool_name == "search"
+        assert len(restored.pipeline) == 1
+        assert restored.pipeline[0].type == "free_trial"
+
+    def test_from_row_with_string_model_json(self) -> None:
+        row = {
+            "id": "uuid-1",
+            "operator": "npub1op",
+            "name": "Test",
+            "model_json": json.dumps({
+                "name": "Test",
+                "tools": [{"tool_name": "a", "price_sats": 1}],
+                "pipeline": [],
+            }),
+            "is_active": True,
+        }
+        model = PricingModel.from_row(row)
+        assert model.model_id == "uuid-1"
+        assert model.operator == "npub1op"
+        assert model.is_active is True
+        assert len(model.tools) == 1
+
+    def test_from_row_with_dict_model_json(self) -> None:
+        """Neon may return JSONB as a dict instead of string."""
+        row = {
+            "id": "uuid-2",
+            "operator": "npub1op",
+            "name": "Test",
+            "model_json": {
+                "name": "Test",
+                "tools": [],
+                "pipeline": [],
+            },
+            "is_active": False,
+        }
+        model = PricingModel.from_row(row)
+        assert model.model_id == "uuid-2"
+        assert model.is_active is False

--- a/tests/test_pricing_resolver.py
+++ b/tests/test_pricing_resolver.py
@@ -1,0 +1,200 @@
+"""Tests for PricingResolver — cache TTL, fallback, graceful failure."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tollbooth.pricing_model import PipelineStep, PricingModel, ToolPrice
+from tollbooth.pricing_resolver import PricingResolver
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _active_model() -> PricingModel:
+    return PricingModel(
+        model_id="uuid-1",
+        operator="npub1op",
+        name="Active",
+        is_active=True,
+        tools=[
+            ToolPrice(tool_name="search", price_sats=3),
+            ToolPrice(tool_name="create", price_sats=7),
+        ],
+        pipeline=[
+            PipelineStep(id="s1", type="free_trial", params={"first_n_free": 5}),
+        ],
+    )
+
+
+class _MockStore:
+    """Minimal mock that exposes fetch_active_model."""
+
+    def __init__(self, model: PricingModel | None = None, *, fail: bool = False):
+        self._model = model
+        self._fail = fail
+        self.call_count = 0
+
+    async def fetch_active_model(self, operator: str) -> PricingModel | None:
+        self.call_count += 1
+        if self._fail:
+            raise RuntimeError("Neon down")
+        return self._model
+
+
+# ---------------------------------------------------------------------------
+# get_cost
+# ---------------------------------------------------------------------------
+
+
+class TestGetCost:
+    @pytest.mark.asyncio
+    async def test_returns_active_model_cost(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", fallback_costs={"search": 99},
+        )
+        cost = await resolver.get_cost("search")
+        assert cost == 3  # from model, not fallback
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_static_dict(self) -> None:
+        store = _MockStore(model=None)
+        resolver = PricingResolver(
+            store=store, operator="npub1op", fallback_costs={"search": 99},
+        )
+        cost = await resolver.get_cost("search")
+        assert cost == 99
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_zero(self) -> None:
+        store = _MockStore(model=None)
+        resolver = PricingResolver(store=store, operator="npub1op")
+        cost = await resolver.get_cost("unknown_tool")
+        assert cost == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_with_active_model(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", fallback_costs={"other": 42},
+        )
+        cost = await resolver.get_cost("other")
+        assert cost == 42  # not in model, but in fallback
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_caches_within_ttl(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", cache_ttl=60.0,
+        )
+        await resolver.get_cost("search")
+        await resolver.get_cost("search")
+        await resolver.get_cost("search")
+        assert store.call_count == 1  # only one Neon call
+
+    @pytest.mark.asyncio
+    async def test_refresh_resets_cache(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", cache_ttl=60.0,
+        )
+        await resolver.get_cost("search")
+        assert store.call_count == 1
+
+        resolver.refresh()
+        await resolver.get_cost("search")
+        assert store.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_triggers_refresh(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", cache_ttl=0.01,
+        )
+        await resolver.get_cost("search")
+        assert store.call_count == 1
+
+        # Wait for cache to expire
+        time.sleep(0.02)
+        await resolver.get_cost("search")
+        assert store.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Graceful Neon failure
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulFailure:
+    @pytest.mark.asyncio
+    async def test_neon_failure_uses_fallback(self) -> None:
+        store = _MockStore(fail=True)
+        resolver = PricingResolver(
+            store=store, operator="npub1op", fallback_costs={"search": 50},
+        )
+        cost = await resolver.get_cost("search")
+        assert cost == 50  # fallback
+
+    @pytest.mark.asyncio
+    async def test_neon_failure_after_cache_keeps_stale(self) -> None:
+        """If Neon was reachable before but fails now, use stale cache."""
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(
+            store=store, operator="npub1op", cache_ttl=0.01,
+        )
+        # First call succeeds and caches
+        cost = await resolver.get_cost("search")
+        assert cost == 3
+
+        # Make store fail and expire cache
+        store._fail = True
+        time.sleep(0.02)
+
+        # Should use stale cache
+        cost = await resolver.get_cost("search")
+        assert cost == 3
+
+
+# ---------------------------------------------------------------------------
+# get_constraint_engine
+# ---------------------------------------------------------------------------
+
+
+class TestGetConstraintEngine:
+    @pytest.mark.asyncio
+    async def test_returns_engine_from_pipeline(self) -> None:
+        store = _MockStore(model=_active_model())
+        resolver = PricingResolver(store=store, operator="npub1op")
+        engine = await resolver.get_constraint_engine()
+        assert engine is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_pipeline(self) -> None:
+        model = PricingModel(
+            model_id="uuid-2", operator="npub1op", name="NoPipeline",
+            is_active=True, tools=[], pipeline=[],
+        )
+        store = _MockStore(model=model)
+        resolver = PricingResolver(store=store, operator="npub1op")
+        engine = await resolver.get_constraint_engine()
+        assert engine is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_model(self) -> None:
+        store = _MockStore(model=None)
+        resolver = PricingResolver(store=store, operator="npub1op")
+        engine = await resolver.get_constraint_engine()
+        assert engine is None

--- a/tests/test_pricing_store.py
+++ b/tests/test_pricing_store.py
@@ -1,0 +1,275 @@
+"""Tests for PricingModelStore — CRUD via Neon HTTP API.
+
+Follows the same mock pattern as test_neon_vault.py: patches
+``vault._client.post`` with AsyncMock.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from tollbooth.pricing_model import PricingModel, ToolPrice
+from tollbooth.pricing_store import PricingModelStore
+from tollbooth.vaults.neon import NeonVault
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same pattern as test_neon_vault.py)
+# ---------------------------------------------------------------------------
+
+DATABASE_URL = "postgresql://user:password@ep-test.us-east-2.aws.neon.tech/testdb"
+HTTP_ENDPOINT = "https://ep-test.us-east-2.aws.neon.tech/sql"
+
+
+def _vault() -> NeonVault:
+    return NeonVault(database_url=DATABASE_URL)
+
+
+def _store(vault: NeonVault | None = None) -> PricingModelStore:
+    return PricingModelStore(neon_vault=vault or _vault())
+
+
+def _response(
+    status_code: int = 200, json_data: dict | list | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("POST", HTTP_ENDPOINT),
+    )
+
+
+def _sql_result(
+    rows: list[dict] | None = None,
+    row_count: int | None = None,
+    command: str = "SELECT",
+) -> dict:
+    result: dict = {"command": command}
+    if rows is not None:
+        result["rows"] = rows
+        result["rowCount"] = row_count if row_count is not None else len(rows)
+    return result
+
+
+def _sample_model() -> PricingModel:
+    return PricingModel(
+        operator="npub1abc",
+        name="Test Model",
+        tools=[ToolPrice(tool_name="search", price_sats=5)],
+        pipeline=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_schema
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureSchema:
+    @pytest.mark.asyncio
+    async def test_creates_table_and_indexes(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="CREATE"))
+        )
+        store = _store(vault)
+        await store.ensure_schema()
+        # 1 CREATE TABLE + 2 CREATE INDEX
+        assert vault._client.post.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# fetch_active_model
+# ---------------------------------------------------------------------------
+
+
+class TestFetchActiveModel:
+    @pytest.mark.asyncio
+    async def test_returns_model(self) -> None:
+        vault = _vault()
+        model_json = json.dumps({
+            "name": "Active Model",
+            "tools": [{"tool_name": "search", "price_sats": 5}],
+            "pipeline": [],
+        })
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[{
+                "id": "uuid-1",
+                "operator": "npub1abc",
+                "name": "Active Model",
+                "model_json": model_json,
+                "is_active": True,
+            }]))
+        )
+        store = _store(vault)
+        model = await store.fetch_active_model("npub1abc")
+        assert model is not None
+        assert model.name == "Active Model"
+        assert model.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_active(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[]))
+        )
+        store = _store(vault)
+        model = await store.fetch_active_model("npub1abc")
+        assert model is None
+
+
+# ---------------------------------------------------------------------------
+# list_models
+# ---------------------------------------------------------------------------
+
+
+class TestListModels:
+    @pytest.mark.asyncio
+    async def test_returns_list(self) -> None:
+        vault = _vault()
+        model_json = json.dumps({"name": "M1", "tools": [], "pipeline": []})
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[
+                {"id": "u1", "operator": "npub1abc", "name": "M1",
+                 "model_json": model_json, "is_active": False},
+                {"id": "u2", "operator": "npub1abc", "name": "M2",
+                 "model_json": model_json, "is_active": True},
+            ]))
+        )
+        store = _store(vault)
+        models = await store.list_models("npub1abc")
+        assert len(models) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_empty(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[]))
+        )
+        store = _store(vault)
+        models = await store.list_models("npub1abc")
+        assert models == []
+
+
+# ---------------------------------------------------------------------------
+# create_model
+# ---------------------------------------------------------------------------
+
+
+class TestCreateModel:
+    @pytest.mark.asyncio
+    async def test_returns_uuid(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(
+                rows=[{"id": "new-uuid-123"}], command="INSERT",
+            ))
+        )
+        store = _store(vault)
+        model_id = await store.create_model(_sample_model())
+        assert model_id == "new-uuid-123"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_no_rows(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="INSERT"))
+        )
+        store = _store(vault)
+        with pytest.raises(RuntimeError, match="no rows"):
+            await store.create_model(_sample_model())
+
+
+# ---------------------------------------------------------------------------
+# update_model
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateModel:
+    @pytest.mark.asyncio
+    async def test_sends_update(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="UPDATE"))
+        )
+        store = _store(vault)
+        new_json = json.dumps({"name": "Updated", "tools": [], "pipeline": []})
+        await store.update_model("uuid-1", new_json)
+        vault._client.post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# activate_model
+# ---------------------------------------------------------------------------
+
+
+class TestActivateModel:
+    @pytest.mark.asyncio
+    async def test_deactivates_then_activates(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[], command="UPDATE"))
+        )
+        store = _store(vault)
+        await store.activate_model("uuid-new", operator="npub1abc")
+        # Two UPDATE calls: deactivate all, then activate target
+        assert vault._client.post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# delete_model
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteModel:
+    @pytest.mark.asyncio
+    async def test_deletes_inactive(self) -> None:
+        vault = _vault()
+        call_count = 0
+
+        async def mock_post(url: str, **kwargs: dict) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # SELECT check — inactive
+                return _response(200, _sql_result(
+                    rows=[{"is_active": False}]
+                ))
+            else:
+                # DELETE succeeds
+                return _response(200, _sql_result(
+                    rows=[], row_count=1, command="DELETE",
+                ))
+
+        vault._client.post = AsyncMock(side_effect=mock_post)
+        store = _store(vault)
+        result = await store.delete_model("uuid-1")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_refuses_active(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(
+                rows=[{"is_active": True}]
+            ))
+        )
+        store = _store(vault)
+        result = await store.delete_model("uuid-1")
+        assert result is False
+        # Only the SELECT, no DELETE
+        assert vault._client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_false_not_found(self) -> None:
+        vault = _vault()
+        vault._client.post = AsyncMock(
+            return_value=_response(200, _sql_result(rows=[]))
+        )
+        store = _store(vault)
+        result = await store.delete_model("uuid-nonexistent")
+        assert result is False


### PR DESCRIPTION
## Summary

- Add `PricingModel`, `ToolPrice`, `PipelineStep` dataclasses for named pricing bundles (per-tool costs + constraint pipelines)
- Add `PricingModelStore` — Neon CRUD with at-most-one-active DB invariant (partial unique index)
- Add `PricingResolver` — TTL-cached runtime resolver with graceful fallback to static dict on Neon failure
- Add `ConstraintGate.attach_resolver()` + `check_async()` — dynamic engine source, existing `check()` unchanged
- Add `pricing_cache_ttl_seconds` to `TollboothConfig`
- Add `operator_pricing_models` table + indexes to `ensure_schema()` and `neon_schema.sql`
- Export new symbols from `__init__.py`

## What Does NOT Change

- Static `TOOL_COSTS` pattern — still works as-is; `PricingResolver` uses it as fallback
- Existing `ConstraintGate.check()` — unchanged; `check_async()` is additive
- MCP servers — no changes needed; they adopt via version bump + wiring later

## Test plan

- [x] 10 tests in `test_pricing_model.py` — serialization round-trips, `tool_cost_map()`, `to_constraint_config()` feeds `load_constraints()`
- [x] 10 tests in `test_pricing_store.py` — CRUD, activate deactivates previous, delete refuses active
- [x] 12 tests in `test_pricing_resolver.py` — cache TTL, fallback, Neon failure graceful, refresh resets
- [x] 6 tests in `test_gate.py` — `check_async()` with/without resolver, fallback on failure
- [x] Updated `test_neon_vault.py` schema DDL count (9 → 12)
- [x] Full suite: 1190/1190 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)