### PR TITLE
Require Authority consent (authority_proof) on register/update/deregister_operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.26.0] — 2026-05-23
+
+### Changed — Authority consent now cryptographically witnessed (BREAKING)
+
+`authority_register_operator`, `authority_update_operator`, and
+`authority_deregister_operator` now require **two** independent
+Schnorr identity proofs:
+
+1. **`proof`** — signed by the *Operator's* npub. Existing behavior;
+   proves the caller really controls the operator npub they claim.
+2. **`authority_proof`** — signed by the *Authority's own* npub. New.
+   Cryptographic witness that the human who controls the Authority's
+   nsec has consented to this discretionary action. Apps holding the
+   Authority's nsec (e.g. the Pricing Studio) produce this proof
+   inline when their user clicks "adopt".
+
+Without the Authority proof, anyone who knew an operator's public
+npub and held that operator's own nsec could register / mutate /
+remove themselves under any Authority's signature without that
+Authority's awareness. Closes the gap where the Operator's
+self-signed proof was the only gate.
+
+New `ErrorCode.AUTHORITY_CONSENT_REQUIRED` distinguishes the
+Authority-side failure from the Operator-side `PROOF_REQUIRED` /
+`PROOF_INVALID` codes, so calling apps can render the right UX
+remedy.
+
+**Breaking change.** Clients calling these three tools without an
+`authority_proof` argument will receive
+`{success: false, error_code: "authority_consent_required", ...}`.
+Update calling code to mint a fresh Authority-side proof and pass it.
+
+The Pricing Studio's `argsWithProof` machinery already produces
+Operator proofs from Keychain; producing the Authority proof is the
+same code path keyed by the Authority's npub.
+
 ## [0.25.0] — 2026-05-19
 
 ### Changed — DRY pass on the proof gate and operator bootstrap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tollbooth-dpyc"
-version = "0.25.0"
+version = "0.26.0"
 description = "Don't Pester Your Customer™ — Bitcoin Lightning micropayments for MCP servers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tollbooth/authority/tools.py
+++ b/src/tollbooth/authority/tools.py
@@ -421,6 +421,52 @@ async def _resolve_own_service_url() -> str:
         await registry.close()
 
 
+async def _require_authority_consent(
+    runtime: OperatorRuntime,
+    authority_proof: str,
+    tool_name: str,
+) -> dict[str, Any] | None:
+    """Verify the caller holds the Authority's own nsec.
+
+    The Authority's adoption / modification of an Operator entry is a
+    discretionary act. Only someone with the Authority's nsec on hand can
+    produce a valid Schnorr proof signed by the Authority's npub — the
+    cryptographic witness that the human who controls this Authority has
+    authorized this action. An app (e.g. the Pricing Studio) produces
+    this proof automatically when its user clicks "adopt", provided the
+    Authority's nsec is in the app's secure store.
+
+    Returns ``None`` on success (caller proceeds) or a structured error
+    dict the caller should return verbatim. The error code is
+    ``AUTHORITY_CONSENT_REQUIRED`` regardless of whether the proof was
+    missing, expired, or signature-invalid — the patron-actionable
+    remedy is the same: present a fresh valid Authority proof.
+    """
+    from tollbooth.constants import ErrorCode as _EC
+
+    authority_npub = runtime.operator_npub()
+    err = await require_proof(
+        authority_npub,
+        authority_proof,
+        tool_name,
+        proven_cache=await runtime.proven_npub_cache(),
+    )
+    if err is None:
+        return None
+    return {
+        "success": False,
+        "error_code": _EC.AUTHORITY_CONSENT_REQUIRED,
+        "error": (
+            f"Authority consent required: caller must supply a valid identity "
+            f"proof signed by the Authority's npub ({authority_npub[:16]}...). "
+            f"Apps holding the Authority's nsec produce this proof inline; "
+            f"otherwise call request_npub_proof / receive_npub_proof against "
+            f"this MCP using the Authority's npub to cache one."
+        ),
+        "authority_npub": authority_npub,
+    }
+
+
 async def _resend_bootstrap_dm(npub: str) -> bool:
     try:
         vault = await _get_runtime().vault()
@@ -499,18 +545,44 @@ def register_authority_tools(
             str,
             Field(description="Your MCP endpoint URL (e.g. 'https://my-service.fastmcp.app/mcp')."),
         ] = "",
+        authority_proof: Annotated[
+            str,
+            Field(description=(
+                "Identity proof signed by the Authority's OWN npub — the "
+                "Authority's discretionary consent to adopt this Operator. "
+                "Apps with the Authority's nsec in their keystore (e.g. the "
+                "Pricing Studio) produce this proof automatically when the "
+                "user clicks 'adopt'."
+            )),
+        ] = "",
     ) -> dict[str, Any]:
         """Provision an operator in the Authority ledger.
 
         Creates a ledger entry so the operator can purchase credits and
-        certify purchase orders. Idempotent — safe to call again. Requires
-        a Schnorr proof of npub ownership; the candidate operator should
-        call ``request_npub_proof`` + ``receive_npub_proof`` on this
-        Authority first, then pass the resulting token here.
+        certify purchase orders. Idempotent — safe to call again.
+
+        Requires TWO independent identity proofs:
+
+        1. ``proof`` — Schnorr proof signed by the candidate operator's
+           ``npub``. Proves the requester really controls that npub. The
+           operator typically calls ``request_npub_proof`` /
+           ``receive_npub_proof`` against this Authority first to mint
+           a cached proof_token.
+        2. ``authority_proof`` — Schnorr proof signed by the Authority's
+           own npub. This is the Authority's human consent — only an
+           agent with the Authority's nsec on hand can produce it. Apps
+           generate this inline when the human admin clicks 'adopt';
+           otherwise an Authority-side proof can be minted the same way
+           an operator-side one is.
 
         Next step: Call purchase_credits to fund your credit balance.
         """
         err = await require_proof(npub, proof, runtime.runtime_name("register_operator"), proven_cache=await runtime.proven_npub_cache())
+        if err:
+            return err
+        err = await _require_authority_consent(
+            runtime, authority_proof, runtime.runtime_name("register_operator"),
+        )
         if err:
             return err
 
@@ -579,14 +651,30 @@ def register_authority_tools(
         proof: str = "",
         service_url: Annotated[str, Field(description="New MCP endpoint URL (leave empty to keep current).")] = "",
         display_name: Annotated[str, Field(description="New display name (leave empty to keep current).")] = "",
+        authority_proof: Annotated[
+            str,
+            Field(description=(
+                "Identity proof signed by the Authority's OWN npub — the "
+                "Authority's consent to modify this Operator's registry entry."
+            )),
+        ] = "",
     ) -> dict[str, Any]:
         """Update an existing Operator's community registry entry.
 
-        Requires a Schnorr proof of npub ownership — without it, an attacker
-        who knew a victim Operator's public npub could rewrite their
-        ``service_url`` to point at an attacker-controlled MCP endpoint.
+        Requires the same two proofs as ``register_operator``:
+
+        - ``proof`` proves the caller controls the Operator's ``npub``.
+        - ``authority_proof`` proves the Authority's human admin consents
+          to the change. Without the Authority proof, anyone with the
+          Operator's nsec could redirect their own ``service_url`` under
+          this Authority's signature without the Authority's awareness.
         """
         err = await require_proof(npub, proof, runtime.runtime_name("update_operator"), proven_cache=await runtime.proven_npub_cache())
+        if err:
+            return err
+        err = await _require_authority_consent(
+            runtime, authority_proof, runtime.runtime_name("update_operator"),
+        )
         if err:
             return err
         if not service_url and not display_name:
@@ -613,14 +701,31 @@ def register_authority_tools(
     async def deregister_operator(
         npub: Annotated[str, Field(description="Nostr npub of the Operator to deregister.")] = "",
         proof: str = "",
+        authority_proof: Annotated[
+            str,
+            Field(description=(
+                "Identity proof signed by the Authority's OWN npub — the "
+                "Authority's consent to remove this Operator from the community "
+                "registry under its signature."
+            )),
+        ] = "",
     ) -> dict[str, Any]:
         """Remove an Operator from the DPYC community registry.
 
-        Requires a Schnorr proof of npub ownership — without it, anyone who
-        knew a victim Operator's public npub could remove them from the
-        community registry under this Authority's signature.
+        Requires the same two proofs as ``register_operator``:
+
+        - ``proof`` proves the caller controls the Operator's ``npub``.
+        - ``authority_proof`` proves the Authority's human admin consents
+          to the removal. Without the Authority proof, anyone who knew an
+          Operator's public npub and held its nsec could remove themselves
+          from this Authority's roster without the Authority noticing.
         """
         err = await require_proof(npub, proof, runtime.runtime_name("deregister_operator"), proven_cache=await runtime.proven_npub_cache())
+        if err:
+            return err
+        err = await _require_authority_consent(
+            runtime, authority_proof, runtime.runtime_name("deregister_operator"),
+        )
         if err:
             return err
 

--- a/src/tollbooth/constants.py
+++ b/src/tollbooth/constants.py
@@ -28,6 +28,14 @@ class ErrorCode:
     PROOF_INVALID = "proof_invalid"          # signature does not verify
     PROOF_REFRESH_NEEDED = "proof_refresh_needed"  # poison-keyed proof_token cache miss
 
+    # Authority-side discretionary consent (register/update/deregister_operator).
+    # The Authority's adoption of a new Operator (or modification of an
+    # existing one) is gated by a Schnorr proof signed by the Authority's
+    # OWN npub — the cryptographic witness that the human who controls the
+    # Authority's nsec has authorized this action. A missing or invalid
+    # ``authority_proof`` argument trips this code.
+    AUTHORITY_CONSENT_REQUIRED = "authority_consent_required"
+
     # Tool/registry
     RESTRICTED = "restricted"
     TOOL_NOT_REGISTERED = "tool_not_registered"


### PR DESCRIPTION
## Why
The Authority's adoption / modification of an Operator entry is a *discretionary* act — only the human who controls the Authority's nsec should authorize it. Until this PR, \`register/update/deregister_operator\` checked only the **Operator's** own self-signed proof, so anyone who held that operator's nsec could register, mutate, or remove themselves under any Authority's signature without the Authority's awareness.

Symptom that triggered this work: a Pricing Studio user clicked **Register Operator** for a new operator (Optionality MCP) against Tollbooth-Authority-NewEngland. The Authority happily provisioned a Neon tenant for that operator, with no DM, no human in the loop, and no cryptographic record that the Authority's human admin had ever heard of the operator.

## What changed
Each of the three tools now requires a **second** Schnorr identity proof signed by the Authority's own npub:

| Arg | Signs as | Purpose |
|---|---|---|
| \`proof\` | Operator's npub | Existing — proves caller controls operator npub |
| \`authority_proof\` | **Authority's own npub** (\`runtime.operator_npub()\`) | **New** — cryptographic witness of human consent |

Apps with the Authority's nsec in secure storage (e.g. the Pricing Studio with a Keychain entry under the Authority npub) produce \`authority_proof\` inline when the user clicks "adopt". The Operator's MCP, lacking the Authority's nsec, *cannot* generate this proof — exactly as intended.

The reuse of \`require_proof\`'s two existing tactics (cached poison-hash OR inline kind-27235 Schnorr event) keeps the mechanism stateless on the Authority side. No new Neon tables, no pending-approval queue, no DM round-trip. The Authority's consent IS the cryptographic witness.

### New error code
\`ErrorCode.AUTHORITY_CONSENT_REQUIRED = "authority_consent_required"\` distinguishes Authority-side failures from Operator-side \`PROOF_REQUIRED\` / \`PROOF_INVALID\`. The error payload includes the Authority's npub so calling apps can target the right keystore entry:

\`\`\`json
{
  "success": false,
  "error_code": "authority_consent_required",
  "error": "Authority consent required: caller must supply a valid identity proof signed by the Authority's npub (npub1...).",
  "authority_npub": "npub1..."
}
\`\`\`

## Breaking change
Clients calling \`register_operator\`, \`update_operator\`, or \`deregister_operator\` without an \`authority_proof\` argument will receive the new error. Update calling code to mint a fresh Authority-side proof and pass it. The Pricing Studio's \`argsWithProof\` machinery already produces Operator-side proofs from Keychain; producing the Authority-side proof is the same code path keyed by the Authority's npub — a separate PR is coming on the Studio side.

Version bump 0.25.0 → 0.26.0.

## Test plan
- [x] \`ast.parse\` on tools.py and constants.py — both clean
- [x] \`from tollbooth.authority.tools import _require_authority_consent, register_authority_tools\` — imports clean
- [x] \`ErrorCode.AUTHORITY_CONSENT_REQUIRED\` resolves to \`"authority_consent_required"\`
- [x] Existing test suite scan: only \`tests/test_authority_protocol.py\` references these tool names, and only at the Protocol-shape level — no test invokes the actual tool implementation, so no test breakage
- [ ] Live exercise: after this lands on PyPI (via the existing tag pipeline), redeploy tollbooth-authority-newengland and verify \`authority_register_operator\` without \`authority_proof\` returns \`authority_consent_required\`, and with a valid Authority proof returns \`success\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)